### PR TITLE
Add more Unit tests

### DIFF
--- a/attributes/attributes.go
+++ b/attributes/attributes.go
@@ -22,6 +22,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"io/ioutil"
 	"net/http"
 )
 
@@ -38,34 +39,32 @@ func PostAttribute(url string, value io.Reader) error {
 		return err
 	}
 	if resp.StatusCode != http.StatusOK {
-		return fmt.Errorf(`received status code %q for request "%s %s"`, resp.Status, req.Method, req.URL.String())
+		b, err := ioutil.ReadAll(resp.Body)
+		responseErr := fmt.Sprintf(`received status code %q for request "%s %s"`, resp.Status, req.Method, req.URL.String())
+		if err == nil {
+			responseErr = fmt.Sprintf("%s\n Error response: %s", responseErr, string(b))
+		}
+		return fmt.Errorf("%s", responseErr)
 	}
 	return nil
 }
 
 // PostAttributeCompressed compresses and posts data to Guest Attributes
 func PostAttributeCompressed(url string, body interface{}) error {
-	buf, err := getCompressData(body)
-	if err != nil {
-		return err
-	}
-	return PostAttribute(url, buf)
-}
-
-func getCompressData(body interface{}) (*bytes.Buffer, error) {
 	buf := &bytes.Buffer{}
 	b := base64.NewEncoder(base64.StdEncoding, buf)
 	zw := gzip.NewWriter(b)
 	w := json.NewEncoder(zw)
 	if err := w.Encode(body); err != nil {
-		return nil, err
+		return err
 	}
 
 	if err := zw.Close(); err != nil {
-		return nil, err
+		return err
 	}
 	if err := b.Close(); err != nil {
-		return nil, err
+		return err
 	}
-	return buf, nil
+
+	return PostAttribute(url, buf)
 }

--- a/attributes/attributes.go
+++ b/attributes/attributes.go
@@ -45,20 +45,27 @@ func PostAttribute(url string, value io.Reader) error {
 
 // PostAttributeCompressed compresses and posts data to Guest Attributes
 func PostAttributeCompressed(url string, body interface{}) error {
+	buf, err := getCompressData(body)
+	if err != nil {
+		return err
+	}
+	return PostAttribute(url, buf)
+}
+
+func getCompressData(body interface{}) (*bytes.Buffer, error) {
 	buf := &bytes.Buffer{}
 	b := base64.NewEncoder(base64.StdEncoding, buf)
 	zw := gzip.NewWriter(b)
 	w := json.NewEncoder(zw)
 	if err := w.Encode(body); err != nil {
-		return err
+		return nil, err
 	}
 
 	if err := zw.Close(); err != nil {
-		return err
+		return nil, err
 	}
 	if err := b.Close(); err != nil {
-		return err
+		return nil, err
 	}
-
-	return PostAttribute(url, buf)
+	return buf, nil
 }

--- a/attributes/attributes_test.go
+++ b/attributes/attributes_test.go
@@ -64,7 +64,7 @@ func TestPostAttributeStatusNotOk(t *testing.T) {
 		w.WriteHeader(http.StatusBadRequest)
 	}))
 	defer ts.Close()
-	err := PostAttribute(ts.URL, strings.NewReader("test bytes"))
+	err := PostAttribute(ts.URL, nil)
 	if err == nil || !strings.Contains(err.Error(), "400 Bad Request") {
 		t.Errorf("test failed, Should be (400 bad request; got(%+v))", err)
 	}

--- a/attributes/attributes_test.go
+++ b/attributes/attributes_test.go
@@ -12,57 +12,80 @@
 //  See the License for the specific language governing permissions and
 //  limitations under the License.
 
-// Package attributes posts data to Guest Attributes.
-
 package attributes
 
 import (
+	"bytes"
 	"fmt"
+	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"strings"
 	"testing"
 )
 
-func TestPostAttribute_happyCase(t *testing.T) {
+func TestPostAttributeHappyCase(t *testing.T) {
+	testData := "test bytes"
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		fmt.Fprintln(w, `{}`)
+		buf := new(bytes.Buffer)
+		buf.ReadFrom(r.Body)
+		newStr := buf.String()
+
+		if strings.Compare(testData, newStr) != 0 {
+			// this is just a way to notify client that the data
+			// recieved was different than what was sent
+			w.WriteHeader(http.StatusExpectationFailed)
+		} else {
+			w.WriteHeader(http.StatusOK)
+		}
 	}))
 	defer ts.Close()
