### PR TITLE
Update startup logic to prevent hanging

### DIFF
--- a/config/config_test.go
+++ b/config/config_test.go
@@ -16,6 +16,7 @@
 package config
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -37,7 +38,7 @@ func TestSetConfig(t *testing.T) {
 		t.Fatalf("Error running os.Setenv: %v", err)
 	}
 
-	if err := SetConfig(); err != nil {
+	if err := SetConfig(context.Background()); err != nil {
 		t.Fatalf("Error running SetConfig: %v", err)
 	}
 
@@ -109,7 +110,7 @@ func TestSetConfigEnabled(t *testing.T) {
 
 	for i, want := range []bool{false, false, true} {
 		request = i
-		if err := SetConfig(); err != nil {
+		if err := SetConfig(context.Background()); err != nil {
 			t.Fatalf("Error running SetConfig: %v", err)
 		}
 
@@ -129,7 +130,7 @@ func TestSetConfigEnabled(t *testing.T) {
 	}
 
 	request = 3
-	if err := SetConfig(); err != nil {
+	if err := SetConfig(context.Background()); err != nil {
 		t.Fatalf("Error running SetConfig: %v", err)
 	}
 
@@ -159,7 +160,7 @@ func TestSetConfigDefaultValues(t *testing.T) {
 		t.Fatalf("Error running os.Setenv: %v", err)
 	}
 
-	if err := SetConfig(); err != nil {
+	if err := SetConfig(context.Background()); err != nil {
 		t.Fatalf("Error running SetConfig: %v", err)
 	}
 
@@ -224,7 +225,7 @@ func TestSetConfigError(t *testing.T) {
 		t.Fatalf("Error running os.Setenv: %v", err)
 	}
 
-	if err := SetConfig(); err == nil || !strings.Contains(err.Error(), "unexpected end of JSON input") {
+	if err := SetConfig(context.Background()); err == nil || !strings.Contains(err.Error(), "unexpected end of JSON input") {
 		t.Errorf("Unexpected output %+v", err)
 	}
 }

--- a/packaging/debian/rules
+++ b/packaging/debian/rules
@@ -17,6 +17,7 @@ override_dh_auto_install:
 	dh_auto_install -- --no-source
 	mv debian/google-osconfig-agent/usr/bin/osconfig debian/google-osconfig-agent/usr/bin/google_osconfig_agent
 	rm debian/google-osconfig-agent/usr/bin/e2e_tests
+	install -d debian/google-osconfig-agent/etc/osconfig
 	install -d debian/google-osconfig-agent/lib/systemd/system
 	install -p -m 0644 *.service debian/google-osconfig-agent/lib/systemd/system/
 	install -d debian/google-osconfig-agent/lib/systemd/system-preset/

--- a/packaging/google-osconfig-agent.spec
+++ b/packaging/google-osconfig-agent.spec
@@ -40,6 +40,7 @@ GOPATH=%{_gopath} CGO_ENABLED=0 %{_go} build -ldflags="-s -w -X main.version=%{_
 
 %install
 install -d %{buildroot}%{_bindir}
+install -d /etc/osconfig
 install -p -m 0755 google_osconfig_agent %{buildroot}%{_bindir}/google_osconfig_agent
 %if 0%{?el6}
 install -d %{buildroot}/etc/init


### PR DESCRIPTION
Windows expects a quick signal that the service is started, waiting for metadata could slow that.
Waiting for metadata could prevent the agent from shutting down as quickly as it should (~15s), updated to wait on the canceled context.
Overall there should not be any major changes to startup, just code moved around. 