### PR TITLE
add pre-/post-patch step execution for linux and windows

### DIFF
--- a/common/common.go
+++ b/common/common.go
@@ -38,6 +38,15 @@ var (
 	testHTTPClient    *http.Client
 )
 
+// Logger holds log functions.
+type Logger struct {
+	Debugf   func(string, ...interface{})
+	Infof    func(string, ...interface{})
+	Warningf func(string, ...interface{})
+	Errorf   func(string, ...interface{})
+	Fatalf   func(string, ...interface{})
+}
+
 // PrettyFmt uses jsonpb to marshal a proto for pretty printing.
 func PrettyFmt(pb proto.Message) string {
 	m := jsonpb.Marshaler{Indent: "  "}

--- a/ospatch/exec_step.go
+++ b/ospatch/exec_step.go
@@ -1,0 +1,79 @@
+//  Copyright 2019 Google Inc. All Rights Reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
+package ospatch
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"path"
+	"path/filepath"
+
+	osconfigpb "github.com/GoogleCloudPlatform/osconfig/_internal/gapi-cloud-osconfig-go/google.golang.org/genproto/googleapis/cloud/osconfig/v1alpha2"
+	"github.com/GoogleCloudPlatform/osconfig/common"
+)
+
+func getExecutablePath(ctx context.Context, logger *common.Logger, stepConfig *osconfigpb.ExecStepConfig) (string, error) {
+	if gcsObject := stepConfig.GetGcsObject(); gcsObject != nil {
+		var reader io.ReadCloser
+		reader, err := common.FetchWithGCS(ctx, gcsObject.GetBucket(), gcsObject.GetObject(), gcsObject.GetGenerationNumber())
+		if err != nil {
+			return "", fmt.Errorf("error reading GCS object: %s", err)
+		}
+		defer reader.Close()
+		logger.Debugf("Fetched GCS object bucket %s object %s generation number %d", gcsObject.GetBucket(), gcsObject.GetObject(), gcsObject.GetGenerationNumber())
+
+		localPath := filepath.Join(os.TempDir(), path.Base(gcsObject.GetObject()))
+		if err := downloadFile(logger, reader, localPath); err != nil {
+			return "", err
+		}
+		return localPath, nil
+	}
+
+	return stepConfig.GetLocalPath(), nil
+}
+
+func executeCommand(logger *common.Logger, path string, exitCodes []int32, args ...string) error {
+	logger.Debugf("Running command %s with args %s", path, args)
+	cmdObj := exec.Command(path, args...)
+
+	stdoutStderr, err := cmdObj.CombinedOutput()
+	if err != nil {
+		if exitErr, ok := err.(*exec.ExitError); ok {
+			allowedCodes := append(exitCodes, 0)
+			for _, code := range allowedCodes {
+				if int32(exitErr.ExitCode()) == code {
+					return nil
+				}
+			}
+		}
+		return err
+	}
+	logger.Infof("%s\n", stdoutStderr)
+	return nil
+}
+
+func downloadFile(logger *common.Logger, reader io.ReadCloser, localPath string) error {
+	if err := common.DownloadStream(reader, "", localPath); err != nil {
+		return fmt.Errorf("error downloading GCS object: %s", err)
+	}
+	if err := os.Chmod(localPath, 0755); err != nil {
+		return fmt.Errorf("error making file executable: %s", err)
+	}
+	logger.Debugf("Downloaded to local path %s", localPath)
+	return nil
+}

