### PR TITLE
Add basic integration test framework

### DIFF
--- a/e2etester/compute/compute.go
+++ b/e2etester/compute/compute.go
@@ -1,0 +1,53 @@
+package e2etestcompute
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+
+	daisyCompute "github.com/GoogleCloudPlatform/compute-image-tools/daisy/compute"
+	"google.golang.org/api/compute/v1"
+)
+
+const (
+	metadataURL = "http://metadata.google.internal/computeMetadata/v1/instance/attributes/?recursive=true&alt=json"
+)
+
+// GetMetadata gets instance attributes from metadata.
+func GetMetadata() (map[string]string, error) {
+	var md map[string]string
+	if md != nil {
+		return md, nil
+	}
+
+	client := &http.Client{}
+	req, err := http.NewRequest("GET", metadataURL, nil)
+	if err != nil {
+		return nil, fmt.Errorf("error building HTTP request for metadata: %s", err)
+	}
+	req.Header.Add("Metadata-Flavor", "Google")
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("error getting metadata: %s", err)
+	}
+	body, err := ioutil.ReadAll(resp.Body)
+	resp.Body.Close()
+	if err != nil {
+		return nil, fmt.Errorf("error getting metadata: %s", err)
+	}
+	err = json.Unmarshal(body, &md)
+	if err != nil {
+		return nil, fmt.Errorf("error parsing metadata: %s", err)
+	}
+	return md, nil
+}
+
+func GetCommonInstanceMetadata(client daisyCompute.Client, project string) (*compute.Metadata, error) {
+	proj, err := client.GetProject(project)
+	if err != nil {
+		return nil, fmt.Errorf("error getting project: %v", err)
+	}
+
+	return proj.CommonInstanceMetadata, nil
+}

--- a/e2etester/config/config.go
+++ b/e2etester/config/config.go
@@ -1,0 +1,28 @@
+package config
+
+import (
+	"flag"
+	"time"
+)
+
+const (
+	DefaultParallelCount = 5
+	TimeFormat           = time.RFC3339
+)
+
+var (
+	Oauth         = flag.String("oauth", "", "path to oauth json file")
+	Project       = flag.String("project", "", "comma separated list of project that can be used for tests")
+	Images        = flag.String("images", "", "comma separated list of images to run tests for")
+	Zone          = flag.String("zone", "", "zone to use for tests")
+	PrintTests    = flag.Bool("print", false, "print out the parsed test cases for debugging")
+	Validate      = flag.Bool("validate", false, "validate all the test cases and exit")
+	Ce            = flag.String("compute_endpoint_override", "", "API endpoint to override default")
+	Filter        = flag.String("filter", "", "test name filter")
+	OutPath       = flag.String("out_path", "junit.xml", "junit xml path")
+	ParallelCount = flag.Int("parallel_count", 0, "TestParallelCount")
+)
+
+func init() {
+	flag.Parse()
+}

--- a/e2etester/error/error.go
+++ b/e2etester/error/error.go
@@ -1,0 +1,28 @@
+package error
+
+import "fmt"
+
+// ErrorCollector is used to combine
+// a list of errors together into a
+// single error
+type ErrorCollector []error
+
+// Collect collects all the errors to be combined
+// together
+func (c *ErrorCollector) Collect(e error) {
+	*c = append(*c, e)
+}
+
+// Error returns number of errors collected and combined
+// error from collected errors
+func (c *ErrorCollector) Error() (int, error) {
+	if len(*c) == 0 {
+		return 0, nil
+	}
+
+	err := "Errors:\n"
+	for _, e := range *c {
+		err += fmt.Sprintf("%s\n", e.Error())
+	}
+	return len(*c), fmt.Errorf(err)
+}

--- a/e2etester/error/error_test.go
+++ b/e2etester/error/error_test.go
@@ -1,0 +1,36 @@
+package error
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+)
+
+func TestErrorCollectorError(t *testing.T) {
+	collector := new(ErrorCollector)
+	collector.Collect(fmt.Errorf("error 1"))
+	collector.Collect(fmt.Errorf("error 2"))
+	count, err := collector.Error()
+	if count != 2 {
+		t.Errorf("Unexpected number of Errors: (%d) wanted (%d)", count, 2)
+	}
+	if !strings.Contains(err.Error(), "error 1") {
+		t.Errorf("Unexpected error: (%s)! wanted(%s)", err.Error(), "error 1")
+	}
+
+	if !strings.Contains(err.Error(), "error 2") {
+		t.Errorf("Unexpected error: (%s)! wanted(%s)", err.Error(), "error 2")
+	}
+}
+
+func TestErrorCollectorEmptyCollector(t *testing.T) {
+	collector := new(ErrorCollector)
+	count, err := collector.Error()
+	if count != 0 {
+		t.Errorf("Unexpected number of Errors: (%d) wanted (%d)", count, 0)
+	}
+
+	if err != nil {
+		t.Errorf("Unexpected error: (+%v)! wanted(nil)", err)
+	}
+}

