### PR TITLE
Install and remove each package by itself

### DIFF
--- a/inventory/packages/apt_deb.go
+++ b/inventory/packages/apt_deb.go
@@ -43,9 +43,9 @@ func init() {
 	AptExists = exists(aptGet)
 }
 
-// InstallAptPackages installs apt packages.
-func InstallAptPackages(pkgs []string) error {
-	args := append(aptGetInstallArgs, pkgs...)
+// InstallAptPackage installs an apt package.
+func InstallAptPackage(pkgs string) error {
+	args := append(aptGetInstallArgs, pkgs)
 	out, err := run(exec.Command(aptGet, args...))
 	if err != nil {
 		return err
@@ -58,9 +58,9 @@ func InstallAptPackages(pkgs []string) error {
 	return nil
 }
 
-// RemoveAptPackages removes apt packages.
-func RemoveAptPackages(pkgs []string) error {
-	args := append(aptGetRemoveArgs, pkgs...)
+// RemoveAptPackage removes an apt packages.
+func RemoveAptPackage(pkgs string) error {
+	args := append(aptGetRemoveArgs, pkgs)
 	out, err := run(exec.Command(aptGet, args...))
 	if err != nil {
 		return err

--- a/inventory/packages/apt_deb_test.go
+++ b/inventory/packages/apt_deb_test.go
@@ -19,16 +19,16 @@ import (
 	"testing"
 )
 
-func TestInstallAptPackages(t *testing.T) {
-	run = getMockRun([]byte("TestInstallAptPackages"), nil)
-	if err := InstallAptPackages(pkgs); err != nil {
+func TestInstallAptPackage(t *testing.T) {
+	run = getMockRun([]byte("TestInstallAptPackage"), nil)
+	if err := InstallAptPackage(pkgs[0]); err != nil {
 		t.Errorf("unexpected error: %v", err)
 	}
 }
 
 func TestInstallAptPackagesReturnsError(t *testing.T) {
 	run = getMockRun([]byte("TestInstallAptPackagesReturnsError"), errors.New("Could not install package"))
-	err := InstallAptPackages(pkgs)
+	err := InstallAptPackage(pkgs[0])
 	if err == nil {
 		t.Errorf("did not get expected error")
 	}
@@ -36,14 +36,14 @@ func TestInstallAptPackagesReturnsError(t *testing.T) {
 
 func TestRemoveApt(t *testing.T) {
 	run = getMockRun([]byte("TestRemoveApt"), nil)
-	if err := RemoveAptPackages(pkgs); err != nil {
+	if err := RemoveAptPackage(pkgs[0]); err != nil {
 		t.Errorf("unexpected error: %v", err)
 	}
 }
 
 func TestRemoveAptReturnError(t *testing.T) {
 	run = getMockRun([]byte("TestRemoveAptReturnError"), errors.New("Could not find package"))
-	if err := RemoveAptPackages(pkgs); err == nil {
+	if err := RemoveAptPackage(pkgs[0]); err == nil {
 		t.Errorf("did not get expected error")
 	}
 }

--- a/policies/apt.go
+++ b/policies/apt.go
@@ -67,26 +67,32 @@ func aptChanges(aptInstalled, aptRemoved, aptUpdated []*osconfigpb.Package) erro
 	changes := getNecessaryChanges(installed, updates, aptInstalled, aptRemoved, aptUpdated)
 
 	if changes.packagesToInstall != nil {
-		logger.Infof("Installing packages %s", changes.packagesToInstall)
-		if err := packages.InstallAptPackages(changes.packagesToInstall); err != nil {
-			logger.Errorf("Error installing apt packages: %v", err)
-			errs = append(errs, fmt.Sprintf("error installing apt packages: %v", err))
+		for _, p := range changes.packagesToInstall {
+			logger.Infof("Installing package %s", p)
+			if err := packages.InstallAptPackage(p); err != nil {
+				logger.Errorf("Error installing apt package '%s': %v", p, err)
+				errs = append(errs, fmt.Sprintf("error installing apt package: %v", err))
+			}
 		}
 	}
 
 	if changes.packagesToUpgrade != nil {
-		logger.Infof("Upgrading packages %s", changes.packagesToUpgrade)
-		if err := packages.InstallAptPackages(changes.packagesToUpgrade); err != nil {
-			logger.Errorf("Error upgrading apt packages: %v", err)
-			errs = append(errs, fmt.Sprintf("error upgrading apt packages: %v", err))
+		for _, p := range changes.packagesToUpgrade {
+			logger.Infof("Upgrading package %s", p)
+			if err := packages.InstallAptPackage(p); err != nil {
+				logger.Errorf("Error upgrading apt package '%s': %v", p, err)
+				errs = append(errs, fmt.Sprintf("error upgrading apt package: %v", err))
+			}
 		}
 	}
 
 	if changes.packagesToRemove != nil {
-		logger.Infof("Removing packages %s", changes.packagesToRemove)
-		if err := packages.RemoveAptPackages(changes.packagesToRemove); err != nil {
-			logger.Errorf("Error removing apt packages: %v", err)
-			errs = append(errs, fmt.Sprintf("error removing apt packages: %v", err))
+		for _, p := range changes.packagesToRemove {
+			logger.Infof("Removing package %s", p)
+			if err := packages.RemoveAptPackage(p); err != nil {
+				logger.Errorf("Error removing apt package '%s': %v", p, err)
+				errs = append(errs, fmt.Sprintf("error removing apt package: %v", err))
+			}
 		}
 	}
 


### PR DESCRIPTION
- This avoids problems where a single package installation failure prevents all packages from being installed. For example, without this change, apt-get install good, another-good, bad will not install any
packages.