### PR TITLE
fix watchconfig bug

### DIFF
--- a/agentendpoint/agentendpoint.go
+++ b/agentendpoint/agentendpoint.go
@@ -320,6 +320,7 @@ func (c *Client) WaitForTaskNotification(ctx context.Context) {
 			if err := c.waitForTask(ctx); err != nil {
 				if err == errServiceNotEnabled {
 					// Service is disabled, close this client and return.
+					logger.Warningf("OSConfig Service is disabled.")
 					c.Close()
 					return
 				}

--- a/config/config.go
+++ b/config/config.go
@@ -71,7 +71,7 @@ const (
 
 	osConfigPollIntervalDefault = 10
 	osConfigMetadataPollTimeout = 60
-	osConfigWatchConfigTimeout  = 600
+	osConfigWatchConfigTimeout  = 10 * time.Minute
 )
 
 var (
@@ -411,7 +411,7 @@ func WatchConfig(ctx context.Context) error {
 
 		select {
 		case <-ticker.C:
-			break
+			return nil
 		case <-ctx.Done():
 			return nil
 		default:


### PR DESCRIPTION
'break' does not stop the watch config. 'break' only breaks the inner most 'for', 'switch' or 'select'.
int64 are by automatically casted to duration type; which is equivalent to 10^-9 secs.
also, adding logging to show to the customers if the service is disabled. (not having this was misleading for me while testing.)