--- a/e2etester/executor/executor.go
+++ b/e2etester/executor/executor.go
@@ -1,0 +1,83 @@
+package executor
+
+import (
+	"fmt"
+	"net/http"
+	"strings"
+
+	"github.com/GoogleCloudPlatform/osconfig/e2etester/test_suite_base"
+)
+
+type TestOptions struct {
+	Name       string
+	images     []string
+	testHandle interface{}
+}
+
+func NewTestOptions(name string, i []string, th interface{}) *TestOptions {
+	return &TestOptions{
+		Name:       name,
+		images:     i,
+		testHandle: th,
+	}
+}
+
+func (t *TestOptions) GetImages() []string {
+	return t.images
+}
+
+func (t *TestOptions) GetTestHandle() interface{} {
+	return t.testHandle
+}
+
+type ITestExecutor struct {
+	testSets []*TestOptions
+}
+
+var executor *ITestExecutor
+
+func GetITestExecutor() *ITestExecutor {
+	if executor == nil {
+		tOptions := []*TestOptions{}
+		executor = &ITestExecutor{testSets: tOptions}
+	}
+	return executor
+}
+
+func (e *ITestExecutor) AddTestOptions(t *TestOptions) error {
+	if t == nil {
+		return fmt.Errorf("cannot add empty option")
+	}
+	e.testSets = append(e.testSets, t)
+	return nil
+}
+
+func (e *ITestExecutor) GetTestOptions() []*TestOptions {
+	return e.testSets
+}
+
+func (e *ITestExecutor) Execute(options *TestOptions) {
+	if isRunningOnGCE() {
+		run(options.GetTestHandle())
+		return
+	}
+	test_suite_base.Prepare(options.Name, options.GetImages(), options.GetTestHandle())
+}
+
+func run(testHandle interface{}) {
+	err := test_suite_base.RunAllTests(testHandle)
+	if err != nil {
+		fmt.Printf("TEST-FAILURE: test failed: %v\n", err)
+	} else {
+		fmt.Printf("TEST-SUCCESS: test succeeded\n")
+	}
+}
+
+func isRunningOnGCE() bool {
+	metadataServer := "http://metadata.google.internal/computeMetadata/"
+	resp, err := http.Get(metadataServer)
+	if err != nil {
+		return !strings.Contains(err.Error(), "no such host")
+	}
+	return resp.StatusCode == http.StatusOK
+}

--- a/e2etester/logger/logger.go
+++ b/e2etester/logger/logger.go
@@ -1,0 +1,29 @@
+package logger
+
+import (
+	"bytes"
+	"sync"
+
+	"github.com/GoogleCloudPlatform/compute-image-tools/daisy"
+)
+
+type TLogger struct {
+	Buf bytes.Buffer
+	Mx  sync.Mutex
+}
+
+func (l *TLogger) WriteLogEntry(e *daisy.LogEntry) {
+	l.Mx.Lock()
+	defer l.Mx.Unlock()
+	l.Buf.WriteString(e.String())
+}
+
+func (l *TLogger) WriteSerialPortLogs(w *daisy.Workflow, instance string, buf bytes.Buffer) {
+	return
+}
+
+func (l *TLogger) ReadSerialPortLogs() []string {
+	return []string{}
+}
+
+func (l *TLogger) Flush() { return }

--- a/e2etester/test_suite_base/junitxml.go
+++ b/e2etester/test_suite_base/junitxml.go
@@ -1,0 +1,40 @@
+package test_suite_base
+
+import (
+	"encoding/xml"
+	"sync"
+)
+
+type junitTestSuite struct {
+	mx sync.Mutex
+
+	XMLName  xml.Name `xml:"testsuite"`
+	Name     string   `xml:"name,attr"`
+	Tests    int      `xml:"tests,attr"`
+	Failures int      `xml:"failures,attr"`
+	Errors   int      `xml:"errors,attr"`
+	Disabled int      `xml:"disabled,attr"`
+	Skipped  int      `xml:"skipped,attr"`
+	Time     float64  `xml:"time,attr"`
+
+	TestCase []*junitTestCase `xml:"testcase"`
+}
+
+type junitTestCase struct {
+	Classname string        `xml:"classname,attr"`
+	ID        string        `xml:"id,attr"`
+	Name      string        `xml:"name,attr"`
+	Time      float64       `xml:"time,attr"`
+	Skipped   *junitSkipped `xml:"skipped,omitempty"`
+	Failure   *junitFailure `xml:"failure,omitempty"`
+	SystemOut string        `xml:"system-out,omitempty"`
+}
+
+type junitSkipped struct {
+	Message string `xml:"message,attr"`
+}
+
+type junitFailure struct {
+	FailMessage string `xml:",chardata"`
+	FailType    string `xml:"type,attr"`
+}

