### PR TITLE
Retry installing WUA updates until canceled or retries exceeded

### DIFF
--- a/agentendpoint/patch_beta_windows.go
+++ b/agentendpoint/patch_beta_windows.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/GoogleCloudPlatform/guest-logging-go/logger"
 	"github.com/GoogleCloudPlatform/osconfig/ospatch"
 	"github.com/GoogleCloudPlatform/osconfig/packages"
 
@@ -115,7 +116,7 @@ func (r *patchTaskBeta) wuaUpdates(ctx context.Context) error {
 		}
 		count, err := r.installWUAUpdates(ctx, cf)
 		if err != nil {
-			log.Errorf("Error installing Windows updates (attempt %d): %v", i, err)
+			logger.Errorf("Error installing Windows updates (attempt %d): %v", i, err)
 		}
 		if count == 0 {
 			return nil

--- a/agentendpoint/patch_beta_windows.go
+++ b/agentendpoint/patch_beta_windows.go
@@ -117,6 +117,7 @@ func (r *patchTaskBeta) wuaUpdates(ctx context.Context) error {
 		count, err := r.installWUAUpdates(ctx, cf)
 		if err != nil {
 			logger.Errorf("Error installing Windows updates (attempt %d): %v", i, err)
+			continue
 		}
 		if count == 0 {
 			return nil

--- a/agentendpoint/patch_windows.go
+++ b/agentendpoint/patch_windows.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/GoogleCloudPlatform/guest-logging-go/logger"
 	"github.com/GoogleCloudPlatform/osconfig/ospatch"
 	"github.com/GoogleCloudPlatform/osconfig/packages"
 
@@ -116,7 +117,7 @@ func (r *patchTask) wuaUpdates(ctx context.Context) error {
 		}
 		count, err := r.installWUAUpdates(ctx, cf)
 		if err != nil {
-			log.Errorf("Error installing Windows updates (attempt %d): %v", i, err)
+			logger.Errorf("Error installing Windows updates (attempt %d): %v", i, err)
 		}
 		if count == 0 {
 			return nil

--- a/agentendpoint/patch_windows.go
+++ b/agentendpoint/patch_windows.go
@@ -94,7 +94,7 @@ func (r *patchTask) installWUAUpdates(ctx context.Context, cf []string) (int32, 
 		defer updt.Release()
 
 		if err := session.InstallWUAUpdate(updt); err != nil {
-			return i, fmt.Errorf(`installUpdate(class, excludes, updt): %v`, err)
+			return i, fmt.Errorf(`installUpdate(updt): %v`, err)
 		}
 	}
 
@@ -107,12 +107,16 @@ func (r *patchTask) wuaUpdates(ctx context.Context) error {
 		return err
 	}
 
-	// We keep searching for and installing updates until the count == 0 or there is an error.
-	retries := 20
-	for i := 0; i < retries; i++ {
+	// We keep searching for and installing updates until the count == 0,
+	// we get a stop signal, or retries exceed 10.
+	retries := 10
+	for i := 1; i <= retries; i++ {
+		if err := r.reportContinuingState(ctx, agentendpointpb.ApplyPatchesTaskProgress_APPLYING_PATCHES); err != nil {
+			return err
+		}
 		count, err := r.installWUAUpdates(ctx, cf)
 		if err != nil {
-			return err
+			log.Errorf("Error installing Windows updates (attempt %d): %v", i, err)
 		}
 		if count == 0 {
 			return nil
@@ -123,7 +127,8 @@ func (r *patchTask) wuaUpdates(ctx context.Context) error {
 }
 
 func (r *patchTask) runUpdates(ctx context.Context) error {
-	if err := retryFunc(30*time.Minute, "installing Windows updates", func() error { return r.wuaUpdates(ctx) }); err != nil {
+	// Don't use retry function as wuaUpdates handles it's own retries.
+	if err := r.wuaUpdates(ctx); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
Don't return on first error, keep retrying unless we get a stop signal. Reduce retry number down to a more reasonable 10.