### PR TITLE
Don't stream serial port in e2e_tests

### DIFF
--- a/e2e_tests/test_suites/inventory/inventory.go
+++ b/e2e_tests/test_suites/inventory/inventory.go
@@ -106,8 +106,7 @@ func runGatherInventoryTest(ctx context.Context, testSetup *inventoryTestSetup, 
 	if err != nil {
 		testCase.WriteFailure("Error getting storage client: %v", err)
 	}
-	logwg.Add(1)
-	go inst.StreamSerialOutput(ctx, storageClient, path.Join(testSuiteName, config.LogsPath()), config.LogBucket(), logwg, 1, config.LogPushInterval())
+	defer inst.RecordSerialOutput(ctx, storageClient, path.Join(testSuiteName, config.LogsPath()), config.LogBucket(), 1)
 
 	testCase.Logf("Waiting for agent install to complete")
 	if _, err := inst.WaitForGuestAttributes("osconfig_tests/install_done", 5*time.Second, 10*time.Minute); err != nil {

--- a/packaging/debian/rules
+++ b/packaging/debian/rules
@@ -24,8 +24,10 @@ override_dh_auto_test:
 	# Skip tests as they are already setup as part of the commit process.
 
 override_dh_auto_build:
-	rm -rf e2e_tests
-	dh_auto_build -O--buildsystem=golang -- -ldflags="-s -w -X main.version=$(VERSION)" -mod=readonly
+	# Skip build and jump straight to install.
+
+override_dh_auto_install:
+	dh_auto_install -O--buildsystem=golang -- -ldflags="-s -w -X main.version=$(VERSION)" -mod=readonly
 
 override_dh_installinit:
 	dh_installinit --noscripts

--- a/packaging/debian/rules
+++ b/packaging/debian/rules
@@ -24,10 +24,7 @@ override_dh_auto_test:
 	# Skip tests as they are already setup as part of the commit process.
 
 override_dh_auto_build:
-	# Skip build and jump straight to install.
-
-override_dh_auto_install:
-	dh_auto_install -O--buildsystem=golang -- -ldflags="-s -w -X main.version=$(VERSION)" -mod=readonly
+	dh_auto_build -O--buildsystem=golang -- -ldflags="-s -w -X main.version=$(VERSION)" -mod=readonly
 
 override_dh_installinit:
 	dh_installinit --noscripts

--- a/packaging/debian/rules
+++ b/packaging/debian/rules
@@ -24,6 +24,7 @@ override_dh_auto_test:
 	# Skip tests as they are already setup as part of the commit process.
 
 override_dh_auto_build:
+	rm -rf e2e_tests
 	dh_auto_build -O--buildsystem=golang -- -ldflags="-s -w -X main.version=$(VERSION)" -mod=readonly
 
 override_dh_installinit:


### PR DESCRIPTION
This was causing way too much api traffic, instead just record the serial port output at the end of each test before we delete the instance.