### PR TITLE
update rules to not include e2e test binary

### DIFF
--- a/packaging/debian/rules
+++ b/packaging/debian/rules
@@ -18,7 +18,6 @@ override_dh_auto_install:
 	# Binary-only package.
 	dh_auto_install -- --no-source
 	mv debian/google-osconfig-agent/usr/bin/osconfig debian/google-osconfig-agent/usr/bin/google_osconfig_agent
-	rm debian/google-osconfig-agent/usr/bin/e2e_tests
 	install -d debian/google-osconfig-agent/etc/osconfig
 	install -d debian/google-osconfig-agent/lib/systemd/system
 	install -p -m 0644 *.service debian/google-osconfig-agent/lib/systemd/system/


### PR DESCRIPTION
since we are already exluding the e2e_tests directory from getting built, there is no e2e_test binary created which results in failure of this command and breaks the overall build

tested with local build, here is the resulting files

subratp@agent-build:/tmp/debpackage-e$ dpkg -c google-osconfig-agent_1dummy-g1_amd64.deb
drwxr-xr-x root/root         0 2020-06-25 19:38 ./
drwxr-xr-x root/root         0 2020-06-25 19:38 ./etc/
drwxr-xr-x root/root         0 2020-06-25 19:38 ./etc/osconfig/
drwxr-xr-x root/root         0 2020-06-25 19:38 ./lib/
drwxr-xr-x root/root         0 2020-06-25 19:38 ./lib/systemd/
drwxr-xr-x root/root         0 2020-06-25 19:38 ./lib/systemd/system/
-rw-r--r-- root/root       321 2020-06-25 18:54 ./lib/systemd/system/google-osconfig-agent.service
drwxr-xr-x root/root         0 2020-06-25 19:38 ./usr/
drwxr-xr-x root/root         0 2020-06-25 19:38 ./usr/bin/
-rwxr-xr-x root/root  16220088 2020-06-25 19:38 ./usr/bin/google_osconfig_agent
drwxr-xr-x root/root         0 2020-06-25 19:38 ./usr/share/
drwxr-xr-x root/root         0 2020-06-25 19:38 ./usr/share/doc/
drwxr-xr-x root/root         0 2020-06-25 19:38 ./usr/share/doc/google-osconfig-agent/
-rw-r--r-- root/root       162 2020-06-25 19:38 ./usr/share/doc/google-osconfig-agent/changelog.Debian.gz
-rw-r--r-- root/root       982 2020-06-25 19:38 ./usr/share/doc/google-osconfig-agent/copyright