--- a/e2etester/test_suite_base/test_main.go
+++ b/e2etester/test_suite_base/test_main.go
@@ -1,0 +1,214 @@
+package test_suite_base
+
+import (
+	"context"
+	"encoding/xml"
+	"fmt"
+	"io/ioutil"
+	"log"
+	"os"
+	"os/signal"
+	"path/filepath"
+	"regexp"
+	"sync"
+	"time"
+
+	"github.com/GoogleCloudPlatform/osconfig/e2etester/config"
+)
+
+func Prepare(suiteName string, images []string, testHandle interface{}) {
+	ctx := context.Background()
+
+	var regex *regexp.Regexp
+	if *config.Filter != "" {
+		var err error
+		regex, err = regexp.Compile(*config.Filter)
+		if err != nil {
+			fmt.Println("-filter flag not valid:", err)
+			os.Exit(1)
+		}
+	}
+
+	ts, err := CreateTestSuite(suiteName, images, testHandle)
+	if err != nil {
+		log.Fatalln("test case creation error:", err)
+	}
+
+	if ts == nil {
+		// If filters resulted in no possible tests..?
+		return
+	}
+
+	errors := make(chan error, len(ts.Tests))
+	// Retry failed locks 2x as many tests in the test case.
+	retries := len(ts.Tests) * 2
+	if len(ts.Tests) == 0 {
+		fmt.Println("[TestRunner] Nothing to do")
+		return
+	}
+
+	if *config.PrintTests {
+		for n, t := range ts.Tests {
+			if t.W == nil {
+				continue
+			}
+			fmt.Printf("[TestRunner] Printing test case %q\n", n)
+			t.W.Print(ctx)
+		}
+		CheckError(errors)
+		return
+	}
+
+	if *config.Validate {
+		for n, t := range ts.Tests {
+			if t.W == nil {
+				continue
+			}
+			fmt.Printf("[TestRunner] Validating test case %q\n", t.W.Name)
+			if err := t.W.Validate(ctx); err != nil {
+				errors <- fmt.Errorf("Error validating test case %s: %v", n, err)
+			}
+		}
+		CheckError(errors)
+		return
+	}
+
+	if err := os.MkdirAll(filepath.Dir(*config.Oauth), 0770); err != nil {
+		log.Fatal(err)
+	}
+
+	junit := &junitTestSuite{Name: ts.Name, Tests: len(ts.Tests)}
+	tests := make(chan *test, len(ts.Tests))
+	var wg sync.WaitGroup
+	for i := 0; i < ts.TestParallelCount; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for test := range tests {
+				tc := &junitTestCase{Classname: ts.Name, ID: test.testCase.id, Name: test.name}
+				junit.mx.Lock()
+				junit.TestCase = append(junit.TestCase, tc)
+				junit.mx.Unlock()
+
+				if test.testCase.W == nil {
+					junit.mx.Lock()
+					junit.Skipped++
+					junit.mx.Unlock()
+					tc.Skipped = &junitSkipped{Message: fmt.Sprintf("Test does not match filter: %q", regex.String())}
+					continue
+				}
+
+				runTestCase(ctx, test, tc, errors, retries)
+			}
+		}()
+	}
+
+	start := time.Now()
+	for n, t := range ts.Tests {
+		tests <- &test{name: n, testCase: t}
+	}
+	close(tests)
+	wg.Wait()
+
+	fmt.Printf("[TestRunner] Creating junit xml file: %q\n", *config.OutPath)
+	junit.Time = time.Since(start).Seconds()
+	d, err := xml.MarshalIndent(junit, "  ", "   ")
+	if err != nil {
+		log.Fatal(err)
+	}
+	if err := ioutil.WriteFile(*config.OutPath, d, 0644); err != nil {
+		log.Fatal(err)
+	}
+
+	CheckError(errors)
+	fmt.Println("[TestRunner] All test cases completed successfully.")
+}
+
+func runTestCase(ctx context.Context, test *test, tc *junitTestCase, errors chan error, retries int) {
+	if err := test.testCase.W.PopulateClients(ctx); err != nil {
+		errors <- fmt.Errorf("%s: %v", tc.Name, err)
+		tc.Failure = &junitFailure{FailMessage: err.Error(), FailType: "Error"}
+		return
+	}
+
+	c := make(chan os.Signal, 1)
+	signal.Notify(c, os.Interrupt)
+	go func() {
+		select {
+		case <-c:
+			fmt.Printf("\nCtrl-C caught, sending cancel signal to %q...\n", test.name)
+			close(test.testCase.W.Cancel)
+			err := fmt.Errorf("test case %q was canceled", test.name)
+			errors <- err
+			tc.Failure = &junitFailure{FailMessage: err.Error(), FailType: "Canceled"}
+		case <-test.testCase.W.Cancel:
+		}
+	}()
+
+	project := test.testCase.W.Project
+	client := test.testCase.W.ComputeClient
+	key := test.testCase.W.ID()
+	var lock string
+	var err error
+	if test.testCase.CustomProjectLock != "" {
+		for i := 0; i < retries; i++ {
+			lock, err = customProjectWriteLock(client, project, allowedChars.ReplaceAllString(test.testCase.CustomProjectLock, "_"), key, test.testCase.timeout)
+			if err == nil {
+				break
+			}
+		}
+		if err != nil {
+			errors <- err
+			return
+		}
+	} else if test.testCase.ProjectLock {
+		for i := 0; i < retries; i++ {
+			lock, err = projectWriteLock(client, project, key, test.testCase.timeout)
+			if err == nil {
+				break
+			}
+		}
+		if err != nil {
+			errors <- err
+			return
+		}
+	} else {
+		for i := 0; i < retries; i++ {
+			lock, err = projectReadLock(client, project, key, test.testCase.timeout)
+			if err == nil {
+				break
+			}
+		}
+		if err != nil {
+			errors <- err
+			return
+		}
+	}
+	defer func() {
+		for i := 0; i < retries; i++ {
+			err := projectUnlock(client, project, lock)
+			if err == nil {
+				break
+			}
+		}
+		if err != nil {
+			fmt.Printf("[TestRunner] Test %q: Error unlocking project: %v\n", test.name, err)
+		}
+	}()
+
+	select {
+	case <-test.testCase.W.Cancel:
+		return
+	default:
+	}
+
+	start := time.Now()
+	fmt.Printf("[TestRunner] Running test case %q\n", tc.Name)
+	if err := test.testCase.W.Run(ctx); err != nil {
+		errors <- fmt.Errorf("%s: %v", tc.Name, err)
+		tc.Failure = &junitFailure{FailMessage: err.Error(), FailType: "Failure"}
+	}
+	tc.Time = time.Since(start).Seconds()
+	tc.SystemOut = test.testCase.logger.Buf.String()
+	fmt.Printf("[TestRunner] Test case %q finished\n", tc.Name)
+}

