### PR TITLE
switching default permission constant to be specified in octal

### DIFF
--- a/policies/recipes/steps.go
+++ b/policies/recipes/steps.go
@@ -85,7 +85,7 @@ func StepFileCopy(step *osconfigpb.SoftwareRecipe_Step_FileCopy, artifacts map[s
 
 func parsePermissions(s string) (os.FileMode, error) {
 	if s == "" {
-		return 755, nil
+		return 0755, nil
 	}
 
 	i, err := strconv.ParseUint(s, 8, 32)


### PR DESCRIPTION
I don't know how it got from decimal 755 to the permissions that you saw but from testing it looks like switching it to octal fixes the issue.