### PR TITLE
add timeout to watchconfig

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -70,7 +70,8 @@ const (
 	restartFileLinux     = configDirLinux + "/osconfig_agent_restart_required"
 
 	osConfigPollIntervalDefault = 10
-	osConfigMetadataPollTimeout = 300
+	osConfigMetadataPollTimeout = 60
+	osConfigWatchConfigTimeout  = 600
 )
 
 var (
@@ -376,6 +377,7 @@ func getMetadata(suffix string) ([]byte, string, error) {
 func WatchConfig(ctx context.Context) error {
 	var md []byte
 	var webError error
+	ticker := time.NewTicker(osConfigWatchConfigTimeout)
 	eTag := lEtag.get()
 	webErrorCount := 0
 	for {
@@ -408,6 +410,8 @@ func WatchConfig(ctx context.Context) error {
 		}
 
 		select {
+		case <-ticker.C:
+			break
 		case <-ctx.Done():
 			return nil
 		default:

--- a/main.go
+++ b/main.go
@@ -157,7 +157,6 @@ func runLoop(ctx context.Context) {
 
 	go func() {
 		for {
-			config.LogFeatures()
 			if config.TaskNotificationEnabled() && (taskNotificationClient == nil || taskNotificationClient.Closed()) {
 				// Start WaitForTaskNotification if we need to.
 				taskNotificationClient, err = agentendpoint.NewClient(ctx)


### PR DESCRIPTION
Add an overall timeout for watchconfig and reduced the metadata watch timeout. this is to handle the case where agent is enabled and but the service is not enabled.
If there is no change in the metadata, the agent never gets a chance to establish a connection with the service.
the current timeout is 10 mins.
In the situtation mentioned above, it will take a total of 11 mins

also, removed the feature logging for now, since it will spam the serial console of vm incurring extra cost to customers. we will come up with a better plan for logging.