--- a/e2etester/test_suite_base/test_runner.go
+++ b/e2etester/test_suite_base/test_runner.go
@@ -1,0 +1,60 @@
+//  Copyright 2019 Google Inc. All Rights Reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
+// Package e2etester is a library for VM-based e2e tests using Daisy workflows.
+package test_suite_base
+
+import (
+	"fmt"
+	"reflect"
+
+	e2etestcompute "github.com/GoogleCloudPlatform/osconfig/e2etester/compute"
+)
+
+func RunAllTests(tests interface{}) error {
+	md, err := e2etestcompute.GetMetadata()
+	if err != nil {
+		return err
+	}
+	testname, ok := md["TestName"]
+	if !ok {
+		return fmt.Errorf("TestName not in metadata")
+	}
+
+	typ := reflect.TypeOf(tests)
+	m, ok := typ.MethodByName(testname)
+	if !ok {
+		return fmt.Errorf("could not locate specified test %q", testname)
+	}
+	if m.Type.NumIn() != 1 {
+		return fmt.Errorf("func %q should only have one input", testname)
+	}
+	if m.Type.In(0) != typ {
+		return fmt.Errorf("func %q should take %v type as first arg, but takes %v", testname, typ, m.Type.In(0))
+	}
+	if m.Type.NumOut() != 1 {
+		return fmt.Errorf("func %q should only have one output", testname)
+	}
+	errType := reflect.TypeOf((*error)(nil)).Elem() // create pointer to nil error then resolve.
+	if !m.Type.Out(0).Implements(errType) {
+		return fmt.Errorf("func %q should return %v/%T, but returns %v/%T", testname, errType, errType, m.Type.Out(0), m.Type.Out(0))
+	}
+
+	res := m.Func.Call([]reflect.Value{reflect.ValueOf(tests)})
+	ierr := res[0].Interface()
+	if ierr != nil {
+		return ierr.(error)
+	}
+	return nil
+}

