### PR TITLE
Fix stepExecFile chmod permissions to 0700

### DIFF
--- a/policies/recipes/steps.go
+++ b/policies/recipes/steps.go
@@ -436,7 +436,7 @@ func stepExecFile(step *agentendpointpb.SoftwareRecipe_Step_ExecFile, artifacts 
 			return fmt.Errorf("%q not found in artifact map", artifact)
 		}
 
-		err := os.Chmod(path, 700)
+		err := os.Chmod(path, 0700)
 		if err != nil {
 			return fmt.Errorf("error setting execute permissions on artifact %s: %v", step.GetArtifactId(), err)
 		}


### PR DESCRIPTION
Changed created file permissions from 700 (`-w-rwxr--`) to 0700 (`rwx------`).

PoC:
```
dc@jhtc:~/gogo/chmod$ touch 700 0700
dc@jhtc:~/gogo/chmod$ cat chmod.go
package main

import "os"

func main() {
    os.Chmod("700", 700)
    os.Chmod("0700", 0700)
}
dc@jhtc:~/gogo/chmod$ go run chmod.go
dc@jhtc:~/gogo/chmod$ ls -la
total 12
drwxrwxr-x 2 dc dc 4096 Jun  9 17:37 .
drwxrwxr-x 7 dc dc 4096 Jun  9 17:36 ..
-rwx------ 1 dc dc    0 Jun  9 17:37 0700
--w-rwxr-- 1 dc dc    0 Jun  9 17:37 700
-rw-rw-r-- 1 dc dc   95 Jun  9 17:37 chmod.go
```

This might actually produce a security risk if there are other users on the system and the chmod'ed directory/file is accessible by them.