### PR TITLE
reduce number of retries for guest policy operations

### DIFF
--- a/policies/policies.go
+++ b/policies/policies.go
@@ -177,7 +177,7 @@ func setConfig(egp *agentendpointpb.EffectiveGuestPolicy) {
 		if err := googetRepositories(gooRepos, config.GooGetRepoFilePath()); err != nil {
 			logger.Errorf("Error writing googet repo file: %v", err)
 		}
-		if err := retryutil.RetryFunc(2*time.Minute, "Applying googet changes", func() error {
+		if err := retryutil.RetryFunc(1*time.Minute, "Applying googet changes", func() error {
 			return googetChanges(gooInstallPkgs, gooRemovePkgs, gooUpdatePkgs)
 		}); err != nil {
 			logger.Errorf("Error performing googet changes: %v", err)
@@ -194,7 +194,7 @@ func setConfig(egp *agentendpointpb.EffectiveGuestPolicy) {
 		if err := aptRepositories(aptRepos, config.AptRepoFilePath()); err != nil {
 			logger.Errorf("Error writing apt repo file: %v", err)
 		}
-		if err := retryutil.RetryFunc(2*time.Minute, "Applying apt changes", func() error {
+		if err := retryutil.RetryFunc(1*time.Minute, "Applying apt changes", func() error {
 			return aptChanges(aptInstallPkgs, aptRemovePkgs, aptUpdatePkgs)
 		}); err != nil {
 			logger.Errorf("Error performing apt changes: %v", err)
@@ -211,7 +211,7 @@ func setConfig(egp *agentendpointpb.EffectiveGuestPolicy) {
 		if err := yumRepositories(yumRepos, config.YumRepoFilePath()); err != nil {
 			logger.Errorf("Error writing yum repo file: %v", err)
 		}
-		if err := retryutil.RetryFunc(2*time.Minute, "Applying yum changes", func() error {
+		if err := retryutil.RetryFunc(1*time.Minute, "Applying yum changes", func() error {
 			return yumChanges(yumInstallPkgs, yumRemovePkgs, yumUpdatePkgs)
 		}); err != nil {
 			logger.Errorf("Error performing yum changes: %v", err)
@@ -228,7 +228,7 @@ func setConfig(egp *agentendpointpb.EffectiveGuestPolicy) {
 		if err := zypperRepositories(zypperRepos, config.ZypperRepoFilePath()); err != nil {
 			logger.Errorf("Error writing zypper repo file: %v", err)
 		}
-		if err := retryutil.RetryFunc(2*time.Minute, "Applying zypper changes.", func() error {
+		if err := retryutil.RetryFunc(1*time.Minute, "Applying zypper changes.", func() error {
 			return zypperChanges(zypperInstallPkgs, zypperRemovePkgs, zypperUpdatePkgs)
 		}); err != nil {
 			logger.Errorf("Error performing zypper changes: %v", err)


### PR DESCRIPTION
Larger sleep time makes the agent retry for long time. This results in longer wait time for subsequent tasks, sometimes resulting in timeouts.