--- a/e2etester/test_suite_base/testsuite.go
+++ b/e2etester/test_suite_base/testsuite.go
@@ -1,0 +1,304 @@
+//  Copyright 2018 Google Inc. All Rights Reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
+package test_suite_base
+
+import (
+	"errors"
+	"fmt"
+	"math/rand"
+	"os"
+	"regexp"
+	"strings"
+	"time"
+
+	"github.com/GoogleCloudPlatform/compute-image-tools/daisy"
+	daisyCompute "github.com/GoogleCloudPlatform/compute-image-tools/daisy/compute"
+	e2etestcompute "github.com/GoogleCloudPlatform/osconfig/e2etester/compute"
+	"github.com/GoogleCloudPlatform/osconfig/e2etester/config"
+	"github.com/GoogleCloudPlatform/osconfig/e2etester/logger"
+	"github.com/GoogleCloudPlatform/osconfig/e2etester/workflow"
+	"github.com/google/uuid"
+	"google.golang.org/api/compute/v1"
+)
+
+// A TestSuite describes the tests to run.
+type TestSuite struct {
+	// Name for this set of tests.
+	Name string
+	// Project pool to use
+	Project string
+	// Images to test.
+	Images []string
+	// Default zone to use.
+	Zone string
+	// The test cases to run.
+	Tests map[string]*TestCase
+	// How many tests to run in parallel.
+	TestParallelCount int
+
+	OAuthPath       string
+	ComputeEndpoint string
+}
+
+// A TestCase is a single test to run.
+type TestCase struct {
+	// Path to the daisy workflow to use.
+	// Each test workflow should manage its own resource creation and cleanup.
+	W      *daisy.Workflow
+	id     string
+	logger *logger.TLogger
+
+	// Default timeout is 2 hours.
+	// Must be parsable by https://golang.org/pkg/time/#ParseDuration.
+	TestTimeout string
+	timeout     time.Duration
+
+	// If set this test will be the only test allowed to run in the project.
+	// This is required for any test that changes project level settings that may
+	// impact other concurrent test runs.
+	// TODO: allow setting these..
+	ProjectLock       bool
+	CustomProjectLock string
+}
+
+func CreateTestSuite(suiteName string, images []string, testHandle interface{}) (*TestSuite, error) {
+	fmt.Printf("creating test suite: %s\n", testHandle)
+	var t TestSuite
+
+	t.Name = suiteName
+	t.Project = *config.Project
+
+	if len(images) == 0 {
+		return nil, errors.New("no images provided")
+	}
+	t.Images = images
+
+	if *config.Zone != "" {
+		t.Zone = *config.Zone
+	}
+	if *config.Oauth != "" {
+		t.OAuthPath = *config.Oauth
+	}
+	if *config.Ce != "" {
+		t.ComputeEndpoint = *config.Ce
+	}
+	if *config.ParallelCount != 0 {
+		t.TestParallelCount = *config.ParallelCount
+	}
+
+	if t.TestParallelCount == 0 {
+		t.TestParallelCount = config.DefaultParallelCount
+	}
+
+	var regex *regexp.Regexp
+	if *config.Filter != "" {
+		var err error
+		regex, err = regexp.Compile(*config.Filter)
+		if err != nil {
+			fmt.Println("-filter flag not valid:", err)
+			os.Exit(1)
+		}
+	}
+
+	fmt.Printf("[TestRunner] Creating test cases\n")
+
+	workflows, err := workflow.CreateTestWorkflows(testHandle, images, regex)
+	if err != nil {
+		return nil, err
+	}
+
+	t.Tests = make(map[string]*TestCase)
+	for name, w := range workflows {
+		t.Tests[name] = &TestCase{W: w}
+	}
+
+	for name, test := range t.Tests {
+		test.id = uuid.New().String()
+		if test.TestTimeout == "" {
+			test.timeout = defaultTimeout
+		} else {
+			d, err := time.ParseDuration(test.TestTimeout)
+			if err != nil {
+				test.timeout = defaultTimeout
+			} else {
+				test.timeout = d
+			}
+		}
+
+		fmt.Printf("  - Creating test case for %q\n", name)
+
+		test.logger = &logger.TLogger{}
+
+		rand.Seed(time.Now().UnixNano())
+		test.W.Project = t.Project
+		test.W.Zone = t.Zone
+		test.W.OAuthPath = t.OAuthPath
+		test.W.ComputeEndpoint = t.ComputeEndpoint
+		test.W.DisableGCSLogging()
+		test.W.DisableCloudLogging()
+		test.W.DisableStdoutLogging()
+		test.W.Logger = test.logger
+	}
+
+	return &t, nil
+}
+
+func CheckError(errors chan error) {
+	select {
+	case err := <-errors:
+		fmt.Fprintln(os.Stderr, "\n[TestRunner] Errors in one or more test cases:")
+		fmt.Fprintln(os.Stderr, "\n - ", err)
+		for {
+			select {
+			case err := <-errors:
+				fmt.Fprintln(os.Stderr, "\n - ", err)
+				continue
+			default:
+				fmt.Fprintln(os.Stderr, "\n[TestRunner] Exiting with exit code 1")
+				os.Exit(1)
+			}
+		}
+	default:
+		return
+	}
+}
+
+type test struct {
+	name     string
+	testCase *TestCase
+}
+
+func delItem(items []*compute.MetadataItems, i int) []*compute.MetadataItems {
+	// Delete the element.
+	// https://github.com/golang/go/wiki/SliceTricks
+	copy(items[i:], items[i+1:])
+	items[len(items)-1] = nil
+	return items[:len(items)-1]
+}
+
+func isExpired(val string) bool {
+	t, err := time.Parse(config.TimeFormat, val)
+	if err != nil {
+		return false
+	}
+	return time.Now().After(t)
+}
+
+const (
+	writeLock      = "TestWriteLock-"
+	readLock       = "TestReadLock-"
+	defaultTimeout = 2 * time.Hour
+)
+
+func waitLock(client daisyCompute.Client, project string, prefix ...string) (*compute.Metadata, error) {
+	var md *compute.Metadata
+	var err error
+Loop:
+	for {
+		md, err = e2etestcompute.GetCommonInstanceMetadata(client, project)
+		if err != nil {
+			return nil, err
+		}
+
+		for i, mdi := range md.Items {
+			if mdi != nil {
+				for _, p := range prefix {
+					if strings.HasPrefix(mdi.Key, p) {
+						if isExpired(*mdi.Value) {
+							md.Items = delItem(md.Items, i)
+						} else {
+							r := rand.Intn(10) + 5
+							time.Sleep(time.Duration(r) * time.Second)
+							continue Loop
+						}
+					}
+				}
+			}
+		}
+		return md, nil
+	}
+}
+
+func projectReadLock(client daisyCompute.Client, project, key string, timeout time.Duration) (string, error) {
+	md, err := waitLock(client, project, writeLock)
+	if err != nil {
+		return "", err
+	}
+
+	lock := readLock + key
+	val := time.Now().Add(timeout).Format(config.TimeFormat)
+	md.Items = append(md.Items, &compute.MetadataItems{Key: lock, Value: &val})
+	if err := client.SetCommonInstanceMetadata(project, md); err != nil {
+		return "", err
+	}
+	return lock, nil
+}
+
+func customProjectWriteLock(client daisyCompute.Client, project, custom, key string, timeout time.Duration) (string, error) {
+	customLock := readLock + custom
+	md, err := waitLock(client, project, writeLock, customLock)
+	if err != nil {
+		return "", err
+	}
+
+	lock := customLock + key
+	val := time.Now().Add(timeout).Format(config.TimeFormat)
+	md.Items = append(md.Items, &compute.MetadataItems{Key: lock, Value: &val})
+	if err := client.SetCommonInstanceMetadata(project, md); err != nil {
+		return "", err
+	}
+
+	return lock, nil
+}
+
+func projectWriteLock(client daisyCompute.Client, project, key string, timeout time.Duration) (string, error) {
+	md, err := waitLock(client, project, writeLock)
+	if err != nil {
+		return "", err
+	}
+
+	// This means the project has no current write locks, set the write lock
+	// now and then wait till all current read locks are gone.
+	lock := writeLock + key
+	val := time.Now().Add(timeout).Format(config.TimeFormat)
+	md.Items = append(md.Items, &compute.MetadataItems{Key: lock, Value: &val})
+	if err := client.SetCommonInstanceMetadata(project, md); err != nil {
+		return "", err
+	}
+
+	if _, err := waitLock(client, project, readLock); err != nil {
+		// Attempt to unlock.
+		projectUnlock(client, project, lock)
+		return "", err
+	}
+	return lock, nil
+}
+
+func projectUnlock(client daisyCompute.Client, project, lock string) error {
+	md, err := e2etestcompute.GetCommonInstanceMetadata(client, project)
+	if err != nil {
+		return err
+	}
+
+	for i, mdi := range md.Items {
+		if mdi != nil && lock == mdi.Key {
+			md.Items = delItem(md.Items, i)
+		}
+	}
+
+	return client.SetCommonInstanceMetadata(project, md)
+}
+
+var allowedChars = regexp.MustCompile("[^-_a-zA-Z0-9]+")