-	err := PostAttribute(ts.URL, strings.NewReader("test bytes"))
-	if err != nil {
-		t.Errorf("test failed, should not be an error")
+	if err := PostAttribute(ts.URL, strings.NewReader(testData)); err != nil {
+		// PostAttribute throw error if status is not 200
+		t.Errorf("test failed, should not be an error; got(%s)", err.Error())
 	}
 }
 
-func TestPostAttribute_InvalidUrl(t *testing.T) {
-	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-	}))
-	defer ts.Close()
-	err := PostAttribute("http://foo.com/ctl\x80", strings.NewReader("test bytes"))
+func TestPostAttributeInvalidUrl(t *testing.T) {
+	err := PostAttribute("http://foo.com/ctl\x80", nil)
 	if err == nil {
 		t.Errorf("test failed, Should be an error")
 	}
 }
 
-func TestPostAttribute_StatusNotOk(t *testing.T) {
+func TestPostAttributeStatusNotOk(t *testing.T) {
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusBadRequest)
 	}))
 	defer ts.Close()
 	err := PostAttribute(ts.URL, strings.NewReader("test bytes"))
 	if err == nil || !strings.Contains(err.Error(), "400 Bad Request") {
-		t.Errorf("test failed, Should be an error")
+		t.Errorf("test failed, Should be (400 bad request; got(%+v))", err)
 	}
 }
 
-func TestPostAttributeCompressed_happyCase(t *testing.T) {
+func TestPostAttributeCompressedhappyCase(t *testing.T) {
+	td := "testing-compression"
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		fmt.Fprintln(w, `{}`)
+		body, err := ioutil.ReadAll(r.Body)
+		if err != nil {
+			w.WriteHeader(http.StatusExpectationFailed)
+			w.Write([]byte("error reading body"))
+
+			return
+		}
+		buf, err := getCompressData(strings.NewReader(td))
+		if strings.Compare(string(body), buf.String()) != 0 {
+			w.WriteHeader(http.StatusExpectationFailed)
+			w.Write([]byte(fmt.Sprintf("expected(%s); got(%s)", buf.String(), string(body))))
+			return
+		}
+		w.WriteHeader(http.StatusOK)
 	}))
 	defer ts.Close()
-	err := PostAttributeCompressed(ts.URL, strings.NewReader("test bytes"))
+
+	err := PostAttributeCompressed(ts.URL, strings.NewReader(td))
 	if err != nil {
-		t.Errorf("test failed, should not be an error")
+		t.Errorf("test failed, should not be an error; got(%s)", err.Error())
 	}
 }

--- a/attributes/attributes_test.go
+++ b/attributes/attributes_test.go
@@ -1,0 +1,68 @@
+//  Copyright 2019 Google Inc. All Rights Reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
+// Package attributes posts data to Guest Attributes.
+
+package attributes
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestPostAttribute_happyCase(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprintln(w, `{}`)
+	}))
+	defer ts.Close()
+	err := PostAttribute(ts.URL, strings.NewReader("test bytes"))
+	if err != nil {
+		t.Errorf("test failed, should not be an error")
+	}
+}
+
+func TestPostAttribute_InvalidUrl(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	}))
+	defer ts.Close()
+	err := PostAttribute("http://foo.com/ctl\x80", strings.NewReader("test bytes"))
+	if err == nil {
+		t.Errorf("test failed, Should be an error")
+	}
+}
+
+func TestPostAttribute_StatusNotOk(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusBadRequest)
+	}))
+	defer ts.Close()
+	err := PostAttribute(ts.URL, strings.NewReader("test bytes"))
+	if err == nil || !strings.Contains(err.Error(), "400 Bad Request"){
+		t.Errorf("test failed, Should be an error")
+	}
+}
+
+func TestPostAttributeCompressed_happyCase(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprintln(w, `{}`)
+	}))
+	defer ts.Close()
+	err := PostAttributeCompressed(ts.URL, strings.NewReader("test bytes"))
+	if err != nil {
+		t.Errorf("test failed, should not be an error")
+	}
+}

--- a/attributes/attributes_test.go
+++ b/attributes/attributes_test.go
@@ -51,7 +51,7 @@ func TestPostAttribute_StatusNotOk(t *testing.T) {
 	}))
 	defer ts.Close()
 	err := PostAttribute(ts.URL, strings.NewReader("test bytes"))
-	if err == nil || !strings.Contains(err.Error(), "400 Bad Request"){
+	if err == nil || !strings.Contains(err.Error(), "400 Bad Request") {
 		t.Errorf("test failed, Should be an error")
 	}
 }

