### PR TITLE
e2e_tests: Record serial output in artifacts

### DIFF
--- a/e2e_tests/compute/instance.go
+++ b/e2e_tests/compute/instance.go
@@ -16,14 +16,13 @@
 package compute
 
 import (
-	"bytes"
 	"context"
 	"fmt"
 	"net/http"
 	"path"
 	"time"
+	"os"
 
-	"cloud.google.com/go/storage"
 	daisyCompute "github.com/GoogleCloudPlatform/compute-image-tools/daisy/compute"
 	computeApiBeta "google.golang.org/api/compute/v0.beta"
 	computeApi "google.golang.org/api/compute/v1"
@@ -104,9 +103,12 @@ func (i *Instance) AddMetadata(mdi ...*computeApi.MetadataItems) error {
 }
 
 // RecordSerialOutput stores the serial output of an instance to GCS bucket
-func (i *Instance) RecordSerialOutput(ctx context.Context, storageClient *storage.Client, logsPath, bucket string, port int64) {
-	logsObj := path.Join(logsPath, fmt.Sprintf("%s-serial-port%d.log", i.Name, port))
-	var buf bytes.Buffer
+func (i *Instance) RecordSerialOutput(ctx context.Context, logsPath string, port int64) {
+	os.MkdirAll(logsPath, 0770)
+	f, err := os.Create(path.Join(logsPath, fmt.Sprintf("%s-serial-port%d.log", i.Name, port)))
+	if err != nil {
+		fmt.Printf("Instance %q: error creating serial log file: %s", i.Name, err)
+	}
 	resp, err := i.client.GetSerialPortOutput(path.Base(i.Project), path.Base(i.Zone), i.Name, port, 0)
 	if err != nil {
 		// Instance is stopped or stopping.
@@ -116,18 +118,12 @@ func (i *Instance) RecordSerialOutput(ctx context.Context, storageClient *storag
 		}
 		return
 	}
-	wc := storageClient.Bucket(bucket).Object(logsObj).NewWriter(ctx)
-	buf.WriteString(resp.Contents)
-	wc.ContentType = "text/plain"
-	if _, err := wc.Write(buf.Bytes()); err != nil {
-		fmt.Printf("Instance %q: error writing log to GCS: %v", i.Name, err)
-		return
+	if _, err := f.Write([]byte(resp.Contents)); err != nil {
+		fmt.Printf("Instance %q: error writing serial log file: %s", i.Name, err)
 	}
-	if err := wc.Close(); err != nil {
-		fmt.Printf("Instance %q: error saving log to GCS: %v", i.Name, err)
-		return
+	if err := f.Close(); err != nil {
+		fmt.Printf("Instance %q: error closing serial log file: %s", i.Name, err)
 	}
-
 }
 
 func isTerminal(status string) bool {

--- a/e2e_tests/compute/instance.go
+++ b/e2e_tests/compute/instance.go
@@ -19,9 +19,9 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"os"
 	"path"
 	"time"
-	"os"
 
 	daisyCompute "github.com/GoogleCloudPlatform/compute-image-tools/daisy/compute"
 	computeApiBeta "google.golang.org/api/compute/v0.beta"

--- a/e2e_tests/config/config.go
+++ b/e2e_tests/config/config.go
@@ -45,7 +45,7 @@ var (
 	testProjectIDs         = flag.String("test_project_ids", "", "test project ids")
 
 	// OutDir is the out directory to use.
-	OutDir = flag.String("out_dir", "/tmp", "junit xml directory")
+	OutDir = flag.String("out_dir", "/tmp", "artifact directory")
 )
 
 func init() {

--- a/e2e_tests/gcp_clients/gcp_clients.go
+++ b/e2e_tests/gcp_clients/gcp_clients.go
@@ -34,10 +34,7 @@ func PopulateClients(ctx context.Context) error {
 	if err := createComputeClient(ctx); err != nil {
 		return err
 	}
-	if err := createOsConfigClientV1beta(ctx); err != nil {
-		return err
-	}
-	return createStorageClient(ctx)
+	return createOsConfigClientV1beta(ctx)
 }
 
 func createComputeClient(ctx context.Context) error {

--- a/e2e_tests/gcp_clients/gcp_clients.go
+++ b/e2e_tests/gcp_clients/gcp_clients.go
@@ -19,14 +19,12 @@ import (
 	"fmt"
 
 	osconfigV1beta "cloud.google.com/go/osconfig/apiv1beta"
-	"cloud.google.com/go/storage"
 	"github.com/GoogleCloudPlatform/compute-image-tools/daisy/compute"
 	"github.com/GoogleCloudPlatform/osconfig/e2e_tests/config"
 	"google.golang.org/api/option"
 )
 
 var (
-	storageClient        *storage.Client
 	computeClient        compute.Client
 	osconfigClientV1beta *osconfigV1beta.Client
 )
@@ -48,12 +46,6 @@ func createComputeClient(ctx context.Context) error {
 	return err
 }
 
-func createStorageClient(ctx context.Context) error {
-	var err error
-	storageClient, err = storage.NewClient(ctx, option.WithCredentialsFile(config.OauthPath()))
-	return err
-}
-
 func createOsConfigClientV1beta(ctx context.Context) error {
 	var err error
 	osconfigClientV1beta, err = osconfigV1beta.NewClient(ctx, option.WithCredentialsFile(config.OauthPath()), option.WithEndpoint(config.SvcEndpoint()))
@@ -66,14 +58,6 @@ func GetComputeClient() (compute.Client, error) {
 		return nil, fmt.Errorf("compute client was not initialized")
 	}
 	return computeClient, nil
-}
-
-// GetStorageClient returns a singleton GCP client for osconfig tests
-func GetStorageClient() (*storage.Client, error) {
-	if storageClient == nil {
-		return nil, fmt.Errorf("storage client was not initialized")
-	}
-	return storageClient, nil
 }
 
 // GetOsConfigClientV1beta returns a singleton GCP client for osconfig tests

--- a/e2e_tests/go.mod
+++ b/e2e_tests/go.mod
@@ -4,7 +4,6 @@ go 1.13
 
 require (
 	cloud.google.com/go v0.51.0
-	cloud.google.com/go/storage v1.5.0
 	github.com/GoogleCloudPlatform/compute-image-tools/daisy v0.0.0-20200114232830-6d2d59acb179
 	github.com/GoogleCloudPlatform/compute-image-tools/go/e2e_test_utils v0.0.0-20200114232830-6d2d59acb179
 	github.com/GoogleCloudPlatform/osconfig v0.0.0-20200115000133-a7c6fc334759
@@ -12,7 +11,6 @@ require (
 	github.com/kylelemons/godebug v1.1.0
 	golang.org/x/net v0.0.0-20200114155413-6afb5195e5aa // indirect
 	golang.org/x/sys v0.0.0-20200113162924-86b910548bc1 // indirect
-	golang.org/x/tools v0.0.0-20200114235610-7ae403b6b589 // indirect
 	google.golang.org/api v0.15.0
 	google.golang.org/genproto v0.0.0-20200113173426-e1de0a7b01eb
 	google.golang.org/grpc v1.26.0

--- a/e2e_tests/go.sum
+++ b/e2e_tests/go.sum
@@ -232,8 +232,6 @@ golang.org/x/tools v0.0.0-20191227053925-7b8e75db28f4 h1:Toz2IK7k8rbltAXwNAxKcn9
 golang.org/x/tools v0.0.0-20191227053925-7b8e75db28f4/go.mod h1:TB2adYChydJhpapKDTa4BR/hXlZSLoq2Wpct/0txZ28=
 golang.org/x/tools v0.0.0-20200107184032-11e9d9cc0042/go.mod h1:TB2adYChydJhpapKDTa4BR/hXlZSLoq2Wpct/0txZ28=
 golang.org/x/tools v0.0.0-20200108203644-89082a384178/go.mod h1:TB2adYChydJhpapKDTa4BR/hXlZSLoq2Wpct/0txZ28=
-golang.org/x/tools v0.0.0-20200114235610-7ae403b6b589 h1:rjUrONFu4kLchcZTfp3/96bR8bW8dIa8uz3cR5n0cgM=
-golang.org/x/tools v0.0.0-20200114235610-7ae403b6b589/go.mod h1:TB2adYChydJhpapKDTa4BR/hXlZSLoq2Wpct/0txZ28=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543 h1:E7g+9GITq07hpfrRu66IVDexMakfv52eLZ2CXBWiKr4=

--- a/e2e_tests/test_suites/guestpolicies/guest_policies.go
+++ b/e2e_tests/test_suites/guestpolicies/guest_policies.go
@@ -145,12 +145,7 @@ func runTest(ctx context.Context, testCase *junitxml.TestCase, testSetup *guestP
 		return
 	}
 	defer inst.Cleanup()
-
-	storageClient, err := gcpclients.GetStorageClient()
-	if err != nil {
-		testCase.WriteFailure("Error getting storage client: %v", err)
-	}
-	defer inst.RecordSerialOutput(ctx, storageClient, path.Join(testSuiteName, config.LogsPath()), config.LogBucket(), 1)
+	defer inst.RecordSerialOutput(ctx, path.Join(*config.OutDir, testSuiteName), 1)
 
 	testCase.Logf("Waiting for agent install to complete")
 	if _, err := inst.WaitForGuestAttributes("osconfig_tests/install_done", 5*time.Second, 10*time.Minute); err != nil {

--- a/e2e_tests/test_suites/inventory/inventory.go
+++ b/e2e_tests/test_suites/inventory/inventory.go
@@ -95,18 +95,13 @@ func runGatherInventoryTest(ctx context.Context, testSetup *inventoryTestSetup, 
 	zone := testProjectConfig.AcquireZone()
 	defer testProjectConfig.ReleaseZone(zone)
 
-	inst, err := utils.CreateComputeInstance(metadataItems, computeClient, "n1-standard-2", testSetup.image, testSetup.hostname, testProjectConfig.TestProjectID, zone, testProjectConfig.ServiceAccountEmail, testProjectConfig.ServiceAccountScopes)
+	inst, err := utils.CreateComputeInstance(metadataItems, computeClient, testSetup.machineType, testSetup.image, testSetup.hostname, testProjectConfig.TestProjectID, zone, testProjectConfig.ServiceAccountEmail, testProjectConfig.ServiceAccountScopes)
 	if err != nil {
 		testCase.WriteFailure("Error creating instance: %v", err)
 		return nil, false
 	}
 	defer inst.Cleanup()
-
-	storageClient, err := gcpclients.GetStorageClient()
-	if err != nil {
-		testCase.WriteFailure("Error getting storage client: %v", err)
-	}
-	defer inst.RecordSerialOutput(ctx, storageClient, path.Join(testSuiteName, config.LogsPath()), config.LogBucket(), 1)
+	defer inst.RecordSerialOutput(ctx, path.Join(*config.OutDir, testSuiteName), 1)
 
 	testCase.Logf("Waiting for agent install to complete")
 	if _, err := inst.WaitForGuestAttributes("osconfig_tests/install_done", 5*time.Second, 10*time.Minute); err != nil {

--- a/e2e_tests/test_suites/patch/patch.go
+++ b/e2e_tests/test_suites/patch/patch.go
@@ -252,12 +252,7 @@ func runExecutePatchJobTest(ctx context.Context, testCase *junitxml.TestCase, te
 		return
 	}
 	defer inst.Cleanup()
-
-	storageClient, err := gcpclients.GetStorageClient()
-	if err != nil {
-		testCase.WriteFailure("Error getting storage client: %v", err)
-	}
-	defer inst.RecordSerialOutput(ctx, storageClient, path.Join(testSuiteName, config.LogsPath()), config.LogBucket(), 1)
+	defer inst.RecordSerialOutput(ctx, path.Join(*config.OutDir, testSuiteName), 1)
 
 	testCase.Logf("Waiting for agent install to complete")
 	if _, err := inst.WaitForGuestAttributes("osconfig_tests/install_done", 5*time.Second, 15*time.Minute); err != nil {
@@ -321,12 +316,7 @@ func runRebootPatchTest(ctx context.Context, testCase *junitxml.TestCase, testSe
 		return
 	}
 	defer inst.Cleanup()
-
-	storageClient, err := gcpclients.GetStorageClient()
-	if err != nil {
-		testCase.WriteFailure("Error getting storage client: %v", err)
-	}
-	defer inst.RecordSerialOutput(ctx, storageClient, path.Join(testSuiteName, config.LogsPath()), config.LogBucket(), 1)
+	defer inst.RecordSerialOutput(ctx, path.Join(*config.OutDir, testSuiteName), 1)
 
 	testCase.Logf("Waiting for agent install to complete")
 	if _, err := inst.WaitForGuestAttributes("osconfig_tests/install_done", 5*time.Second, 15*time.Minute); err != nil {

--- a/e2e_tests/utils/utils.go
+++ b/e2e_tests/utils/utils.go
@@ -29,6 +29,7 @@ import (
 
 var (
 	yumInstallAgent = `
+sleep 10
 systemctl stop google-osconfig-agent
 stop -q -n google-osconfig-agent  # required for EL6
 while ! yum install -y google-osconfig-agent; do


### PR DESCRIPTION
Instead of uploading directly to GCS, just save serial console output to the artifacts directory that our test wrapper uploads