--- a/e2etester/workflow/daisy_workflow.go
+++ b/e2etester/workflow/daisy_workflow.go
@@ -1,0 +1,54 @@
+package workflow
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/GoogleCloudPlatform/compute-image-tools/daisy"
+	"google.golang.org/api/compute/v1"
+)
+
+func createVMWorkflow(name, image string) (*daisy.Workflow, error) {
+	wf := daisy.New()
+	wf.Name = name
+	wf.Sources = map[string]string{"startup": os.Args[0]}
+
+	diskStepName := fmt.Sprintf("create-disk-%s", name)
+	bootdisk := &daisy.Disk{
+		Disk: compute.Disk{
+			SourceImage: image,
+			Name:        diskStepName,
+		},
+	}
+
+	step, err := wf.NewStep(diskStepName)
+	if err != nil {
+		return nil, err
+	}
+	step.CreateDisks = &daisy.CreateDisks{bootdisk}
+
+	var md map[string]string
+	if md == nil {
+		md = make(map[string]string)
+	}
+	md["TestName"] = name
+	instance := &daisy.Instance{
+		Instance:      compute.Instance{Name: name},
+		StartupScript: "startup",
+		Metadata:      md,
+		Resource:      daisy.Resource{RealName: fmt.Sprintf("test-instance-%s", wf.ID())},
+		Scopes: []string{
+			"https://www.googleapis.com/auth/devstorage.read_only",
+			"https://www.googleapis.com/auth/compute",
+		},
+	}
+	instance.Disks = append(instance.Disks, &compute.AttachedDisk{Source: diskStepName})
+	step, err = wf.NewStep(name)
+	if err != nil {
+		return nil, err
+	}
+	step.CreateInstances = &daisy.CreateInstances{instance}
+
+	wf.AddDependency(wf.Steps[name], wf.Steps[diskStepName])
+	return wf, nil
+}

