### PR TITLE
move artifact fetching logic to common

### DIFF
--- a/common/common.go
+++ b/common/common.go
@@ -16,10 +16,26 @@
 package common
 
 import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+
+	"cloud.google.com/go/storage"
 
 	"github.com/golang/protobuf/jsonpb"
 	"github.com/golang/protobuf/proto"
+)
+
+var (
+	testStorageClient *storage.Client
+	testHTTPClient    *http.Client
 )
 
 // PrettyFmt uses jsonpb to marshal a proto for pretty printing.
@@ -30,4 +46,97 @@ func PrettyFmt(pb proto.Message) string {
 		out = fmt.Sprintf("Error marshaling proto message: %v\n%s", err, out)
 	}
 	return out
+}
+
+// FetchWithGCS produces a GCS reader for a GCS object.
+func FetchWithGCS(ctx context.Context, bucket, object string, generation int64) (*storage.Reader, error) {
+	client, err := newStorageClient(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create storage client: %v", err)
+	}
+	defer client.Close()
+
+	oh := client.Bucket(bucket).Object(object)
+	if generation != 0 {
+		oh = oh.Generation(generation)
+	}
+
+	r, err := oh.NewReader(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	return r, nil
+}
+
+// FetchWithHTTP retrieves a HTTP response from a Get URI.
+func FetchWithHTTP(ctx context.Context, uri string) (*http.Response, error) {
+	resp, err := newHTTPClient().Get(uri)
+	if err != nil {
+		return nil, err
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("got http status %d when attempting to download artifact", resp.StatusCode)
+	}
+
+	return resp, nil
+}
+
+// DownloadStream writes the artifact to a local path.
+func DownloadStream(r io.Reader, checksum string, localPath string) error {
+	localPath, err := NormPath(localPath)
+	if err != nil {
+		return err
+	}
+	file, err := os.Create(localPath)
+	if err != nil {
+		return err
+	}
+	defer file.Close()
+
+	hasher := sha256.New()
+	if _, err = io.Copy(io.MultiWriter(file, hasher), r); err != nil {
+		return err
+	}
+	computed := hex.EncodeToString(hasher.Sum(nil))
+	if checksum != "" && !strings.EqualFold(checksum, computed) {
+		return fmt.Errorf("got %q for checksum, expected %q", computed, checksum)
+	}
+	return nil
+}
+
+// NormPath transforms a windows path into an extended-length path as described in
+// https://msdn.microsoft.com/en-us/library/windows/desktop/aa365247(v=vs.85).aspx#maxpath
+// when not running on windows it will just return the input path. Copied from
+// https://github.com/google/googet/blob/master/oswrap/oswrap_windows.go
+func NormPath(path string) (string, error) {
+	if runtime.GOOS != "windows" {
+		return path, nil
+	}
+
+	if strings.HasPrefix(path, "\\\\?\\") {
+		return path, nil
+	}
+
+	path, err := filepath.Abs(path)
+	if err != nil {
+		return "", err
+	}
+	path = filepath.Clean(path)
+	return "\\\\?\\" + path, nil
+}
+
+func newStorageClient(ctx context.Context) (*storage.Client, error) {
+	if testStorageClient != nil {
+		return testStorageClient, nil
+	}
+	return storage.NewClient(ctx)
+}
+
+func newHTTPClient() *http.Client {
+	if testHTTPClient != nil {
+		return testHTTPClient
+	}
+	return &http.Client{}
 }

--- a/packaging/README.md
+++ b/packaging/README.md
@@ -27,6 +27,7 @@ For more information on Daisy and how workflows work, refer to the
 
 All variables are optional.
 
-* `base_repo` Specify a different base for github repo (for example a fork of this repo). Default: `GoogleCloudPlatform`.
-* `repo` Specify a different github repo. Default: `osconfig`.
-* `pull_ref` Specify a git reference to check out. Default: `master`.
+*   `base_repo` Specify a different base for github repo (for example a fork of
+    this repo). Default: `GoogleCloudPlatform`.
+*   `repo` Specify a different github repo. Default: `osconfig`.
+*   `pull_ref` Specify a git reference to check out. Default: `master`.

--- a/policies/recipes/artifacts.go
+++ b/policies/recipes/artifacts.go
@@ -16,40 +16,16 @@ package recipes
 
 import (
 	"context"
-	"crypto/sha256"
-	"encoding/hex"
 	"fmt"
 	"io"
-	"net/http"
 	"net/url"
-	"os"
 	"path"
 	"path/filepath"
-	"runtime"
-	"strings"
 
-	"cloud.google.com/go/storage"
+	"github.com/GoogleCloudPlatform/osconfig/common"
+
 	osconfigpb "github.com/GoogleCloudPlatform/osconfig/_internal/gapi-cloud-osconfig-go/google.golang.org/genproto/googleapis/cloud/osconfig/v1alpha2"
 )
-
-var (
-	testStorageClient *storage.Client
-	testHTTPClient    *http.Client
-)
-
-func newStorageClient(ctx context.Context) (*storage.Client, error) {
-	if testStorageClient != nil {
-		return testStorageClient, nil
-	}
-	return storage.NewClient(ctx)
-}
-
-func newHTTPClient() *http.Client {
-	if testHTTPClient != nil {
-		return testHTTPClient
-	}
-	return &http.Client{}
-}
 
 // FetchArtifacts takes in a slice of artifacs and dowloads them into the specified directory,
 // Returns a map of artifact names to their new locations on the local disk.
@@ -73,7 +49,7 @@ func fetchArtifact(ctx context.Context, artifact *osconfigpb.SoftwareRecipe_Arti
 	switch v := artifact.Artifact.(type) {
 	case *osconfigpb.SoftwareRecipe_Artifact_Gcs_:
 		extension = path.Ext(v.Gcs.Object)
-		reader, err := fetchWithGCS(ctx, v.Gcs.Bucket, v.Gcs.Object, v.Gcs.Generation)
+		reader, err := common.FetchWithGCS(ctx, v.Gcs.Bucket, v.Gcs.Object, v.Gcs.Generation)
 		if err != nil {
 			return "", fmt.Errorf("error fetching artifact %q from GCS: %v", artifact.Id, err)
 		}
@@ -88,7 +64,7 @@ func fetchArtifact(ctx context.Context, artifact *osconfigpb.SoftwareRecipe_Arti
 			return "", fmt.Errorf("error, artifact %q has unsupported protocol scheme %s", artifact.Id, uri.Scheme)
 		}
 		checksum = v.Remote.Checksum
-		response, err := fetchWithHTTP(ctx, v.Remote.Uri)
+		response, err := common.FetchWithHTTP(ctx, v.Remote.Uri)
 		if err != nil {
 			return "", fmt.Errorf("error fetching artifact %q with http or https: %v", artifact.Id, err)
 		}
@@ -102,85 +78,9 @@ func fetchArtifact(ctx context.Context, artifact *osconfigpb.SoftwareRecipe_Arti
 	if extension != "" {
 		localPath = localPath + extension
 	}
-	err := downloadStream(reader, checksum, localPath)
+	err := common.DownloadStream(reader, checksum, localPath)
 	if err != nil {
 		return "", err
 	}
 	return localPath, nil
-}
-
-func fetchWithGCS(ctx context.Context, bucket, object string, generation int64) (*storage.Reader, error) {
-	client, err := newStorageClient(ctx)
-	if err != nil {
-		return nil, fmt.Errorf("failed to create storage client: %v", err)
-	}
-	defer client.Close()
-
-	oh := client.Bucket(bucket).Object(object)
-	if generation != 0 {
-		oh = oh.Generation(generation)
-	}
-
-	r, err := oh.NewReader(ctx)
-	if err != nil {
-		return nil, err
-	}
-
-	return r, nil
-}
-
-func fetchWithHTTP(ctx context.Context, uri string) (*http.Response, error) {
-	resp, err := newHTTPClient().Get(uri)
-	if err != nil {
-		return nil, err
-	}
-
-	if resp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("got http status %d when attempting to download artifact", resp.StatusCode)
-	}
-
-	return resp, nil
-}
-
-func downloadStream(r io.Reader, checksum string, localPath string) error {
-	localPath, err := normPath(localPath)
-	if err != nil {
-		return err
-	}
-	file, err := os.Create(localPath)
-	if err != nil {
-		return err
-	}
-	defer file.Close()
-
-	hasher := sha256.New()
-	if _, err = io.Copy(io.MultiWriter(file, hasher), r); err != nil {
-		return err
-	}
-	computed := hex.EncodeToString(hasher.Sum(nil))
-	if checksum != "" && !strings.EqualFold(checksum, computed) {
-		return fmt.Errorf("got %q for checksum, expected %q", computed, checksum)
-	}
-	return nil
-}
-
-// normPath transforms a windows path into an extended-length path as described in
-// https://msdn.microsoft.com/en-us/library/windows/desktop/aa365247(v=vs.85).aspx#maxpath
-// when not running on windows it will just return the input path. Copied from
-// https://github.com/google/googet/blob/master/oswrap/oswrap_windows.go
-func normPath(path string) (string, error) {
-	if runtime.GOOS != "windows" {
-		return path, nil
-	}
-
-	if strings.HasPrefix(path, "\\\\?\\") {
-		return path, nil
-	}
-
-	path, err := filepath.Abs(path)
-	if err != nil {
-		return "", err
-	}
-	path = filepath.Clean(path)
-	return "\\\\?\\" + path, nil
 }

--- a/policies/recipes/steps.go
+++ b/policies/recipes/steps.go
@@ -24,12 +24,14 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/GoogleCloudPlatform/osconfig/common"
+
 	osconfigpb "github.com/GoogleCloudPlatform/osconfig/_internal/gapi-cloud-osconfig-go/google.golang.org/genproto/googleapis/cloud/osconfig/v1alpha2"
 )
 
 // StepFileCopy builds the command for a FileCopy step
 func StepFileCopy(step *osconfigpb.SoftwareRecipe_Step_FileCopy, artifacts map[string]string) error {
-	dest, err := normPath(step.FileCopy.Destination)
+	dest, err := common.NormPath(step.FileCopy.Destination)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
so that they can be used for patching too

Tests done:
- `go build`
- `go test ./...`

/woof