### PR TITLE
Add fallback logic for installing/removing apt packages when applying…

### DIFF
--- a/inventory/packages/apt_deb.go
+++ b/inventory/packages/apt_deb.go
@@ -16,7 +16,6 @@ package packages
 
 import (
 	"bytes"
-	"errors"
 	"fmt"
 	"os"
 	"os/exec"
@@ -62,20 +61,6 @@ func InstallAptPackages(pkgs []string) error {
 	return err
 }
 
-// InstallAptPackagesIndividually installs apt packages individually.
-func InstallAptPackagesIndividually(pkgs []string) error {
-	var errs []string
-	for _, pkg := range pkgs {
-		if err := InstallAptPackages([]string{pkg}); err != nil {
-			errs = append(errs, fmt.Sprintf("Error installing package: %v. Error details: %v", pkg, err))
-		}
-	}
-	if len(errs) > 0 {
-		return errors.New(strings.Join(errs, ",\n"))
-	}
-	return nil
-}
-
 // RemoveAptPackages removes apt packages.
 func RemoveAptPackages(pkgs []string) error {
 	args := append(aptGetRemoveArgs, pkgs...)
@@ -90,20 +75,6 @@ func RemoveAptPackages(pkgs []string) error {
 	}
 	DebugLogger.Printf("apt remove output:\n%s", msg)
 	return err
-}
-
-// RemoveAptPackagesIndividually removes apt packages individually.
-func RemoveAptPackagesIndividually(pkgs []string) error {
-	var errs []string
-	for _, pkg := range pkgs {
-		if err := RemoveAptPackages([]string{pkg}); err != nil {
-			errs = append(errs, fmt.Sprintf("Error removing package: %v. Error details: %v", pkg, err))
-		}
-	}
-	if len(errs) > 0 {
-		return errors.New(strings.Join(errs, ",\n"))
-	}
-	return nil
 }
 
 func parseAptUpdates(data []byte) []PkgInfo {

--- a/inventory/packages/apt_deb.go
+++ b/inventory/packages/apt_deb.go
@@ -16,6 +16,7 @@ package packages
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 	"os"
 	"os/exec"
@@ -61,6 +62,20 @@ func InstallAptPackages(pkgs []string) error {
 	return err
 }
 
+// InstallAptPackagesIndividually installs apt packages individually.
+func InstallAptPackagesIndividually(pkgs []string) error {
+	var errs []string
+	for _, pkg := range pkgs {
+		if err := InstallAptPackages([]string{pkg}); err != nil {
+			errs = append(errs, fmt.Sprintf("Error installing package: %v. Error details: %v", pkg, err))
+		}
+	}
+	if len(errs) > 0 {
+		return errors.New(strings.Join(errs, ",\n"))
+	}
+	return nil
+}
+
 // RemoveAptPackages removes apt packages.
 func RemoveAptPackages(pkgs []string) error {
 	args := append(aptGetRemoveArgs, pkgs...)
@@ -75,6 +90,20 @@ func RemoveAptPackages(pkgs []string) error {
 	}
 	DebugLogger.Printf("apt remove output:\n%s", msg)
 	return err
+}
+
+// RemoveAptPackagesIndividually removes apt packages individually.
+func RemoveAptPackagesIndividually(pkgs []string) error {
+	var errs []string
+	for _, pkg := range pkgs {
+		if err := RemoveAptPackages([]string{pkg}); err != nil {
+			errs = append(errs, fmt.Sprintf("Error removing package: %v. Error details: %v", pkg, err))
+		}
+	}
+	if len(errs) > 0 {
+		return errors.New(strings.Join(errs, ",\n"))
+	}
+	return nil
 }
 
 func parseAptUpdates(data []byte) []PkgInfo {

--- a/inventory/packages/apt_deb_test.go
+++ b/inventory/packages/apt_deb_test.go
@@ -27,24 +27,9 @@ func TestInstallAptPackages(t *testing.T) {
 	}
 }
 
-func TestInstallAptPackagesIndividually(t *testing.T) {
-	run = getMockRun([]byte("TestInstallAptPackagesIndividually"), nil)
-	if err := InstallAptPackagesIndividually(pkgs); err != nil {
-		t.Errorf("unexpected error: %v", err)
-	}
-}
-
 func TestInstallAptPackagesReturnsError(t *testing.T) {
 	run = getMockRun([]byte("TestInstallAptPackagesReturnsError"), errors.New("Could not install package"))
 	err := InstallAptPackages(pkgs)
-	if err == nil {
-		t.Errorf("did not get expected error")
-	}
-}
-
-func TestInstallAptPackagesIndividuallyReturnsError(t *testing.T) {
-	run = getMockRun([]byte("TestInstallAptPackagesIndividuallyReturnsError"), errors.New("Could not install package"))
-	err := InstallAptPackagesIndividually(pkgs)
 	if err == nil {
 		t.Errorf("did not get expected error")
 	}
@@ -57,23 +42,9 @@ func TestRemoveAptPackages(t *testing.T) {
 	}
 }
 
-func TestRemoveAptPackagesIndividually(t *testing.T) {
-	run = getMockRun([]byte("TestRemoveAptPackagesIndividually"), nil)
-	if err := RemoveAptPackagesIndividually(pkgs); err != nil {
-		t.Errorf("unexpected error: %v", err)
-	}
-}
-
 func TestRemoveAptPackagesReturnError(t *testing.T) {
 	run = getMockRun([]byte("TestRemoveAptPackagesReturnError"), errors.New("Could not find package"))
 	if err := RemoveAptPackages(pkgs); err == nil {
-		t.Errorf("did not get expected error")
-	}
-}
-
-func TestRemoveAptPackagesIndividuallyReturnError(t *testing.T) {
-	run = getMockRun([]byte("TestRemoveAptPackagesIndividuallyReturnError"), errors.New("Could not find package"))
-	if err := RemoveAptPackagesIndividually(pkgs); err == nil {
 		t.Errorf("did not get expected error")
 	}
 }

--- a/inventory/packages/apt_deb_test.go
+++ b/inventory/packages/apt_deb_test.go
@@ -27,6 +27,13 @@ func TestInstallAptPackages(t *testing.T) {
 	}
 }
 
+func TestInstallAptPackagesIndividually(t *testing.T) {
+	run = getMockRun([]byte("TestInstallAptPackagesIndividually"), nil)
+	if err := InstallAptPackagesIndividually(pkgs); err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
 func TestInstallAptPackagesReturnsError(t *testing.T) {
 	run = getMockRun([]byte("TestInstallAptPackagesReturnsError"), errors.New("Could not install package"))
 	err := InstallAptPackages(pkgs)
@@ -35,16 +42,38 @@ func TestInstallAptPackagesReturnsError(t *testing.T) {
 	}
 }
 
-func TestRemoveApt(t *testing.T) {
-	run = getMockRun([]byte("TestRemoveApt"), nil)
+func TestInstallAptPackagesIndividuallyReturnsError(t *testing.T) {
+	run = getMockRun([]byte("TestInstallAptPackagesIndividuallyReturnsError"), errors.New("Could not install package"))
+	err := InstallAptPackagesIndividually(pkgs)
+	if err == nil {
+		t.Errorf("did not get expected error")
+	}
+}
+
+func TestRemoveAptPackages(t *testing.T) {
+	run = getMockRun([]byte("TestRemoveAptPackages"), nil)
 	if err := RemoveAptPackages(pkgs); err != nil {
 		t.Errorf("unexpected error: %v", err)
 	}
 }
 
-func TestRemoveAptReturnError(t *testing.T) {
-	run = getMockRun([]byte("TestRemoveAptReturnError"), errors.New("Could not find package"))
+func TestRemoveAptPackagesIndividually(t *testing.T) {
+	run = getMockRun([]byte("TestRemoveAptPackagesIndividually"), nil)
+	if err := RemoveAptPackagesIndividually(pkgs); err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+func TestRemoveAptPackagesReturnError(t *testing.T) {
+	run = getMockRun([]byte("TestRemoveAptPackagesReturnError"), errors.New("Could not find package"))
 	if err := RemoveAptPackages(pkgs); err == nil {
+		t.Errorf("did not get expected error")
+	}
+}
+
+func TestRemoveAptPackagesIndividuallyReturnError(t *testing.T) {
+	run = getMockRun([]byte("TestRemoveAptPackagesIndividuallyReturnError"), errors.New("Could not find package"))
+	if err := RemoveAptPackagesIndividually(pkgs); err == nil {
 		t.Errorf("did not get expected error")
 	}
 }

--- a/policies/apt.go
+++ b/policies/apt.go
@@ -148,9 +148,17 @@ func aptChanges(aptInstalled, aptRemoved, aptUpdated []*osconfigpb.Package) erro
 
 			// Try fallback logic to install the packages individually.
 			logger.Infof("Trying to install packages individually")
-			if err = packages.InstallAptPackagesIndividually(changes.packagesToInstall); err != nil {
-				logger.Errorf("Error installing apt packages individually: %v", err)
-				errs = append(errs, fmt.Sprintf("error installing apt packages: %v", err))
+			var installPkgErrs []string
+			for _, pkg := range changes.packagesToInstall {
+				if err = packages.InstallAptPackages([]string{pkg}); err != nil {
+					installPkgErrs = append(installPkgErrs, fmt.Sprintf("Error installing apt package: %v. Error details: %v", pkg, err))
+				}
+			}
+
+			if len(installPkgErrs) > 0 {
+				errorString := strings.Join(installPkgErrs, "\n")
+				logger.Errorf("Error installing apt packages individually: %v", errorString)
+				errs = append(errs, fmt.Sprintf("error installing apt packages: %v", errorString))
 			}
 		}
 	}
@@ -170,9 +178,17 @@ func aptChanges(aptInstalled, aptRemoved, aptUpdated []*osconfigpb.Package) erro
 
 			// Try fallback logic to remove the packages individually.
 			logger.Infof("Trying to remove packages individually")
-			if err = packages.RemoveAptPackagesIndividually(changes.packagesToRemove); err != nil {
-				logger.Errorf("Error removing apt packages individually: %v", err)
-				errs = append(errs, fmt.Sprintf("error removing apt packages: %v", err))
+			var removePkgErrs []string
+			for _, pkg := range changes.packagesToRemove {
+				if err = packages.RemoveAptPackages([]string{pkg}); err != nil {
+					removePkgErrs = append(removePkgErrs, fmt.Sprintf("Error removing apt package: %v. Error details: %v", pkg, err))
+				}
+			}
+
+			if len(removePkgErrs) > 0 {
+				errorString := strings.Join(removePkgErrs, "\n")
+				logger.Errorf("Error removing apt packages individually: %v", errorString)
+				errs = append(errs, fmt.Sprintf("error removing apt packages: %v", errorString))
 			}
 		}
 	}

--- a/policies/apt.go
+++ b/policies/apt.go
@@ -145,7 +145,13 @@ func aptChanges(aptInstalled, aptRemoved, aptUpdated []*osconfigpb.Package) erro
 		logger.Infof("Installing packages %s", changes.packagesToInstall)
 		if err := packages.InstallAptPackages(changes.packagesToInstall); err != nil {
 			logger.Errorf("Error installing apt packages: %v", err)
-			errs = append(errs, fmt.Sprintf("error installing apt packages: %v", err))
+
+			// Try fallback logic to install the packages individually.
+			logger.Infof("Trying to install packages individually")
+			if err = packages.InstallAptPackagesIndividually(changes.packagesToInstall); err != nil {
+				logger.Errorf("Error installing apt packages individually: %v", err)
+				errs = append(errs, fmt.Sprintf("error installing apt packages: %v", err))
+			}
 		}
 	}
 
@@ -161,7 +167,13 @@ func aptChanges(aptInstalled, aptRemoved, aptUpdated []*osconfigpb.Package) erro
 		logger.Infof("Removing packages %s", changes.packagesToRemove)
 		if err := packages.RemoveAptPackages(changes.packagesToRemove); err != nil {
 			logger.Errorf("Error removing apt packages: %v", err)
-			errs = append(errs, fmt.Sprintf("error removing apt packages: %v", err))
+
+			// Try fallback logic to remove the packages individually.
+			logger.Infof("Trying to remove packages individually")
+			if err = packages.RemoveAptPackagesIndividually(changes.packagesToRemove); err != nil {
+				logger.Errorf("Error removing apt packages individually: %v", err)
+				errs = append(errs, fmt.Sprintf("error removing apt packages: %v", err))
+			}
 		}
 	}
 


### PR DESCRIPTION
When there are invalid packages that are configured to be installed/updated/deleted, the apt package manager fails to install the valid packages as well.

For example: `apt-get install dos2unix xxxxxx` fails to install the valid `dos2unix` package because of the presence of the invalid package `xxxxxx`.

As a result, this PR adds fallback logic to install the packages individually when the combined install fails. We add this as a fallback and not as default logic because the combined install is relatively faster than individual installs.

The same rationale applies when removing the packages as well.

Note: This PR only applies to the `apt` package manager. Once we are in agreement with this approach, we can apply this to the other package managers as well