### PR TITLE
Don't restart service on package upgrade

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -48,8 +48,12 @@ const (
 	osPatchEnabledDefault     = false
 	debugEnabledDefault       = false
 
-	osPatchStateFileWindows = `C:\Program Files\Google\OSConfig\osconfig_patch.state`
-	osPatchStateFileLinux   = "/etc/osconfig/osconfig_patch.state"
+	configDirWindows        = `C:\Program Files\Google\OSConfig`
+	configDirLinux          = "/etc/osconfig"
+	osPatchStateFileWindows = configDirWindows + `\osconfig_patch.state`
+	osPatchStateFileLinux   = configDirLinux + "/osconfig_patch.state"
+	restartFileWindows      = configDirWindows + `\restart_required`
+	restartFileLinux        = configDirLinux + "/restart_required"
 
 	osConfigPollIntervalDefault = 10
 )
@@ -389,4 +393,13 @@ func PatchStateFile() string {
 	}
 
 	return osPatchStateFileLinux
+}
+
+// RestartFile is the location of the restart required file.
+func RestartFile() string {
+	if runtime.GOOS == "windows" {
+		return restartFileWindows
+	}
+
+	return restartFileLinux
 }

--- a/config/config.go
+++ b/config/config.go
@@ -52,8 +52,8 @@ const (
 	configDirLinux          = "/etc/osconfig"
 	osPatchStateFileWindows = configDirWindows + `\osconfig_patch.state`
 	osPatchStateFileLinux   = configDirLinux + "/osconfig_patch.state"
-	restartFileWindows      = configDirWindows + `\restart_required`
-	restartFileLinux        = configDirLinux + "/restart_required"
+	restartFileWindows      = `C:\Windows\Temp\osconfig_agent_restart_required`
+	restartFileLinux        = "/tmp/osconfig_agent_restart_required"
 
 	osConfigPollIntervalDefault = 10
 )

--- a/google-osconfig-agent.service
+++ b/google-osconfig-agent.service
@@ -2,6 +2,8 @@
 Description=Google OSConfig Agent
 After=local-fs.target network-online.target network.target
 Wants=local-fs.target network-online.target network.target
+StartLimitInterval=120
+StartLimitBurst=3
 
 [Service]
 ExecStart=/usr/bin/google_osconfig_agent

--- a/google-osconfig-agent.service
+++ b/google-osconfig-agent.service
@@ -6,7 +6,7 @@ Wants=local-fs.target network-online.target network.target
 [Service]
 ExecStart=/usr/bin/google_osconfig_agent
 Restart=always
-RestartSec=120
+RestartSec=1
 
 [Install]
 WantedBy=multi-user.target

--- a/main.go
+++ b/main.go
@@ -57,7 +57,7 @@ func run(ctx context.Context) {
 		}
 
 		if _, err := os.Stat(config.RestartFile()); err == nil {
-			logger.Infof("Restart signal recieved, waiting for tasks to complete.")
+			logger.Infof("Restart required marker file exists, beginning agent shutdown, waiting for tasks to complete.")
 			tasker.Close()
 			logger.Infof("All tasks completed, stopping agent.")
 			if err := os.Remove(config.RestartFile()); err != nil && !os.IsNotExist(err) {

--- a/packaging/build_packages_wf.json
+++ b/packaging/build_packages_wf.json
@@ -7,6 +7,10 @@
     "common.sh": "./common.sh"
   },
   "Vars": {
+    "gcs_path": {
+      "Value": "${SCRATCHPATH}/packages",
+      "Description": "GCS path to dump the built packages in: gs://my-bucket/packages"
+    },
     "base_repo": {
       "Value": "GoogleCloudPlatform",
       "Description": "Base GitHub repo"
@@ -153,6 +157,14 @@
           }
         }
       ]
+    },
+    "copy-packages": {
+      "CopyGCSObjects": [
+        {
+          "Source": "${OUTSPATH}/",
+          "Destination": "${gcs_path}/"
+        }
+      ]
     }
   },
   "Dependencies": {
@@ -161,6 +173,9 @@
     ],
     "wait-for-build": [
       "build-packages"
+    ],
+    "copy-packages": [
+      "wait-for-build"
     ]
   }
 }

--- a/packaging/common.sh
+++ b/packaging/common.sh
@@ -16,7 +16,7 @@
 set -e
 
 export PKGNAME="google-osconfig-agent"