--- a/e2etester/workflow/test_workflow.go
+++ b/e2etester/workflow/test_workflow.go
@@ -1,0 +1,52 @@
+package workflow
+
+import (
+	"fmt"
+	"reflect"
+	"regexp"
+
+	"github.com/GoogleCloudPlatform/compute-image-tools/daisy"
+)
+
+func CreateTestWorkflows(tests interface{}, images []string, regex *regexp.Regexp) (map[string]*daisy.Workflow, error) {
+	// Create base test workflows.
+	workflows := make(map[string]*daisy.Workflow)
+	typ := reflect.TypeOf(tests)
+	for i := 0; i < typ.NumMethod(); i++ {
+		m := typ.Method(i)
+		if regex != nil && !regex.MatchString(m.Name) {
+			continue
+		}
+		for _, image := range images {
+			fmt.Printf("creating vm workflow for %s\n", image)
+			wf, err := createVMWorkflow(m.Name, image)
+			if err != nil {
+				return nil, fmt.Errorf("failed to create workflow for %q", m.Name)
+			}
+			nameAndImage := fmt.Sprintf("%s [%s]", m.Name, image)
+			workflows[nameAndImage] = wf
+		}
+	}
+
+	// Add wait signals to top-level WFs.
+	for _, wf := range workflows {
+		waitStepName := fmt.Sprintf("wait-instance-%s", wf.Name)
+		step, err := wf.NewStep(waitStepName)
+		if err != nil {
+			return nil, fmt.Errorf("Failed to create workflow step: %v", err)
+		}
+		instanceSignal := &daisy.InstanceSignal{
+			Name: wf.Name,
+			SerialOutput: &daisy.SerialOutput{
+				Port:         1,
+				SuccessMatch: "TEST-SUCCESS",
+				FailureMatch: daisy.FailureMatches{"TEST-FAILURE"},
+			},
+		}
+		step.WaitForInstancesSignal = &daisy.WaitForInstancesSignal{instanceSignal}
+		step.Timeout = "15m"
+		wf.AddDependency(wf.Steps[waitStepName], wf.Steps[wf.Name])
+	}
+
+	return workflows, nil
+}

