### PR TITLE
Implement patch whitelisting for zypper

### DIFF
--- a/inventory/packages/zypper.go
+++ b/inventory/packages/zypper.go
@@ -18,7 +18,9 @@ import (
 	"bytes"
 	"fmt"
 	"os/exec"
+	"regexp"
 	"runtime"
+	"strconv"
 	"strings"
 
 	"github.com/GoogleCloudPlatform/osconfig/inventory/osinfo"
@@ -28,10 +30,12 @@ import (
 var (
 	zypper string
 
-	zypperInstallArgs     = []string{"--gpg-auto-import-keys", "install", "--no-confirm"}
+	// ZypperInstallArgs is zypper command to install patches, packages
+	ZypperInstallArgs     = []string{"--gpg-auto-import-keys", "install", "--no-confirm"}
 	zypperRemoveArgs      = []string{"remove", "--no-confirm"}
 	zypperListUpdatesArgs = []string{"--gpg-auto-import-keys", "-q", "list-updates"}
-	zypperListPatchesArgs = []string{"--gpg-auto-import-keys", "-q", "list-patches", "--all", "--with-optional"}
+	zypperListPatchesArgs = []string{"--gpg-auto-import-keys", "-q", "list-patches"}
+	zypperPatchInfoArgs   = []string{"info", "-t", "patch"}
 )
 
 func init() {
@@ -41,9 +45,47 @@ func init() {
 	ZypperExists = util.Exists(zypper)
 }
 
+type zypperListPatchOpts struct {
+	categories   []string
+	severities   []string
+	withOptional bool
+	all          bool
+}
+
+// ZypperListOption is patch list options
+type ZypperListOption func(opts *zypperListPatchOpts)
+
+// ZypperListPatchCategories is zypper list option to provide category filter
+func ZypperListPatchCategories(categories []string) ZypperListOption {
+	return func(args *zypperListPatchOpts) {
+		args.categories = categories
+	}
+}
+
+// ZypperListPatchSeverities is zypper list option to provide severity filter
+func ZypperListPatchSeverities(severities []string) ZypperListOption {
+	return func(args *zypperListPatchOpts) {
+		args.severities = severities
+	}
+}
+
+// ZypperListPatchWithOptional is zypper list option to also list optional patches
+func ZypperListPatchWithOptional(withOptional bool) ZypperListOption {
+	return func(args *zypperListPatchOpts) {
+		args.withOptional = withOptional
+	}
+}
+
+// ZypperListPatchAll is zypper list option to all all patches
+func ZypperListPatchAll(all bool) ZypperListOption {
+	return func(args *zypperListPatchOpts) {
+		args.all = all
+	}
+}
+
 // InstallZypperPackages Installs zypper packages
 func InstallZypperPackages(pkgs []string) error {
-	args := append(zypperInstallArgs, pkgs...)
+	args := append(ZypperInstallArgs, pkgs...)
 	out, err := run(exec.Command(zypper, args...))
 	var msg string
 	for _, s := range strings.Split(string(out), "\n") {
@@ -136,13 +178,44 @@ func parseZypperPatches(data []byte) ([]ZypperPatch, []ZypperPatch) {
 	return ins, avail
 }
 
-func zypperPatches() ([]byte, error) {
-	return run(exec.Command(zypper, zypperListPatchesArgs...))
+func zypperPatches(opts ...ZypperListOption) ([]byte, error) {
+	zOpts := &zypperListPatchOpts{
+		categories:   nil,
+		severities:   nil,
+		withOptional: false,
+		all:          false,
+	}
+
+	for _, opt := range opts {
+		opt(zOpts)
+	}
+
+	args := zypperListPatchesArgs
+	for _, c := range zOpts.categories {
+		args = append(args, "--category="+c)
+	}
+
+	for _, s := range zOpts.severities {
+		args = append(args, "--severity="+s)
+	}
+
+	if zOpts.withOptional {
+		args = append(args, "--with-optional")
+	}
+
+	//  As per zypper's current implementation,
+	// --all is ignored if we have any filters on any other
+	// field.
+	if zOpts.all || (len(zOpts.severities)+len(zOpts.categories)) <= 0 {
+		args = append(args, "--all")
+	}
+
+	return run(exec.Command(zypper, args...))
 }
 
 // ZypperPatches queries for all available zypper patches.
-func ZypperPatches() ([]ZypperPatch, error) {
-	out, err := zypperPatches()
+func ZypperPatches(opts ...ZypperListOption) ([]ZypperPatch, error) {
+	out, err := zypperPatches(opts...)
 	if err != nil {
 		return nil, err
 	}
@@ -151,11 +224,152 @@ func ZypperPatches() ([]ZypperPatch, error) {
 }
 
 // ZypperInstalledPatches queries for all installed zypper patches.
-func ZypperInstalledPatches() ([]ZypperPatch, error) {
-	out, err := zypperPatches()
+func ZypperInstalledPatches(opts ...ZypperListOption) ([]ZypperPatch, error) {
+	out, err := zypperPatches(opts...)
 	if err != nil {
 		return nil, err
 	}
 	patches, _ := parseZypperPatches(out)
 	return patches, nil
+}
+
+func zypperPatchInfo(patches []string) ([]byte, error) {
+	args := zypperPatchInfoArgs
+	for _, name := range patches {
+		args = append(args, name)
+	}
+	return run(exec.Command(zypper, args...))
+}
+
+func parseZypperPatchInfo(out []byte) (map[string][]string, error) {
+	/*
+		Loading repository data...
+		Reading installed packages...
+		Information for patch SUSE-SLE-SERVER-12-SP4-2019-2974:
+		-------------------------------------------------------
+		Repository  : SLES12-SP4-Updates
+		Name        : SUSE-SLE-SERVER-12-SP4-2019-2974
+		Version     : 1
+		Arch        : noarch
+		Vendor      : maint-coord@suse.de
+		Status      : needed
+		Category    : recommended
+		Severity    : important
+		Created On  : Thu Nov 14 13:17:48 2019
+		Interactive : ---
+		Summary     : Recommended update for irqbalance
+		Description :
+		    This update for irqbalance fixes the following issues:
+		    - Irqbalanced spreads the IRQs between the available virtual machines. (bsc#1119465, bsc#1154905)
+		Provides    : patch:SUSE-SLE-SERVER-12-SP4-2019-2974 = 1
+		Conflicts   : [2]
+		    irqbalance.src < 1.1.0-9.3.1
+		    irqbalance.x86_64 < 1.1.0-9.3.1
+	*/
+	patchInfo := make(map[string][]string)
+	var validConflictLine = regexp.MustCompile(`\s*Conflicts\s*:\s*\[\d*\]\s*`)
+	var conflictLineExtract = regexp.MustCompile(`\[[0-9]+\]`)
+	var nameLine = regexp.MustCompile(`\s*Name\s*:\s*`)
+	lines := bytes.Split(bytes.TrimSpace(out), []byte("\n"))
+	i := 0
+	for {
+		// find the name line
+		for ; i < len(lines); i++ {
+			b := nameLine.Find([]byte(lines[i]))
+			if b != nil {
+				break
+			}
+		}
+		if i >= len(lines) {
+			// we do not have any more patch info blobs
+			break
+		}
+
+		parts := strings.Split(string(lines[i]), ":")
+		i++
+
+		if len(parts) != 2 {
+			return nil, fmt.Errorf("invalid name output")
+		}
+		patchName := strings.Trim(parts[1], " ")
+
+		for ; i < len(lines); i++ {
+			b := validConflictLine.Find([]byte(lines[i]))
+			if b != nil {
+				//	Conflicts   : [2]
+				break
+			}
+		}
+
+		if i >= len(lines) {
+			// did not find conflicting packages
+			// this should not happen
+			return nil, nil
+		}
+
+		matches := conflictLineExtract.FindAllString(string(lines[i]), -1)
+		if len(matches) != 1 {
+			return nil, fmt.Errorf("invalid patch info")
+		}
+
+		// get the number of package lines to parse
+		conflicts := strings.Trim(matches[0], "[")
+		conflicts = strings.Trim(conflicts, "]")
+		conflictLines, err := strconv.Atoi(conflicts)
+		if err != nil {
+			return nil, fmt.Errorf("invalid patch info: invalid conflict info")
+		}
+		ctr := i + 1
+		ctrEnd := ctr + conflictLines
+		for ; ctr < ctrEnd; ctr++ {
+			//libsolv.src < 0.6.36-2.27.19.8
+			//libsolv-tools.x86_64 < 0.6.36-2.27.19.8
+			//libzypp.src < 16.20.2-27.60.4
+			//libzypp.x86_64 < 16.20.2-27.60.4
+			//perl-solv.x86_64 < 0.6.36-2.27.19.8
+			//python-solv.x86_64 < 0.6.36-2.27.19.8
+			//zypper.src < 1.13.54-18.40.2
+			//zypper.x86_64 < 1.13.54-18.40.2
+			//zypper-log.noarch < 1.13.54-18.40.2
+			parts := strings.Split(string(lines[ctr]), "<")
+			if len(parts) != 2 {
+				return nil, fmt.Errorf("invalid package info")
+			}
+			nameArch := strings.Split(parts[0], ".")
+			if len(nameArch) != 2 {
+				return nil, fmt.Errorf("invalid package info")
+			}
+
+			pkgName := strings.Trim(nameArch[0], " ")
+			patches, ok := patchInfo[pkgName]
+			if !ok {
+				patches = make([]string, 0)
+			}
+			patches = append(patches, patchName)
+			patchInfo[pkgName] = patches
+		}
+
+		// set i for next patch information blob
+		i = ctrEnd
+	}
+	// TODO: instead of returning a map of <string, []string>
+	// make it more concrete type returns with more information
+	// about the package and patch
+	if len(patchInfo) == 0 {
+		return nil, fmt.Errorf("invalid patch information, did not find patch blobs")
+	}
+	return patchInfo, nil
+}
+
+// ZypperPackagesInPatch returns the list of patches, a package upgrade belongs to
+func ZypperPackagesInPatch(patches []ZypperPatch) (map[string][]string, error) {
+	var patchNames []string
+	for _, patch := range patches {
+		patchNames = append(patchNames, patch.Name)
+	}
+	out, err := zypperPatchInfo(patchNames)
+	if err != nil {
+		return nil, err
+	}
+	return parseZypperPatchInfo(out)
 }

--- a/inventory/packages/zypper_test.go
+++ b/inventory/packages/zypper_test.go
@@ -16,8 +16,16 @@ package packages
 
 import (
 	"errors"
+	"fmt"
 	"reflect"
+	"strings"
 	"testing"
+
+	"github.com/kylelemons/godebug/pretty"
+)
+
+var (
+	dump = &pretty.Config{IncludeUnexported: true}
 )
 
 func TestZypperInstalls(t *testing.T) {
@@ -162,4 +170,122 @@ func TestZypperInstalledPatches(t *testing.T) {
 	if _, err := ZypperInstalledPatches(); err == nil {
 		t.Errorf("did not get expected error")
 	}
+}
+
+func TestParsePatchInfo(t *testing.T) {
+	patchInfo := `
+Loading repository data...
+Reading installed packages...
+Information for patch SUSE-SLE-SERVER-12-SP4-2019-2974:
+-------------------------------------------------------
+Repository  : SLES12-SP4-Updates                        
+Name        : SUSE-SLE-SERVER-12-SP4-2019-2974          
+Version     : 1                                         
+Arch        : noarch                                    
+Vendor      : maint-coord@suse.de                       
+Status      : needed                                    
+Category    : recommended                               
+Severity    : important                                 
+Created On  : Thu Nov 14 13:17:48 2019                  
+Interactive : ---                                       
+Summary     : Recommended update for irqbalance         
+Description :                                           
+    This update for irqbalance fixes the following issues:
+    - Irqbalanced spreads the IRQs between the available virtual machines. (bsc#1119465, bsc#1154905)
+Provides    : patch:SUSE-SLE-SERVER-12-SP4-2019-2974 = 1
+Conflicts   : [4]                                       
+    irqbalance.src < 1.1.0-9.3.1
+    irqbalance.x86_64 < 1.1.0-9.3.1
+    common-package.src < 1.1.0-9.3.1
+    common-package.x86_64 < 1.1.0-9.3.1
+Information for patch SUSE-SLE-Module-Public-Cloud-12-2019-2026:
+----------------------------------------------------------------
+Repository  : SLE-Module-Public-Cloud12-Updates                  
+Name        : SUSE-SLE-Module-Public-Cloud-12-2019-2026          
+Version     : 1                                                  
+Arch        : noarch                                             
+Vendor      : maint-coord@suse.de                                
+Status      : needed                                             
+Category    : recommended                                        
+Severity    : moderate                                           
+Created On  : Tue Jul 30 17:20:02 2019                           
+Interactive : ---                                                
+Summary     : Recommended update for Azure Python SDK            
+Description :                                                    
+    This update brings the following python modules for the Azure Python SDK:
+    - python-Flask
+    - python-Werkzeug
+    - python-click
+    - python-decorator
+    - python-httpbin
+    - python-idna
+    - python-itsdangerous
+    - python-py
+    - python-pytest-httpbin
+    - python-pytest-mock
+    - python-requests
+Provides    : patch:SUSE-SLE-Module-Public-Cloud-12-2019-2026 = 1
+Conflicts   : [32]                                               
+    python-Flask.noarch < 0.12.1-7.4.2
+    python-Flask.src < 0.12.1-7.4.2
+    python-Werkzeug.noarch < 0.12.2-10.4.2
+    python-Werkzeug.src < 0.12.2-10.4.2
+    python-click.noarch < 6.7-2.4.2
+    python-click.src < 6.7-2.4.2
+    python-decorator.noarch < 4.1.2-4.4.2
+    python-decorator.src < 4.1.2-4.4.2
+    python-httpbin.noarch < 0.5.0-2.4.2
+    python-httpbin.src < 0.5.0-2.4.2
+    python-idna.noarch < 2.5-3.10.2
+    python-idna.src < 2.5-3.10.2
+    python-itsdangerous.noarch < 0.24-7.4.2
+    python-itsdangerous.src < 0.24-7.4.2
+    python-py.noarch < 1.5.2-8.8.2
+    python-py.src < 1.5.2-8.8.2
+    python-requests.noarch < 2.18.2-8.4.2
+    python-requests.src < 2.18.2-8.4.2
+    python-six.noarch < 1.11.0-9.21.2
+    python-six.src < 1.11.0-9.21.2
+    python3-Flask.noarch < 0.12.1-7.4.2
+    python3-Werkzeug.noarch < 0.12.2-10.4.2
+    python3-click.noarch < 6.7-2.4.2
+    python3-decorator.noarch < 4.1.2-4.4.2
+    python3-httpbin.noarch < 0.5.0-2.4.2
+    python3-idna.noarch < 2.5-3.10.2
+    python3-itsdangerous.noarch < 0.24-7.4.2
+    python3-py.noarch < 1.5.2-8.8.2
+    python3-requests.noarch < 2.18.2-8.4.2
+    python3-six.noarch < 1.11.0-9.21.2
+    common-package.src < 1.1.0-9.3.1
+    common-package.x86_64 < 1.1.0-9.3.1
+
+`
+	ppMap, err := parseZypperPatchInfo([]byte(patchInfo))
+	if err != nil {
+		t.Errorf("unexpected error: %+v", err)
+	}
+
+	fmt.Printf("result:\n%s\n", dump.Sprint(ppMap))
+
+	if _, ok := ppMap["python3-requests"]; !ok {
+		t.Errorf("Unexpected result: expected a patch for python3-requests")
+	}
+
+	if _, ok := ppMap["random-package"]; ok {
+		t.Errorf("Unexpected result: did not expect patch for random-package")
+	}
+
+	if _, ok := ppMap["random-package"]; ok {
+		t.Errorf("Unexpected result: did not expect patch for random-package")
+	}
+
+	if patches, ok := ppMap["common-package"]; !ok {
+		t.Errorf("Unexpected result: did not expect patch for common-package")
+		for _, patch := range patches {
+			if (strings.Compare(patch, "SUSE-SLE-Module-Public-Cloud-12-2019-2026") != 0) || (strings.Compare(patch, "SUSE-SLE-SERVER-12-SP4-2019-2974") != 0) {
+				t.Errorf("Unexptected result: patch name should be one of SUSE-SLE-SERVER-12-SP4-2019-2974 or SUSE-SLE-Module-Public-Cloud-12-2019-2026")
+			}
+		}
+	}
+
 }

--- a/ospatch/apt_upgrade.go
+++ b/ospatch/apt_upgrade.go
@@ -60,8 +60,10 @@ func AptGetDryRun(dryrun bool) AptGetUpgradeOption {
 // RunAptGetUpgrade runs apt-get upgrade.
 func RunAptGetUpgrade(opts ...AptGetUpgradeOption) error {
 	aptOpts := &aptGetUpgradeOpts{
-		upgradeType: packages.AptGetUpgrade,
-		dryrun:      false,
+		upgradeType:       packages.AptGetUpgrade,
+		excludes:          nil,
+		exclusivePackages: nil,
+		dryrun:            false,
 	}
 
 	for _, opt := range opts {

--- a/ospatch/updates.go
+++ b/ospatch/updates.go
@@ -120,16 +120,16 @@ func containsString(ss []string, c string) bool {
 	return false
 }
 
-func filterPackages(pkgs []packages.PkgInfo, includes, excludes []string) ([]packages.PkgInfo, error) {
-	if len(includes) != 0 && len(excludes) != 0 {
-		return nil, errors.New("includes and excludes can not both be non 0")
+func filterPackages(pkgs []packages.PkgInfo, exclusivePackages, excludes []string) ([]packages.PkgInfo, error) {
+	if len(exclusivePackages) != 0 && len(excludes) != 0 {
+		return nil, errors.New("exclusivePackages and excludes can not both be non 0")
 	}
 	var fPkgs []packages.PkgInfo
 	for _, pkg := range pkgs {
 		if containsString(excludes, pkg.Name) {
 			continue
 		}
-		if includes == nil || containsString(includes, pkg.Name) {
+		if exclusivePackages == nil || containsString(exclusivePackages, pkg.Name) {
 			fPkgs = append(fPkgs, pkg)
 		}
 	}

--- a/ospatch/zypper_patch.go
+++ b/ospatch/zypper_patch.go
@@ -17,6 +17,7 @@ package ospatch
 import (
 	"fmt"
 
+	"github.com/GoogleCloudPlatform/guest-logging-go/logger"
 	"github.com/GoogleCloudPlatform/osconfig/inventory/packages"
 )
 
@@ -122,6 +123,17 @@ func RunZypperPatch(opts ...ZypperPatchOption) error {
 	}
 
 	fPatches, fpkgs, err := runFilter(patches, zOpts.exclusivePatches, zOpts.excludes, zOpts.withUpdate)
+
+	logger.Infof("Updating %d patches.", len(fPatches))
+	logger.Debugf("Patches to be installed: %s", fPatches)
+	logger.Infof("Updating %d packages.", len(fpkgs))
+	logger.Debugf("Packages to be installed: %s", fpkgs)
+
+	if zOpts.dryrun {
+		logger.Infof("Running in dryrun mode, not updating packages.")
+		return nil
+	}
+
 	return packages.ZypperInstall(fPatches, fpkgs)
 }
 

--- a/ospatch/zypper_patch.go
+++ b/ospatch/zypper_patch.go
@@ -132,23 +132,7 @@ func RunZypperPatch(opts ...ZypperPatchOption) error {
 	}
 
 	fPatches, fpkgs, err := runFilter(patches, zOpts.exclusivePatches, zOpts.excludes, zOpts.withUpdate)
-
-	// does a package in pkgs belong to a patch in patchtopkgmap
-	args := packages.ZypperInstallArgs
-
-	// https://www.mankier.com/8/zypper#Concepts-Package_Types use patch install
-	// for single patch and package installs
-	for _, patch := range fPatches {
-		args = append(args, "patch:"+patch.Name)
-	}
-	for _, pkg := range fpkgs {
-		args = append(args, "package:"+pkg.Name)
-	}
-
-	if _, err := zOpts.runner(exec.Command(zypper, args...)); err != nil {
-		return err
-	}
-	return nil
+	return packages.ZypperInstall(fPatches, fpkgs)
 }
 
 func runFilter(patches []packages.ZypperPatch, exclusivePatches, excludes []string, withUpdate bool) ([]packages.ZypperPatch, []packages.PkgInfo, error) {

--- a/ospatch/zypper_patch.go
+++ b/ospatch/zypper_patch.go
@@ -16,7 +16,6 @@ package ospatch
 
 import (
 	"fmt"
-	"os/exec"
 
 	"github.com/GoogleCloudPlatform/osconfig/inventory/packages"
 )
@@ -34,7 +33,6 @@ type zypperPatchOpts struct {
 	withUpdate       bool
 	excludes         []string
 	exclusivePatches []string
-	runner           func(cmd *exec.Cmd) ([]byte, error)
 	dryrun           bool
 }
 
@@ -89,13 +87,6 @@ func ZypperUpdateWithExclusivePatches(exclusivePatches []string) ZypperPatchOpti
 	}
 }
 
-// ZypperPatchRunner returns a ZypperUpdateOption that specifies the runner.
-func ZypperPatchRunner(runner func(cmd *exec.Cmd) ([]byte, error)) ZypperPatchOption {
-	return func(args *zypperPatchOpts) {
-		args.runner = runner
-	}
-}
-
 // ZypperUpdateDryrun returns a ZypperUpdateOption that specifies the runner.
 func ZypperUpdateDryrun(dryrun bool) ZypperPatchOption {
 	return func(args *zypperPatchOpts) {
@@ -106,7 +97,6 @@ func ZypperUpdateDryrun(dryrun bool) ZypperPatchOption {
 // RunZypperPatch runs zypper patch.
 func RunZypperPatch(opts ...ZypperPatchOption) error {
 	zOpts := &zypperPatchOpts{
-		runner:           defaultRunner,
 		excludes:         nil,
 		exclusivePatches: nil,
 		categories:       nil,


### PR DESCRIPTION
--with-update is a tricky case to handle with patches. All the other fields/flags in zyppersettings work on patches except for --with-update, which runs on packages.
readmore: https://www.mankier.com/8/zypper#--with-update

Here is the algorithm to prepare patch and package list for zypper:

- Fetch the list of patches with the filters on severity, category
- If user specifies --with-update, fetch the list of packages that will be updated.
- Filter out any package that will be updated as a part of a patch install from the list of packages to be updated;
- to know packages are going to be updated as a part of a patch, we have used "zypper info -t " command
-  for the list of excluded patches specified by user, filter out the patches from the previously generated patch list.