--- a/config/config.go
+++ b/config/config.go
@@ -269,9 +269,9 @@ func MaxMetadataRetryDelay() time.Duration {
 	return 30 * time.Second
 }
 
-// MaxMetadataRetries is the maximum retry delay when getting data from the metadata server.
+// MaxMetadataRetries is the maximum number of retry when getting data from the metadata server.
 func MaxMetadataRetries() int {
-	return 30
+	return 3
 }
 
 // SerialLogPort is the serial port to log to.

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -142,8 +142,8 @@ func TestSetConfigDefaultValues(t *testing.T) {
 		t.Errorf("Default endpoint: got(%s) != want(%s)", SvcEndpoint(), prodEndpoint)
 	}
 
-	if MaxMetadataRetryDelay() != 30 * time.Second {
-		t.Errorf("MaxMetadataretry: got(%s) != want(%s)", MaxMetadataRetryDelay(), 30 * time.Second)
+	if MaxMetadataRetryDelay() != 30*time.Second {
+		t.Errorf("MaxMetadataretry: got(%s) != want(%s)", MaxMetadataRetryDelay(), 30*time.Second)
 	}
 
 	if MaxMetadataRetries() != 3 {
@@ -172,7 +172,7 @@ func TestSetConfig_Error(t *testing.T) {
 		t.Fatalf("Error running os.Setenv: %v", err)
 	}
 
-	if err := SetConfig(); err == nil || !strings.Contains(err.Error(), "unexpected end of JSON input"){
+	if err := SetConfig(); err == nil || !strings.Contains(err.Error(), "unexpected end of JSON input") {
 		t.Errorf("Unexpected output %s", err.Error())
 	}
 

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -153,7 +153,7 @@ func TestVersion(t *testing.T) {
 	}
 }
 
-func TestSetConfig_Error(t *testing.T) {
+func TestSetConfigError(t *testing.T) {
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 	}))
 	defer ts.Close()

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -25,7 +25,6 @@ import (
 	"runtime"
 	"strings"
 	"testing"
-	"time"
 )
 
 func TestSetConfig(t *testing.T) {
@@ -141,14 +140,6 @@ func TestSetConfigDefaultValues(t *testing.T) {
 	if SvcEndpoint() != prodEndpoint {
 		t.Errorf("Default endpoint: got(%s) != want(%s)", SvcEndpoint(), prodEndpoint)
 	}
-
-	if MaxMetadataRetryDelay() != 30*time.Second {
-		t.Errorf("MaxMetadataretry: got(%s) != want(%s)", MaxMetadataRetryDelay(), 30*time.Second)
-	}
-
-	if MaxMetadataRetries() != 3 {
-		t.Errorf("MaxMetadataretry: got(%d) != want(%d)", MaxMetadataRetries(), 3)
-	}
 }
 
 func TestVersion(t *testing.T) {
@@ -164,16 +155,14 @@ func TestVersion(t *testing.T) {
 
 func TestSetConfig_Error(t *testing.T) {
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		fmt.Fprintln(w, `{}`)
 	}))
 	defer ts.Close()
 
-	if err := os.Setenv("GCE_METADATA_HOST", strings.Trim(ts.URL, "randomurl.com")); err != nil {
+	if err := os.Setenv("GCE_METADATA_HOST", strings.Trim(ts.URL, "http://")); err != nil {
 		t.Fatalf("Error running os.Setenv: %v", err)
 	}
 
 	if err := SetConfig(); err == nil || !strings.Contains(err.Error(), "unexpected end of JSON input") {
-		t.Errorf("Unexpected output %s", err.Error())
+		t.Errorf("Unexpected output %+v", err)
 	}
-
 }

--- a/tasker/tasker.go
+++ b/tasker/tasker.go
@@ -16,6 +16,7 @@
 package tasker
 
 import (
+	"fmt"
 	"sync"
 
 	"github.com/GoogleCloudPlatform/guest-logging-go/logger"
@@ -40,22 +41,26 @@ type task struct {
 // Enqueue adds a task to the task queue.
 func Enqueue(name string, f func()) {
 	mx.Lock()
+	fmt.Printf("added task: %s to tasker\n", name)
 	tc <- &task{name: name, run: f}
 	mx.Unlock()
 }
 
 // Close prevents any further tasks from being enqueued and waits for the queue to empty.
 func Close() {
+	fmt.Printf("close called\n")
 	mx.Lock()
+	close(tc)
 	wg.Wait()
+	fmt.Printf("close end\n")
 }
 
 func tasker() {
-	logger.Debugf("Tasker start.")
 	wg.Add(1)
 	defer wg.Done()
 	for {
 		logger.Debugf("Waiting for tasks to run.")
+		fmt.Printf("waiting for tasks to run\n")
 		select {
 		case t, ok := <-tc:
 			// Indicates an empty and closed channel.
@@ -63,7 +68,9 @@ func tasker() {
 				return
 			}
 			logger.Debugf("Tasker running %q.", t.name)
+			fmt.Printf("Tasker running %q\n", t.name)
 			t.run()
+			fmt.Printf("finished task %q\n", t.name)
 			logger.Debugf("Finished task %q.", t.name)
 		}
 	}

--- a/tasker/tasker.go
+++ b/tasker/tasker.go
@@ -16,7 +16,6 @@
 package tasker
 
 import (
-	"fmt"
 	"sync"
 
 	"github.com/GoogleCloudPlatform/guest-logging-go/logger"
@@ -41,18 +40,15 @@ type task struct {
 // Enqueue adds a task to the task queue.
 func Enqueue(name string, f func()) {
 	mx.Lock()
-	fmt.Printf("added task: %s to tasker\n", name)
 	tc <- &task{name: name, run: f}
 	mx.Unlock()
 }
 
 // Close prevents any further tasks from being enqueued and waits for the queue to empty.
 func Close() {
-	fmt.Printf("close called\n")
 	mx.Lock()
 	close(tc)
 	wg.Wait()
-	fmt.Printf("close end\n")
 }
 
 func tasker() {
@@ -60,7 +56,6 @@ func tasker() {
 	defer wg.Done()
 	for {
 		logger.Debugf("Waiting for tasks to run.")
-		fmt.Printf("waiting for tasks to run\n")
 		select {
 		case t, ok := <-tc:
 			// Indicates an empty and closed channel.
@@ -68,9 +63,7 @@ func tasker() {
 				return
 			}
 			logger.Debugf("Tasker running %q.", t.name)
-			fmt.Printf("Tasker running %q\n", t.name)
 			t.run()
-			fmt.Printf("finished task %q\n", t.name)
 			logger.Debugf("Finished task %q.", t.name)
 		}
 	}

--- a/tasker/tasker_test.go
+++ b/tasker/tasker_test.go
@@ -23,7 +23,7 @@ import (
 )
 
 type timeNote struct {
-	id int
+	id        int
 	timestamp time.Time
 }
 
@@ -31,13 +31,12 @@ var notes = []*timeNote{}
 var lock sync.Mutex
 var counter int
 
-
 // TestEnqueue_taskRunSequentially creates task that writes
 // to a common file
 func TestEnqueue_taskRunSequentially(t *testing.T) {
 	times := 100
 	for i := 0; i < times; i++ {
-		 AddToQueue()
+		AddToQueue()
 	}
 	Close()
 
@@ -54,6 +53,6 @@ func AddToQueue() {
 	i := counter
 	lock.Unlock()
 	Enqueue(strconv.Itoa(i), func() {
-		notes = append(notes, &timeNote{id:i, timestamp:time.Now()})
+		notes = append(notes, &timeNote{id: i, timestamp: time.Now()})
 	})
 }

--- a/tasker/tasker_test.go
+++ b/tasker/tasker_test.go
@@ -1,0 +1,59 @@
+//  Copyright 2019 Google Inc. All Rights Reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
+// Package tasker is a task queue for the osconfig_agent.
+package tasker
+
+import (
+	"strconv"
+	"sync"
+	"testing"
+	"time"
+)
+
+type timeNote struct {
+	id int
+	timestamp time.Time
+}
+
+var notes = []*timeNote{}
+var lock sync.Mutex
+var counter int
+
+
+// TestEnqueue_taskRunSequentially creates task that writes
+// to a common file
+func TestEnqueue_taskRunSequentially(t *testing.T) {
+	times := 100
+	for i := 0; i < times; i++ {
+		 AddToQueue()
+	}
+	Close()
+
+	for i := 1; i < times; i++ {
+		if notes[i].timestamp.Sub(notes[i-1].timestamp) < 0 {
+			t.Errorf("task(%d) expected to run earlier\n", i)
+		}
+	}
+}
+
+func AddToQueue() {
+	lock.Lock()
+	counter++
+	i := counter
+	lock.Unlock()
+	Enqueue(strconv.Itoa(i), func() {
+		notes = append(notes, &timeNote{id:i, timestamp:time.Now()})
+	})
+}

--- a/tasker/tasker_test.go
+++ b/tasker/tasker_test.go
@@ -12,47 +12,36 @@
 //  See the License for the specific language governing permissions and
 //  limitations under the License.
 
-// Package tasker is a task queue for the osconfig_agent.
 package tasker
 
 import (
 	"strconv"
-	"sync"
 	"testing"
-	"time"
 )
 
-type timeNote struct {
-	id        int
-	timestamp time.Time
-}
+var notes []int
 
-var notes = []*timeNote{}
-var lock sync.Mutex
-var counter int
-
-// TestEnqueue_taskRunSequentially creates task that writes
-// to a common file
-func TestEnqueue_taskRunSequentially(t *testing.T) {
-	times := 100
+// TestEnqueueTaskRunSequentially to set sequential
+// execution of tasks in tasker
+func TestEnqueueTaskRunSequentially(t *testing.T) {
+	times := 10000
 	for i := 0; i < times; i++ {
-		AddToQueue()
+		addToQueue(i)
 	}
 	Close()
 
+	if len(notes) != times {
+		t.Fatalf("len(notes) != times, %d != %d", len(notes), times)
+	}
 	for i := 1; i < times; i++ {
-		if notes[i].timestamp.Sub(notes[i-1].timestamp) < 0 {
-			t.Errorf("task(%d) expected to run earlier\n", i)
+		if notes[i] < notes[i-1] {
+			t.Errorf("task(%d) expected to run earlier", i)
 		}
 	}
 }
 
-func AddToQueue() {
-	lock.Lock()
-	counter++
-	i := counter
-	lock.Unlock()
+func addToQueue(i int) {
 	Enqueue(strconv.Itoa(i), func() {
-		notes = append(notes, &timeNote{id: i, timestamp: time.Now()})
+		notes = append(notes, i)
 	})
 }


### PR DESCRIPTION
Improve coverage for unit test
- Add unit test for config, attributes, tasker package
- Fix bug in tasker:
  The tasker would never stop because the underlying channel
  was never closed and this the tasker waited on the channel
  forever

------------------------------------------------------------------------------
Coverage Before
------------------------------------------------------------------------------
?       github.com/GoogleCloudPlatform/osconfig [no test files]
?       github.com/GoogleCloudPlatform/osconfig/attributes      [no test files]
?       github.com/GoogleCloudPlatform/osconfig/common  [no test files]
ok      github.com/GoogleCloudPlatform/osconfig/config  0.067s  coverage: 70.0% of statements
ok      github.com/GoogleCloudPlatform/osconfig/inventory       0.078s  coverage: 30.8% of statements
ok      github.com/GoogleCloudPlatform/osconfig/inventory/osinfo        0.116s  coverage: 83.7% of statements
ok      github.com/GoogleCloudPlatform/osconfig/inventory/packages      0.078s  coverage: 59.7% of statements
ok      github.com/GoogleCloudPlatform/osconfig/ospatch 0.124s  coverage: 19.6% of statements
ok      github.com/GoogleCloudPlatform/osconfig/policies        0.171s  coverage: 24.4% of statements
?       github.com/GoogleCloudPlatform/osconfig/policies/recipes        [no test files]
?       github.com/GoogleCloudPlatform/osconfig/service [no test files]
?       github.com/GoogleCloudPlatform/osconfig/tasker  [no test files]


------------------------------------------------------------------------------
Coverage After
------------------------------------------------------------------------------
ok github.com/GoogleCloudPlatform/osconfig/attributes 0.214s coverage: 76.2% of statements
? github.com/GoogleCloudPlatform/osconfig/common [no test files]
ok github.com/GoogleCloudPlatform/osconfig/config 10.090s coverage: 80.9% of statements
ok github.com/GoogleCloudPlatform/osconfig/inventory 0.077s coverage: 30.8% of statements
ok github.com/GoogleCloudPlatform/osconfig/inventory/osinfo 0.086s coverage: 83.7% of statements
ok github.com/GoogleCloudPlatform/osconfig/inventory/packages 0.091s coverage: 59.7% of statements
ok github.com/GoogleCloudPlatform/osconfig/ospatch 0.086s coverage: 19.6% of statements
ok github.com/GoogleCloudPlatform/osconfig/policies 0.092s coverage: 24.4% of statements
? github.com/GoogleCloudPlatform/osconfig/policies/recipes [no test files]
? github.com/GoogleCloudPlatform/osconfig/service [no test files]
ok github.com/GoogleCloudPlatform/osconfig/tasker 0.079s coverage: 100.0% of statements