### PR TITLE
Fix exec step GCS object fetching

### DIFF
--- a/ospatch/exec_step.go
+++ b/ospatch/exec_step.go
@@ -34,10 +34,13 @@ func getExecutablePath(ctx context.Context, logger *util.Logger, stepConfig *osc
 		var reader io.ReadCloser
 		cl, err := storage.NewClient(ctx)
 		if err != nil {
-			return "", fmt.Errorf("error creating gcs client: %v", err)
+			return "", fmt.Errorf("error creating GCS client: %v", err)
 		}
-		external.FetchGCSObject(ctx, cl, gcsObject.Object, gcsObject.Bucket, gcsObject.GenerationNumber)
+		if reader, err = external.FetchGCSObject(ctx, cl, gcsObject.Object, gcsObject.Bucket, gcsObject.GenerationNumber); err != nil {
+			return "", fmt.Errorf("error fetching GCS object: %v", err)
+		}
 		defer reader.Close()
+
 		logger.Debugf("Fetched GCS object bucket %s object %s generation number %d", gcsObject.GetBucket(), gcsObject.GetObject(), gcsObject.GetGenerationNumber())
 
 		localPath := filepath.Join(os.TempDir(), path.Base(gcsObject.GetObject()))
@@ -47,6 +50,7 @@ func getExecutablePath(ctx context.Context, logger *util.Logger, stepConfig *osc
 		return localPath, nil
 	}
 
+	logger.Debugf("Using local path %s", stepConfig.GetLocalPath())
 	return stepConfig.GetLocalPath(), nil
 }
 

--- a/ospatch/exec_step_linux.go
+++ b/ospatch/exec_step_linux.go
@@ -61,5 +61,7 @@ func execStep(ctx context.Context, logger *util.Logger, stepConfig *osconfigpb.E
 
 		return err
 	}
+
+	logger.Debugf("No ExecStepConfig for Linux")
 	return nil
 }

--- a/ospatch/exec_step_windows.go
+++ b/ospatch/exec_step_windows.go
@@ -61,5 +61,7 @@ func execStep(ctx context.Context, logger *util.Logger, stepConfig *osconfigpb.E
 
 		return err
 	}
+
+	logger.Debugf("No ExecStepConfig for Windows")
 	return nil
 }


### PR DESCRIPTION
FetchGCSObject helper was refactored since the first commit of exec step logic which caused a nil pointer issue.

Testing done:
- `go test ./...`
- gcloud and manual agent installation on instance

/assign @adjackura @iamsubratp 
/woof