### PR TITLE
Fix recipeDB init

### DIFF
--- a/policies/recipes/installrecipe.go
+++ b/policies/recipes/installrecipe.go
@@ -38,9 +38,9 @@ func InstallRecipe(ctx context.Context, recipe *osconfigpb.SoftwareRecipe) error
 	}
 	installedRecipe, ok := recipeDB.getRecipe(recipe.Name)
 	if ok {
-		logger.Debugf("Currently installed version of software recipe %s with version %s.", recipe.Name, installedRecipe.version)
+		logger.Debugf("Currently installed version of software recipe %s with version %s.", recipe.Name, installedRecipe.Version)
 		if (installedRecipe.compare(recipe.Version)) && (recipe.DesiredState == osconfigpb.DesiredState_UPDATED) {
-			logger.Infof("Upgrading software recipe %s from version %s to %s.", recipe.Name, installedRecipe.version, recipe.Version)
+			logger.Infof("Upgrading software recipe %s from version %s to %s.", recipe.Name, installedRecipe.Version, recipe.Version)
 			steps = recipe.UpdateSteps
 		} else {
 			logger.Debugf("Skipping software recipe %s.", recipe.Name)

--- a/policies/recipes/recipe.go
+++ b/policies/recipes/recipe.go
@@ -20,9 +20,9 @@ import (
 	"strings"
 )
 
-type rver []int
+type recipeVersion []int
 
-func (v rver) String() string {
+func (v recipeVersion) String() string {
 	res := fmt.Sprintf("%d", v[0])
 	for _, val := range v[1:] {
 		res = fmt.Sprintf("%s.%d", res, val)
@@ -30,22 +30,23 @@ func (v rver) String() string {
 	return res
 }
 
-type recipe struct {
-	name        string
-	version     rver
-	installTime int64
-	success     bool
+// Recipe represents an installed recipe.
+type Recipe struct {
+	Name        string
+	Version     recipeVersion
+	InstallTime int64
+	Success     bool
 }
 
-func (r *recipe) setVersion(version string) error {
+func (r *Recipe) setVersion(version string) error {
 	var err error
-	r.version, err = convertVersion(version)
+	r.Version, err = convertVersion(version)
 	return err
 }
 
 // compare returns true if the provided Version is greater than the recipe's
 // Version, false otherwise.
-func (r *recipe) compare(version string) bool {
+func (r *Recipe) compare(version string) bool {
 	if version == "" {
 		return false
 	}
@@ -53,20 +54,20 @@ func (r *recipe) compare(version string) bool {
 	if err != nil {
 		return false
 	}
-	if len(r.version) > len(cVersion) {
-		topad := len(r.version) - len(cVersion)
+	if len(r.Version) > len(cVersion) {
+		topad := len(r.Version) - len(cVersion)
 		for i := 0; i < topad; i++ {
 			cVersion = append(cVersion, 0)
 		}
 	} else {
-		topad := len(cVersion) - len(r.version)
+		topad := len(cVersion) - len(r.Version)
 		for i := 0; i < topad; i++ {
-			r.version = append(r.version, 0)
+			r.Version = append(r.Version, 0)
 		}
 	}
-	for i := 0; i < len(r.version); i++ {
-		if r.version[i] != cVersion[i] {
-			return cVersion[i] > r.version[i]
+	for i := 0; i < len(r.Version); i++ {
+		if r.Version[i] != cVersion[i] {
+			return cVersion[i] > r.Version[i]
 		}
 	}
 	return false

--- a/policies/recipes/recipe_test.go
+++ b/policies/recipes/recipe_test.go
@@ -20,23 +20,23 @@ import (
 )
 
 func TestRecipe_SetVersion_ValidVersion(t *testing.T) {
-	rec := &recipe{}
+	rec := &Recipe{}
 	rec.setVersion("1.2.3.23")
-	if rec.version[0] != 1 || rec.version[1] != 2 || rec.version[2] != 3 || rec.version[3] != 23 {
+	if rec.Version[0] != 1 || rec.Version[1] != 2 || rec.Version[2] != 3 || rec.Version[3] != 23 {
 		t.Errorf("invalid Version set for the recipe")
 	}
 }
 
 func TestRecipe_SetVersion_EmptyVersion(t *testing.T) {
-	rec := &recipe{}
+	rec := &Recipe{}
 	rec.setVersion("")
-	if len(rec.version) != 1 || rec.version[0] != 0 {
+	if len(rec.Version) != 1 || rec.Version[0] != 0 {
 		t.Errorf("invalid Version set for the recipe")
 	}
 }
 
 func TestRecipe_SetVersion_InvalidVersion(t *testing.T) {
-	rec := &recipe{}
+	rec := &Recipe{}
 	err := rec.setVersion("12.32.23.23.23.23")
 	if !strings.Contains(err.Error(), "invalid") {
 		t.Errorf("setVersion should return error")
@@ -45,7 +45,7 @@ func TestRecipe_SetVersion_InvalidVersion(t *testing.T) {
 }
 
 func TestRecipe_SetVersion_InvalidCharacter(t *testing.T) {
-	rec := &recipe{}
+	rec := &Recipe{}
 	err := rec.setVersion("12.32.dsf.23")
 	if !strings.Contains(err.Error(), "invalid") {
 		t.Errorf("setVersion should return error")
@@ -53,49 +53,49 @@ func TestRecipe_SetVersion_InvalidCharacter(t *testing.T) {
 }
 
 func TestRecipe_Compare_EmptyVersion(t *testing.T) {
-	rec := &recipe{version: []int{1, 2, 3, 4}}
+	rec := &Recipe{Version: []int{1, 2, 3, 4}}
 	if rec.compare("") {
 		t.Errorf("should return false")
 	}
 }
 
 func TestRecipe_Compare_InvalidInput(t *testing.T) {
-	rec := &recipe{version: []int{1, 2, 3, 4}}
+	rec := &Recipe{Version: []int{1, 2, 3, 4}}
 	if rec.compare("1.2.3.4.56.7") {
 		t.Errorf("should return false")
 	}
 }
 
 func TestRecipe_Compare_PaddingNeededAndCompare(t *testing.T) {
-	rec := &recipe{version: []int{1, 2, 3, 4}}
+	rec := &Recipe{Version: []int{1, 2, 3, 4}}
 	if !rec.compare("1.3") {
 		t.Errorf("should return true")
 	}
 }
 
 func TestRecipe_Compare_PaddingNeededToRecipe(t *testing.T) {
-	rec := &recipe{version: []int{1, 3}}
+	rec := &Recipe{Version: []int{1, 3}}
 	if rec.compare("1.2.3.4") {
 		t.Errorf("should return false")
 	}
 }
 
 func TestRecipe_Compare_IsGreater(t *testing.T) {
-	rec := &recipe{version: []int{1, 2, 3, 4}}
+	rec := &Recipe{Version: []int{1, 2, 3, 4}}
 	if !rec.compare("1.3.4.2") {
 		t.Errorf("should return true")
 	}
 }
 
 func TestRecipe_Compare_IsNotGreater(t *testing.T) {
-	rec := &recipe{version: []int{1, 6, 3, 4}}
+	rec := &Recipe{Version: []int{1, 6, 3, 4}}
 	if rec.compare("1.3.4.2") {
 		t.Errorf("should return false")
 	}
 }
 
 func TestRecipe_Compare_IsEqualVersion(t *testing.T) {
-	rec := &recipe{version: []int{1, 6, 3, 4}}
+	rec := &Recipe{Version: []int{1, 6, 3, 4}}
 	if rec.compare("1.6.3.4") {
 		t.Errorf("should return false")
 	}


### PR DESCRIPTION
Stacked PR, view latest commit only

Corrects 'assignment to nil map' RTE
Resulting on-disk JSON is e.g. `[{Name: "recipe_name", Version: "0", ...}, { ... } ]`

This isn't strictly valid JSON as top level isn't an object, but the marshaling functions don't mind.