### PR TITLE
Install systemd service and preset files in debian

### DIFF
--- a/packaging/debian/rules
+++ b/packaging/debian/rules
@@ -16,6 +16,7 @@ override_dh_auto_install:
 	# Binary-only package.
 	dh_auto_install -- --no-source
 	mv debian/google-osconfig-agent/usr/bin/osconfig debian/google-osconfig-agent/usr/bin/google_osconfig_agent
+	rm debian/google-osconfig-agent/usr/bin/e2e_tests
 
 override_dh_golang:
 	# We don't use any packaged dependencies, so skip dh_golang step.
@@ -27,6 +28,7 @@ override_dh_auto_build:
 	dh_auto_build -O--buildsystem=golang -- -ldflags="-s -w -X main.version=$(VERSION)" -mod=readonly
 
 override_dh_installinit:
+	install -p -m 0644 *.service *.preset debian/
 	dh_installinit --noscripts
 
 override_dh_installsystemd:

--- a/packaging/debian/rules
+++ b/packaging/debian/rules
@@ -17,6 +17,10 @@ override_dh_auto_install:
 	dh_auto_install -- --no-source
 	mv debian/google-osconfig-agent/usr/bin/osconfig debian/google-osconfig-agent/usr/bin/google_osconfig_agent
 	rm debian/google-osconfig-agent/usr/bin/e2e_tests
+	install -d debian/google-osconfig-agent/lib/systemd/system
+	install -p -m 0644 *.service debian/google-osconfig-agent/lib/systemd/system/
+	install -d debian/google-osconfig-agent/lib/systemd/system-preset/
+	install -p -m 0644 *.preset debian/google-osconfig-agent/lib/systemd/system-preset/
 
 override_dh_golang:
 	# We don't use any packaged dependencies, so skip dh_golang step.
@@ -26,10 +30,6 @@ override_dh_auto_test:
 
 override_dh_auto_build:
 	dh_auto_build -O--buildsystem=golang -- -ldflags="-s -w -X main.version=$(VERSION)" -mod=readonly
-
-override_dh_installinit:
-	install -p -m 0644 *.service *.preset debian/
-	dh_installinit --noscripts
 
 override_dh_installsystemd:
 	dh_installsystemd --no-stop-on-upgrade


### PR DESCRIPTION
Service file was being installed by build_deb.sh, so was omitted when we moved to new packagebuilder. The preset file was never being installed previously, apparently dh_installinit doesn't support it. Not that it mattered, since we don't call `systemctl preset`

dpkg-deb -c output:

```
drwxr-xr-x root/root         0 2020-01-10 20:35 ./
drwxr-xr-x root/root         0 2020-01-10 20:35 ./lib/
drwxr-xr-x root/root         0 2020-01-10 20:35 ./lib/systemd/
drwxr-xr-x root/root         0 2020-01-10 20:35 ./lib/systemd/system/
-rw-r--r-- root/root       351 2020-01-10 20:34 ./lib/systemd/system/google-osconfig-agent.service
drwxr-xr-x root/root         0 2020-01-10 20:35 ./lib/systemd/system-preset/
-rw-r--r-- root/root        36 2020-01-10 20:34 ./lib/systemd/system-preset/90-google-osconfig-agent.preset
drwxr-xr-x root/root         0 2020-01-10 20:35 ./usr/
drwxr-xr-x root/root         0 2020-01-10 20:35 ./usr/bin/
-rwxr-xr-x root/root  14421256 2020-01-10 20:35 ./usr/bin/google_osconfig_agent
drwxr-xr-x root/root         0 2020-01-10 20:35 ./usr/share/
drwxr-xr-x root/root         0 2020-01-10 20:35 ./usr/share/doc/
drwxr-xr-x root/root         0 2020-01-10 20:35 ./usr/share/doc/google-osconfig-agent/
-rw-r--r-- root/root       161 2020-01-10 20:35 ./usr/share/doc/google-osconfig-agent/changelog.Debian.gz
-rw-r--r-- root/root       982 2020-01-10 20:35 ./usr/share/doc/google-osconfig-agent/copyright
```