### PR TITLE
read COS package list for inventory report

### DIFF
--- a/packages/cos.go
+++ b/packages/cos.go
@@ -1,0 +1,77 @@
+//  Copyright 2020 Google Inc. All Rights Reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
+package packages
+
+import (
+	"bytes"
+	"fmt"
+	"io/ioutil"
+	"runtime"
+	"strings"
+
+	"github.com/GoogleCloudPlatform/osconfig/osinfo"
+	"github.com/GoogleCloudPlatform/osconfig/util"
+)
+
+var (
+	cosPkgList string
+)
+
+func init() {
+	if runtime.GOOS != "windows" {
+		cosPkgList = "/etc/package-list"
+	}
+	CosPkgListExists = util.Exists(cosPkgList)
+}
+
+var readMachineArch = func() (string, error) {
+	oi, err := osinfo.Get()
+	if err != nil {
+		return "", fmt.Errorf("error getting osinfo: %v", err)
+	}
+	return oi.Architecture, nil
+}
+
+func parseInstalledCosPackages(data []byte) ([]PkgInfo, error) {
+	arch, err := readMachineArch()
+	if err != nil {
+		return nil, fmt.Errorf("error from readMachineArch: %v", err)
+	}
+
+	lines := bytes.Split(bytes.TrimSpace(data), []byte("\n"))
+	var pkgs []PkgInfo
+	for _, ln := range lines {
+		pkg := bytes.Fields(ln)
+		if len(pkg) != 2 {
+			continue
+		}
+		pkgs = append(pkgs, PkgInfo{Name: string(pkg[0]), Arch: arch, Version: string(pkg[1])})
+	}
+	return pkgs, nil
+}
+
+var readCosPackageList = func() ([]byte, error) {
+	return ioutil.ReadFile(cosPkgList)
+}
+
+// InstalledCosPackages queries for all installed COS packages.
+func InstalledCosPackages() ([]PkgInfo, error) {
+	b, err := readCosPackageList()
+	DebugLogger.Printf("cosPkgList contents:\n%s", strings.ReplaceAll(string(b), "\n", "\n "))
+	if err != nil {
+		return nil, fmt.Errorf("error reading COS package list with args :%v, contents: %s", err, b)
+	}
+	return parseInstalledCosPackages(b)
+}

--- a/packages/cos_test.go
+++ b/packages/cos_test.go
@@ -1,0 +1,97 @@
+//  Copyright 2020 Google Inc. All Rights Reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
+package packages
+
+import (
+	"errors"
+	"reflect"
+	"testing"
+)
+
+func TestParseInstalledCosPackages(t *testing.T) {
+	readMachineArch = func() (string, error) {
+		return "", errors.New("failed to obtain machine architecture")
+	}
+	if _, err := parseInstalledCosPackages([]byte{}); err == nil {
+		t.Errorf("did not get expected error")
+	}
+
+	readMachineArch = func() (string, error) {
+		return "x86_64", nil
+	}
+	tests := []struct {
+		name string
+		data []byte
+		want []PkgInfo
+	}{
+		{"NormalCase",
+			[]byte("  dev-util/foo-x     1.2.3-r4\napp-admin/bar 0.1-r1"),
+			[]PkgInfo{{"dev-util/foo-x", "x86_64", "1.2.3-r4"}, {"app-admin/bar", "x86_64", "0.1-r1"}}},
+		{"NoPackages", []byte("no packages here"), nil},
+		{"nil", nil, nil},
+		{"UnrecognizedPackage",
+			[]byte("foo zzz 1.2.3-r4\nsomething we dont understand\n bar 0.1-r1 "),
+			[]PkgInfo{{"bar", "x86_64", "0.1-r1"}}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := parseInstalledCosPackages(tt.data)
+			if err != nil {
+				t.Errorf("unexpected error: %v", err)
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("parseInstalledCosPackages() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestInstalledCosPackages(t *testing.T) {
+	readMachineArch = func() (string, error) {
+		return "", errors.New("failed to obtain machine architecture")
+	}
+	readCosPackageList = func() ([]byte, error) {
+		return []byte("sys-boot/foo-bar 1.2.3-r4"), nil
+	}
+	if _, err := InstalledCosPackages(); err == nil {
+		t.Errorf("did not get expected error from readMachineArch")
+	}
+
+	readMachineArch = func() (string, error) {
+		return "x86_64", nil
+	}
+	readCosPackageList = func() ([]byte, error) {
+		return nil, errors.New("failed to read package list")
+	}
+	if _, err := InstalledCosPackages(); err == nil {
+		t.Errorf("did not get expected error fro readCosPackageList")
+	}
+
+	readMachineArch = func() (string, error) {
+		return "x86_64", nil
+	}
+	readCosPackageList = func() ([]byte, error) {
+		return []byte("sys-boot/foo-bar 1.2.3-r4"), nil
+	}
+	ret, err := InstalledCosPackages()
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+	want := []PkgInfo{{"sys-boot/foo-bar", "x86_64", "1.2.3-r4"}}
+	if !reflect.DeepEqual(ret, want) {
+		t.Errorf("InstalledCosPackages() = %v, want %v", ret, want)
+	}
+
+}

--- a/packages/packages.go
+++ b/packages/packages.go
@@ -39,6 +39,8 @@ var (
 	RPMExists bool
 	// RPMQueryExists indicates whether rpmquery is installed.
 	RPMQueryExists bool
+	// CosPkgListExists indicates whether COS package list file exists.
+	CosPkgListExists bool
 	// GemExists indicates whether gem is installed.
 	GemExists bool
 	// PipExists indicates whether pip is installed.
@@ -60,6 +62,7 @@ type Packages struct {
 	Deb           []PkgInfo     `json:"deb,omitempty"`
 	Zypper        []PkgInfo     `json:"zypper,omitempty"`
 	ZypperPatches []ZypperPatch `json:"zypperPatches,omitempty"`
+	Cos           []PkgInfo     `json:"cos,omitempty"`
 	Gem           []PkgInfo     `json:"gem,omitempty"`
 	Pip           []PkgInfo     `json:"pip,omitempty"`
 	GooGet        []PkgInfo     `json:"googet,omitempty"`

--- a/packages/packages_linux.go
+++ b/packages/packages_linux.go
@@ -125,6 +125,15 @@ func GetInstalledPackages() (Packages, error) {
 			pkgs.Deb = deb
 		}
 	}
+	if util.Exists(cosPkgList) {
+		cos, err := InstalledCosPackages()
+		if err != nil {
+			msg := fmt.Sprintf("error listing installed cos packages: %v", err)
+			DebugLogger.Println("Error:", msg)
+		} else {
+			pkgs.Cos = cos
+		}
+	}
 	if util.Exists(gem) {
 		gem, err := InstalledGemPackages()
 		if err != nil {


### PR DESCRIPTION
With this change, OS Config Agent can read the list of the installed
packages in COS (Container-Optimized OS) and include them in the OS
inventory data.