--- a/ospatch/exec_step_linux.go
+++ b/ospatch/exec_step_linux.go
@@ -1,0 +1,65 @@
+//  Copyright 2018 Google Inc. All Rights Reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
+package ospatch
+
+import (
+	"context"
+	"fmt"
+	"os"
+
+	osconfigpb "github.com/GoogleCloudPlatform/osconfig/_internal/gapi-cloud-osconfig-go/google.golang.org/genproto/googleapis/cloud/osconfig/v1alpha2"
+	"github.com/GoogleCloudPlatform/osconfig/common"
+)
+
+func (r *patchRun) execPreStep() error {
+	logger := &common.Logger{Debugf: r.debugf, Infof: r.infof, Warningf: r.warningf, Errorf: r.errorf, Fatalf: nil}
+	return execStep(r.ctx, logger, r.Job.GetPatchConfig().GetPreStep().GetLinuxExecStepConfig())
+}
+
+func (r *patchRun) execPostStep() error {
+	logger := &common.Logger{Debugf: r.debugf, Infof: r.infof, Warningf: r.warningf, Errorf: r.errorf, Fatalf: nil}
+	return execStep(r.ctx, logger, r.Job.GetPatchConfig().GetPostStep().GetLinuxExecStepConfig())
+}
+
+func execStep(ctx context.Context, logger *common.Logger, stepConfig *osconfigpb.ExecStepConfig) error {
+	if stepConfig != nil {
+		localPath, err := getExecutablePath(ctx, logger, stepConfig)
+		if err != nil {
+			return fmt.Errorf("error getting executable path: %v", err)
+		}
+
+		codes := stepConfig.GetAllowedSuccessCodes()
+
+		switch stepConfig.GetInterpreter() {
+		case osconfigpb.ExecStepConfig_INTERPRETER_UNSPECIFIED:
+			err = executeCommand(logger, localPath, codes)
+		case osconfigpb.ExecStepConfig_SHELL:
+			err = executeCommand(logger, "/bin/sh", codes, localPath)
+		case osconfigpb.ExecStepConfig_POWERSHELL:
+			err = fmt.Errorf("interpreter POWERSHELL cannot be used on non-Windows system")
+		default:
+			err = fmt.Errorf("invalid interpreter %q", stepConfig.GetInterpreter())
+		}
+
+		if gcsObject := stepConfig.GetGcsObject(); gcsObject != nil {
+			if err := os.Remove(localPath); err != nil {
+				logger.Errorf("error removing downloaded file %s", err)
+			}
+		}
+
+		return err
+	}
+	return nil
+}

--- a/ospatch/exec_step_windows.go
+++ b/ospatch/exec_step_windows.go
@@ -1,0 +1,65 @@
+//  Copyright 2018 Google Inc. All Rights Reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
+package ospatch
+
+import (
+	"context"
+	"fmt"
+	"os"
+
+	osconfigpb "github.com/GoogleCloudPlatform/osconfig/_internal/gapi-cloud-osconfig-go/google.golang.org/genproto/googleapis/cloud/osconfig/v1alpha2"
+	"github.com/GoogleCloudPlatform/osconfig/common"
+)
+
+func (r *patchRun) execPreStep() error {
+	logger := &common.Logger{Debugf: r.debugf, Infof: r.infof, Warningf: r.warningf, Errorf: r.errorf, Fatalf: nil}
+	return execStep(r.ctx, logger, r.Job.GetPatchConfig().GetPreStep().GetWindowsExecStepConfig())
+}
+
+func (r *patchRun) execPostStep() error {
+	logger := &common.Logger{Debugf: r.debugf, Infof: r.infof, Warningf: r.warningf, Errorf: r.errorf, Fatalf: nil}
+	return execStep(r.ctx, logger, r.Job.GetPatchConfig().GetPostStep().GetWindowsExecStepConfig())
+}
+
+func execStep(ctx context.Context, logger *common.Logger, stepConfig *osconfigpb.ExecStepConfig) error {
+	if stepConfig != nil {
+		localPath, err := getExecutablePath(ctx, logger, stepConfig)
+		if err != nil {
+			return fmt.Errorf("error getting executable path: %v", err)
+		}
+
+		codes := stepConfig.GetAllowedSuccessCodes()
+
+		switch stepConfig.GetInterpreter() {
+		case osconfigpb.ExecStepConfig_INTERPRETER_UNSPECIFIED:
+			err = fmt.Errorf("interpreter must be specified for a Windows system")
+		case osconfigpb.ExecStepConfig_SHELL:
+			err = executeCommand(logger, "C:\\Windows\\System32\\cmd.exe", codes, "/c", localPath)
+		case osconfigpb.ExecStepConfig_POWERSHELL:
+			err = executeCommand(logger, "C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\PowerShell.exe", codes, "-File", localPath)
+		default:
+			err = fmt.Errorf("invalid interpreter %q", stepConfig.GetInterpreter())
+		}
+
+		if gcsObject := stepConfig.GetGcsObject(); gcsObject != nil {
+			if err := os.Remove(localPath); err != nil {
+				logger.Errorf("error removing downloaded file %s", err)
+			}
+		}
+
+		return err
+	}
+	return nil
+}

--- a/ospatch/patch_run.go
+++ b/ospatch/patch_run.go
@@ -484,10 +484,10 @@ func (r *patchRun) reportPatchDetails(patchState osconfigpb.Instance_PatchState,
 
 func (r *patchRun) prePatchStep() error {
 	r.debugf("Running pre-patch step.")
-	return nil
+	return r.execPreStep()
 }
 
 func (r *patchRun) postPatchStep() error {
 	r.debugf("Running post-patch step.")
-	return nil
+	return r.execPostStep()
 }


### PR DESCRIPTION
- There are debug logs for agent actions and info log for step execution output
- Will download GCS object as a file to the same directory (update: now the temporary directory) as the agent, execute it from within the same directory, then remove it

/woof

/assign @adjackura @ryanwe @hopkiw 