### PR TITLE
update sles image project name

### DIFF
--- a/e2e_tests/utils/utils.go
+++ b/e2e_tests/utils/utils.go
@@ -184,8 +184,8 @@ var HeadSUSEImages = map[string]string{
 
 // OldSUSEImages is a map of names to image paths for old SUSE images.
 var OldSUSEImages = map[string]string{
-	"old/sles-12": "projects/compute-image-osconfig-agent/global/images/sles-12-sp4-v20190221",
-	"old/sles-15": "projects/compute-image-osconfig-agent/global/images/sles-15-sp1-v20190625",
+	"old/sles-12": "projects/compute-image-tools-test/global/images/sles-12-sp5-v20191209",
+	"old/sles-15": "projects/compute-image-tools-test/global/images/sles-15-sp1-v20190625",
 
 	"old/opensuse-leap": "projects/opensuse-cloud/global/images/opensuse-leap-15-1-v20190618",
 }


### PR DESCRIPTION
the old images were created in compute-image-osconfig-agent; instead it should have been created in compute-image-tools-test.
created the image now.