### PR TITLE
add liam as guest policies approver

### DIFF
--- a/policies/OWNERS
+++ b/policies/OWNERS
@@ -1,0 +1,5 @@
+# This file enables automatic assignment of PR reviewers.
+# See the OWNERS docs at https://go.k8s.io/owners
+
+approvers:
+  - hopkiw


### PR DESCRIPTION
This file is additive; it will add one approver to existing, only for files below policies/ directory.