-export VERSION="0.6.0"
+export VERSION="0.6.1"
 
 function exit_error() {
   echo "build failed: $0:$1 \"$BASH_COMMAND\" returned $?"

--- a/packaging/debian/changelog
+++ b/packaging/debian/changelog
@@ -1,3 +1,9 @@
+google-osconfig-agent (0.6.1-1) UNRELEASED; urgency=medium
+
+  * Add agent restart on upgrade.
+
+ -- Google Cloud Team <gc-team@google.com>  Fri, 10 May 2019 12:00:00 +0000
+
 google-osconfig-agent (0.6.0-1) UNRELEASED; urgency=medium
 
   * Rework ospatch, fix a number of bugs.

--- a/packaging/debian/postrm
+++ b/packaging/debian/postrm
@@ -3,7 +3,7 @@
 set -e 
 
 if [ $1 = upgrade ]; then
-	touch /etc/osconfig/restart_required
+	touch /tmp/osconfig_agent_restart_required
 fi
 
 exit 0

--- a/packaging/debian/postrm
+++ b/packaging/debian/postrm
@@ -1,0 +1,9 @@
+#!/bin/sh
+
+set -e 
+
+if [ $1 = upgrade ]; then
+	touch /etc/osconfig/restart_required
+fi
+
+exit 0

--- a/packaging/debian/rules
+++ b/packaging/debian/rules
@@ -24,7 +24,7 @@ override_dh_auto_build:
 	dh_auto_build -O--buildsystem=golang -- -ldflags="-s -w -X main.version=$(VERSION)" -mod=readonly
 
 override_dh_installinit:
-    dh_installinit --noscripts
+	dh_installinit --noscripts
 
 override_dh_installsystemd:
 	dh_installsystemd --no-stop-on-upgrade

--- a/packaging/debian/rules
+++ b/packaging/debian/rules
@@ -15,6 +15,7 @@ override_dh_auto_install:
 	# Binary-only package.
 	dh_auto_install -- --no-source
 	mv debian/google-osconfig-agent/usr/bin/osconfig debian/google-osconfig-agent/usr/bin/google_osconfig_agent
+	dh_installdirs /etc/osconfig
 
 override_dh_golang:
 	# We don't use any packaged dependencies, so skip dh_golang step.

--- a/packaging/debian/rules
+++ b/packaging/debian/rules
@@ -23,4 +23,7 @@ override_dh_auto_build:
 	dh_auto_build -O--buildsystem=golang -- -ldflags="-s -w -X main.version=$(VERSION)" -mod=readonly
 
 override_dh_installinit:
-	dh_installinit --noscripts
+    dh_installinit --noscripts
+
+override_dh_installsystemd:
+	dh_installsystemd --no-stop-on-upgrade

--- a/packaging/debian/rules
+++ b/packaging/debian/rules
@@ -15,7 +15,6 @@ override_dh_auto_install:
 	# Binary-only package.
 	dh_auto_install -- --no-source
 	mv debian/google-osconfig-agent/usr/bin/osconfig debian/google-osconfig-agent/usr/bin/google_osconfig_agent
-	dh_installdirs /etc/osconfig
 
 override_dh_golang:
 	# We don't use any packaged dependencies, so skip dh_golang step.

--- a/packaging/googet/google-osconfig-agent.goospec
+++ b/packaging/googet/google-osconfig-agent.goospec
@@ -10,6 +10,7 @@
     "LICENSE": "<ProgramFiles>/Google/OSConfig/LICENSE.txt"
   },
   "releaseNotes": [
+    "0.6.1 - Add agent restart on upgrade",
     "0.6.0 - Rework ospatch, fix a number of bugs",
     "0.5.0 - Add ospatch functionality",
     "0.4.2 - Add version info to binary",

--- a/packaging/googet/install.ps1
+++ b/packaging/googet/install.ps1
@@ -21,9 +21,9 @@ try {
                 -BinaryPathName '"C:\Program Files\Google\OSConfig\google_osconfig_agent.exe"' `
                 -StartupType Automatic `
                 -Description 'Google OSConfig service agent'
-  }
 
-  Restart-Service google_osconfig_agent -Verbose -ErrorAction Stop
+    Start-Service google_osconfig_agent -Verbose -ErrorAction Stop
+  }
 }
 catch {
   Write-Output $_.InvocationInfo.PositionMessage

--- a/packaging/googet/install.ps1
+++ b/packaging/googet/install.ps1
@@ -32,7 +32,7 @@ try {
   } 
   else {
     Set-FailureMode
-    New-Item -Path 'C:\Program Files\Google\OSConfig\restart_required' -Force
+    New-Item -Path 'C:\Windows\Temp\osconfig_agent_restart_required' -Force
   }
 }
 catch {

--- a/packaging/googet/install.ps1
+++ b/packaging/googet/install.ps1
@@ -14,6 +14,11 @@
 
 $ErrorActionPreference = 'Stop'
 
+function Set-FailureMode {
+  # Restart service after 1s, then 2s. Reset error counter after 60s.
+  sc.exe failure google_osconfig_agent reset=60 actions=restart/1000/restart/2000
+}
+
 try {
   if (-not (Get-Service 'google_osconfig_agent' -ErrorAction SilentlyContinue)) {
     New-Service -DisplayName 'Google OSConfig Agent' `
@@ -22,7 +27,12 @@ try {
                 -StartupType Automatic `
                 -Description 'Google OSConfig service agent'
 
+    Set-FailureMode
     Start-Service google_osconfig_agent -Verbose -ErrorAction Stop
+  } 
+  else {
+    Set-FailureMode
+    New-Item -Path 'C:\Program Files\Google\OSConfig\restart_required' -Force
   }
 }
 catch {

--- a/packaging/google-osconfig-agent.spec
+++ b/packaging/google-osconfig-agent.spec
@@ -66,10 +66,6 @@ if [ $1 -eq 1 ]; then
   # Start the service on first install
   start -q -n google-osconfig-agent
 fi
-if [ $1 -eq 2 ]; then
-  # Restart on upgrade
-  restart -q -n google-osconfig-agent
-fi
 %endif
 
 %if 0%{?el7}
@@ -83,6 +79,6 @@ fi
 %systemd_preun google-osconfig-agent.service
 
 %postun
-%systemd_postun_with_restart google-osconfig-agent.service
+%systemd_postun google-osconfig-agent.service
 
 %endif

--- a/packaging/google-osconfig-agent.spec
+++ b/packaging/google-osconfig-agent.spec
@@ -38,6 +38,7 @@ Contains the OSConfig agent binary and startup scripts
 GOPATH=%{_gopath} CGO_ENABLED=0 %{_go} build -ldflags="-s -w -X main.version=%{_version}" -mod=readonly -o google_osconfig_agent
 
 %install
+install -d %{buildroot}/etc/osconfig
 install -d %{buildroot}%{_bindir}
 install -p -m 0755 google_osconfig_agent %{buildroot}%{_bindir}/google_osconfig_agent
 %if 0%{?el7}
@@ -73,6 +74,10 @@ fi
 if [ $1 -eq 1 ]; then
   # Start the service on first install
   systemctl start google-osconfig-agent.service
+fi
+
+if [ $1 -eq 2 ]; then
+  touch /etc/osconfig/restart_required
 fi
 
 %preun

--- a/packaging/google-osconfig-agent.spec
+++ b/packaging/google-osconfig-agent.spec
@@ -38,7 +38,6 @@ Contains the OSConfig agent binary and startup scripts
 GOPATH=%{_gopath} CGO_ENABLED=0 %{_go} build -ldflags="-s -w -X main.version=%{_version}" -mod=readonly -o google_osconfig_agent
 
 %install
-install -d %{buildroot}/etc/osconfig
 install -d %{buildroot}%{_bindir}
 install -p -m 0755 google_osconfig_agent %{buildroot}%{_bindir}/google_osconfig_agent
 %if 0%{?el7}
@@ -77,7 +76,7 @@ if [ $1 -eq 1 ]; then
 fi
 
 if [ $1 -eq 2 ]; then
-  touch /etc/osconfig/restart_required
+  touch /tmp/osconfig_agent_restart_required
 fi
 
 %preun

--- a/tasker/tasker.go
+++ b/tasker/tasker.go
@@ -24,6 +24,7 @@ import (
 var (
 	tc chan *task
 	wg sync.WaitGroup
+	mx sync.Mutex
 )
 
 func init() {
@@ -38,12 +39,14 @@ type task struct {
 
 // Enqueue adds a task to the task queue.
 func Enqueue(name string, f func()) {
+	mx.Lock()
 	tc <- &task{name: name, run: f}
+	mx.Unlock()
 }
 
-// Close closes the tasker queue waits for the queue to empty.
+// Close prevents any further tasks from being enqueued and waits for the queue to empty.
 func Close() {
-	close(tc)
+	mx.Lock()
 	wg.Wait()
 }
 


### PR DESCRIPTION
Agent now reacts to restart required signal and stops, the various service managers handle the restart automatically.