--- a/go.mod
+++ b/go.mod
@@ -6,13 +6,13 @@ require (
 	cloud.google.com/go v0.47.0
 	cloud.google.com/go/bigquery v1.2.0 // indirect
 	cloud.google.com/go/storage v1.3.0
-	github.com/GoogleCloudPlatform/compute-image-tools v0.0.0-20191119211944-b664bcf441f8 // indirect
-	github.com/GoogleCloudPlatform/guest-logging-go v0.0.0-20191113181522-f7d3a48944cc
-	github.com/GoogleCloudPlatform/osconfig/e2e_tests v0.0.0-20191120183326-a6cc0f56a94a // indirect
+	github.com/GoogleCloudPlatform/compute-image-tools v0.0.0-20191114224139-44c56e7a10fa
+	github.com/GoogleCloudPlatform/guest-logging-go v0.0.0-20191018162143-d6c1e38c4e8f
 	github.com/StackExchange/wmi v0.0.0-20190523213315-cbe66965904d
 	github.com/go-ole/go-ole v1.2.4
 	github.com/golang/groupcache v0.0.0-20191027212112-611e8accdfc9 // indirect
 	github.com/golang/protobuf v1.3.2
+	github.com/google/uuid v1.1.1
 	github.com/googleapis/gax-go/v2 v2.0.5
 	github.com/kylelemons/godebug v1.1.0
 	github.com/tarm/serial v0.0.0-20180830185346-98f6abe2eb07

--- a/go.sum
+++ b/go.sum
@@ -28,9 +28,8 @@ dmitri.shuralyov.com/gpu/mtl v0.0.0-20190408044501-666a987793e9/go.mod h1:H6x//7
 github.com/BurntSushi/toml v0.3.1 h1:WXkYYl6Yr3qBf1K79EBnL4mak0OimBfB0XUf9Vl28OQ=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
-github.com/GoogleCloudPlatform/compute-image-tools v0.0.0-20191115175545-74bf25bce8f9/go.mod h1:fZ41ZusKqa5cT+fzLarvG09dT6eBbEpoyPnYw/1lKfA=
-github.com/GoogleCloudPlatform/compute-image-tools v0.0.0-20191119211944-b664bcf441f8 h1:bXen7JtGWWvG/Ar1LVY9bbUnogoKjtcNp/p5gTUdcR0=
-github.com/GoogleCloudPlatform/compute-image-tools v0.0.0-20191119211944-b664bcf441f8/go.mod h1:fZ41ZusKqa5cT+fzLarvG09dT6eBbEpoyPnYw/1lKfA=
+github.com/GoogleCloudPlatform/compute-image-tools v0.0.0-20191114224139-44c56e7a10fa h1:sJs+Q2dpsG81WK+OyPknX/SaOg7V8EIcHjboRkav40c=
+github.com/GoogleCloudPlatform/compute-image-tools v0.0.0-20191114224139-44c56e7a10fa/go.mod h1:fZ41ZusKqa5cT+fzLarvG09dT6eBbEpoyPnYw/1lKfA=
 github.com/GoogleCloudPlatform/guest-logging-go v0.0.0-20191018162143-d6c1e38c4e8f h1:dN/XE3Oeh5MFqHBWe6fI6gcLdwVTpvnvrwtOjkUTSUw=
 github.com/GoogleCloudPlatform/guest-logging-go v0.0.0-20191018162143-d6c1e38c4e8f/go.mod h1:YWYrZjvs/qwZhDmsDnTaMXcno5Y0MYPN7rhMarLiUmI=
 github.com/GoogleCloudPlatform/guest-logging-go v0.0.0-20191113181522-f7d3a48944cc h1:Rs3eA3azYQaOGmoWnjUvz1UaZk4EptvfTpnTIxrZKKQ=
@@ -73,6 +72,7 @@ github.com/google/martian v2.1.0+incompatible/go.mod h1:9I4somxYTbIHy5NJKHRl3wXi
 github.com/google/pprof v0.0.0-20181206194817-3ea8567a2e57/go.mod h1:zfwlbNMJ+OItoe0UupaVj+oy1omPYYDuagoSzA8v9mc=
 github.com/google/pprof v0.0.0-20190515194954-54271f7e092f/go.mod h1:zfwlbNMJ+OItoe0UupaVj+oy1omPYYDuagoSzA8v9mc=
 github.com/google/renameio v0.1.0/go.mod h1:KWCgfxg9yswjAJkECMjeO8J8rahYeXnNhOm40UhjYkI=
+github.com/google/uuid v1.1.1 h1:Gkbcsh/GbpXz7lPftLA3P6TYMwjCLYm83jiFQZF/3gY=
 github.com/google/uuid v1.1.1/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/googleapis/gax-go/v2 v2.0.4/go.mod h1:0Wqv26UfaUD9n4G6kQubkQ+KchISgw+vpHVxEJEs9eg=
 github.com/googleapis/gax-go/v2 v2.0.5 h1:sjZBwGj9Jlw33ImPtvFviGYvseOtDM7hkSKB7+Tv3SM=

--- a/integration_test/integration_test_main.go
+++ b/integration_test/integration_test_main.go
@@ -1,0 +1,22 @@
+package main
+
+import (
+	"fmt"
+
+	"github.com/GoogleCloudPlatform/osconfig/e2etester/executor"
+	"github.com/GoogleCloudPlatform/osconfig/integration_test/test_classes"
+)
+
+func main() {
+	xcutor := executor.GetITestExecutor()
+	xcutor.AddTestOptions(executor.NewTestOptions("zypper",
+		[]string{"projects/suse-cloud/global/images/family/sles-12",
+			"projects/suse-cloud/global/images/family/sles-15"},
+		test_classes.ZypperTest{}))
+	for _, t := range xcutor.GetTestOptions() {
+		fmt.Printf("running test_suite: %s\n", t.Name)
+		xcutor.Execute(t)
+		fmt.Printf("finished running test_suite\n")
+	}
+	fmt.Printf("tests completed\n")
+}

--- a/integration_test/test_classes/zypper_tests.go
+++ b/integration_test/test_classes/zypper_tests.go
@@ -1,0 +1,40 @@
+package test_classes
+
+import (
+	"fmt"
+
+	customError "github.com/GoogleCloudPlatform/osconfig/e2etester/error"
+	"github.com/GoogleCloudPlatform/osconfig/inventory/packages"
+)
+
+type ZypperTest struct {
+}
+
+func (z ZypperTest) TestZypperCommands() error {
+
+	ec := new(customError.ErrorCollector)
+	// list installed packages
+	pkgs, err := packages.ZypperInstalledPatches()
+	if err != nil || len(pkgs) == 0 {
+		ec.Collect(fmt.Errorf("Error listing patches: %+v\n", err))
+	}
+
+	// install a package
+	err = packages.InstallZypperPackages([]string{"xeyes"})
+	if err != nil {
+		ec.Collect(fmt.Errorf("error installing package: +%v", err))
+	}
+
+	// remove the same package that we just installed
+	err = packages.RemoveZypperPackages([]string{"xeyes"})
+	if err != nil {
+		ec.Collect(fmt.Errorf("Error removing package: %+v", err))
+	}
+
+	count, errs := ec.Error()
+	fmt.Printf("errors generated: %+v\n", errs)
+	if count == 0 {
+		return nil
+	}
+	return errs
+}


### PR DESCRIPTION
Current working of the framework:
1) Creates test_suite for different classes of integration tests that we want to run.. for example; zypper package manager tests is a class.
2) In the test_suite create, creates the different test cases. a test case is a combination of image and a method associated with a testhandle
3) In a test_case; create a daisy_workflow that involves runnign the specific piece  of osconfig agent code on the vm and associate the binary as a source in the daisy workflow
4) during the test_case run; run the daisy_workflow; and wait for pass/fail signals on serialport
5) We can merge multiple tests in a single workflow

This is not very polished. still working on
1) better logging: provide logging library from the framework that writes to serial console instead of tests writing on their own to serial console. this would also streamline reporting success or failure signals
2) better naming