### PR TITLE
Add beginnings of includes/excludes for package management

### DIFF
--- a/agentendpoint/patch_linux.go
+++ b/agentendpoint/patch_linux.go
@@ -33,7 +33,7 @@ func (r *patchTask) runUpdates(ctx context.Context) error {
 		opts := []ospatch.AptGetUpgradeOption{}
 		switch r.Task.GetPatchConfig().GetApt().GetType() {
 		case agentendpointpb.AptSettings_DIST:
-			opts = append(opts, ospatch.AptGetUpgradeType(ospatch.AptGetDistUpgrade))
+			opts = append(opts, ospatch.AptGetUpgradeType(packages.AptGetDistUpgrade))
 		}
 		r.debugf("Installing APT package updates.")
 		if err := retryFunc(retryPeriod, "installing APT package updates", func() error { return ospatch.RunAptGetUpgrade(opts...) }); err != nil {

--- a/inventory/packages/packages_linux.go
+++ b/inventory/packages/packages_linux.go
@@ -27,7 +27,7 @@ func GetPackageUpdates() (Packages, error) {
 	pkgs := Packages{}
 	var errs []string
 	if AptExists {
-		apt, err := AptUpdates()
+		apt, err := AptUpdates(AptGetUpgradeType(AptGetFullUpgrade), AptGetUpgradeShowNew(false))
 		if err != nil {
 			msg := fmt.Sprintf("error getting apt updates: %v", err)
 			DebugLogger.Println("Error:", msg)

--- a/ospatch/apt_upgrade.go
+++ b/ospatch/apt_upgrade.go
@@ -22,10 +22,10 @@ import (
 )
 
 type aptGetUpgradeOpts struct {
-	upgradeType packages.AptUpgradeType
-	includes    []string
-	excludes    []string
-	dryrun      bool
+	upgradeType       packages.AptUpgradeType
+	exclusivePackages []string
+	excludes          []string
+	dryrun            bool
 
 	runner func(cmd *exec.Cmd) ([]byte, error)
 }
@@ -47,10 +47,10 @@ func AptGetExcludes(excludes []string) AptGetUpgradeOption {
 	}
 }
 
-// AptGetIncludes includes only these packages in the upgrade.
-func AptGetIncludes(includes []string) AptGetUpgradeOption {
+// AptGetExclusivePackages includes only these packages in the upgrade.
+func AptGetExclusivePackages(exclusivePackages []string) AptGetUpgradeOption {
 	return func(args *aptGetUpgradeOpts) {
-		args.includes = includes
+		args.exclusivePackages = exclusivePackages
 	}
 }
 
@@ -77,7 +77,7 @@ func RunAptGetUpgrade(opts ...AptGetUpgradeOption) error {
 		return err
 	}
 
-	fPkgs, err := filterPackages(pkgs, aptOpts.includes, aptOpts.excludes)
+	fPkgs, err := filterPackages(pkgs, aptOpts.exclusivePackages, aptOpts.excludes)
 	if err != nil {
 		return err
 	}

--- a/ospatch/googet_update.go
+++ b/ospatch/googet_update.go
@@ -20,9 +20,9 @@ import (
 )
 
 type googetUpdateOpts struct {
-	includes []string
-	excludes []string
-	dryrun   bool
+	exclusivePackages []string
+	excludes          []string
+	dryrun            bool
 }
 
 // GooGetUpdateOption is an option for apt-get update.
@@ -35,10 +35,10 @@ func GooGetExcludes(excludes []string) GooGetUpdateOption {
 	}
 }
 
-// GooGetIncludes includes only these packages in the upgrade.
-func GooGetIncludes(includes []string) GooGetUpdateOption {
+// GooGetExclusivePackages includes only these packages in the upgrade.
+func GooGetExclusivePackages(exclusivePackages []string) GooGetUpdateOption {
 	return func(args *googetUpdateOpts) {
-		args.includes = includes
+		args.exclusivePackages = exclusivePackages
 	}
 }
 
@@ -62,7 +62,7 @@ func RunGooGetUpdate(opts ...GooGetUpdateOption) error {
 		return err
 	}
 
-	fPkgs, err := filterPackages(pkgs, googetOpts.includes, googetOpts.excludes)
+	fPkgs, err := filterPackages(pkgs, googetOpts.exclusivePackages, googetOpts.excludes)
 	if err != nil {
 		return err
 	}

--- a/ospatch/system_linux.go
+++ b/ospatch/system_linux.go
@@ -22,6 +22,7 @@ import (
 	"os/exec"
 
 	"github.com/GoogleCloudPlatform/guest-logging-go/logger"
+	"github.com/GoogleCloudPlatform/osconfig/inventory/packages"
 )
 
 const (
@@ -95,9 +96,8 @@ func DisableAutoUpdates() {
 	// /etc/apt/apt.conf.d/ and setting APT::Periodic::Unattended-Upgrade to 0.
 	if _, err := os.Stat("/usr/bin/unattended-upgrades"); err == nil {
 		logger.Debugf("Removing unattended-upgrades package")
-		out, err := exec.Command(aptGet, "remove", "-y", "unattended-upgrades").CombinedOutput()
-		if err != nil {
-			logger.Errorf("%v, out: %s", err, out)
+		if err := packages.RemoveAptPackages([]string{"unattended-upgrades"}); err != nil {
+			logger.Errorf(err.Error())
 		}
 	}
 }

--- a/ospatch/system_windows.go
+++ b/ospatch/system_windows.go
@@ -18,9 +18,9 @@ package ospatch
 
 import (
 	"os"
-	"os/exec"
 
 	"github.com/GoogleCloudPlatform/guest-logging-go/logger"
+	"github.com/GoogleCloudPlatform/osconfig/inventory/packages"
 	"golang.org/x/sys/windows/registry"
 )
 
@@ -46,9 +46,8 @@ func DisableAutoUpdates() {
 
 	if _, err := os.Stat(`C:\Program Files\Google\Compute Engine\tools\auto_updater.ps1`); err == nil {
 		logger.Debugf("Removing google-compute-engine-auto-updater package")
-		out, err := exec.Command(googet, "-noconfirm", "remove", "google-compute-engine-auto-updater").CombinedOutput()
-		if err != nil {
-			logger.Errorf("error removing google-compute-engine-auto-updater, error: %v, out: %s", err, out)
+		if err := packages.RemoveGooGetPackages([]string{"google-compute-engine-auto-updater"}); err != nil {
+			logger.Errorf(err.Error())
 		}
 	}
 }

--- a/ospatch/updates.go
+++ b/ospatch/updates.go
@@ -17,10 +17,13 @@ package ospatch
 import (
 	"bufio"
 	"bytes"
+	"errors"
 	"fmt"
 	"os"
 	"os/exec"
 	"strconv"
+
+	"github.com/GoogleCloudPlatform/osconfig/inventory/packages"
 )
 
 const (
@@ -106,4 +109,29 @@ func rpmReboot() (bool, error) {
 	}
 
 	return rpmRebootRequired(out, btime), nil
+}
+
+func containsString(ss []string, c string) bool {
+	for _, s := range ss {
+		if s == c {
+			return true
+		}
+	}
+	return false
+}
+
+func filterPackages(pkgs []packages.PkgInfo, includes, excludes []string) ([]packages.PkgInfo, error) {
+	if len(includes) != 0 && len(excludes) != 0 {
+		return nil, errors.New("includes and excludes can not both be non 0")
+	}
+	var fPkgs []packages.PkgInfo
+	for _, pkg := range pkgs {
+		if containsString(excludes, pkg.Name) {
+			continue
+		}
+		if includes == nil || containsString(includes, pkg.Name) {
+			fPkgs = append(fPkgs, pkg)
+		}
+	}
+	return fPkgs, nil
 }


### PR DESCRIPTION
Includes name may/probably will change in the future.
All package management functions for GooGet and APT moved to the 'packages' package from ospatch
Packages to be updated are now evaluated, logged, then installed
Dryrun option does everything up to actually install new packages.
APT logic updated to support both dist/full and normal upgrades
Logging package has been updated so logging initialization changed slightly
