### PR TITLE
make yum fetch updates with excludes

### DIFF
--- a/ospatch/yum_update.go
+++ b/ospatch/yum_update.go
@@ -90,12 +90,14 @@ func RunYumUpdate(ctx context.Context, opts ...YumUpdateOption) error {
 		opt(yumOpts)
 	}
 
-	pkgs, err := packages.YumUpdates(ctx, packages.YumUpdateMinimal(yumOpts.minimal), packages.YumUpdateSecurity(yumOpts.security))
+	pkgs, err := packages.YumUpdates(ctx, packages.YumUpdateMinimal(yumOpts.minimal), packages.YumUpdateSecurity(yumOpts.security), packages.YumExcludes(yumOpts.excludes))
 	if err != nil {
 		return err
 	}
 
-	fPkgs, err := filterPackages(pkgs, yumOpts.exclusivePackages, yumOpts.excludes)
+	// Yum excludes are already excluded while listing yumUpdates, so we send
+	// and empty list.
+	fPkgs, err := filterPackages(pkgs, yumOpts.exclusivePackages, []string{})
 	if err != nil {
 		return err
 	}

--- a/ospatch/yum_update_test.go
+++ b/ospatch/yum_update_test.go
@@ -1,0 +1,107 @@
+//  Copyright 2020 Google Inc. All Rights Reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
+package ospatch
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"testing"
+
+	"github.com/GoogleCloudPlatform/osconfig/packages"
+	"github.com/GoogleCloudPlatform/osconfig/util/mocks"
+	"github.com/golang/mock/gomock"
+)
+
+func TestRunYumUpdateWithSecurity(t *testing.T) {
+	data := []byte(`
+	=================================================================================================================================================================================
+	Package                                      Arch                           Version                                              Repository                                Size
+    =================================================================================================================================================================================
+    Upgrading:
+      foo                                       noarch                         2.0.0-1                           BaseOS                                   361 k
+    blah
+`)
+	ctx := context.Background()
+
+	if os.Getenv("EXIT100") == "1" {
+		os.Exit(100)
+	}
+
+	cmd := exec.Command(os.Args[0], "-test.run=TestRunYumUpdateWithSecurity")
+	cmd.Env = append(os.Environ(), "EXIT100=1")
+	err := cmd.Run()
+
+	mockCtrl := gomock.NewController(t)
+	defer mockCtrl.Finish()
+
+	mockCommandRunner := mocks.NewMockCommandRunner(mockCtrl)
+	packages.SetCommandRunner(mockCommandRunner)
+	checkUpdateCall := mockCommandRunner.EXPECT().Run(ctx, exec.Command("/usr/bin/yum", []string{"check-update", "--assumeyes"}...)).Return([]byte("TestYumUpdatesError"), err).Times(1)
+	// yum install call to install package
+	mockCommandRunner.EXPECT().Run(ctx, exec.Command("/usr/bin/yum", []string{"install", "--assumeyes", "foo"}...)).After(checkUpdateCall).Return([]byte("install successful"), nil).Times(1)
+
+	mockPtyCommandRunner := mocks.NewMockCommandRunner(mockCtrl)
+	packages.SetPtyCommandRunner(mockPtyCommandRunner)
+	mockPtyCommandRunner.EXPECT().Run(ctx, exec.Command("/usr/bin/yum", []string{"update", "--assumeno", "--cacheonly", "--security"}...)).Return(data, nil).Times(1)
+
+	err = RunYumUpdate(ctx, YumUpdateMinimal(false), YumUpdateSecurity(true))
+	if err != nil {
+		t.Errorf("did not expect error: %+v", err)
+	}
+}
+
+func TestRunYumUpdateWithSecurityWithExclusives(t *testing.T) {
+	data := []byte(`
+	=================================================================================================================================================================================
+	Package                                      Arch                           Version                                              Repository                                Size
+	=================================================================================================================================================================================
+	Installing:
+      kernel                                    x86_64                         2.6.32-754.24.3.el6                                  updates                                   32 M
+	    replacing kernel.x86_64 1.0.0-4
+	Upgrading:
+	  foo                                       noarch                         2.0.0-1                                              BaseOS                                   361 k
+	  bar                                       x86_64                         2.0.0-1                                              repo                                      10 M
+	Obsoleting:
+	  baz                                       noarch                         2.0.0-1                                              repo                                      10 M
+`)
+	ctx := context.Background()
+	exclusivePackages := []string{"foo", "bar"}
+	if os.Getenv("EXIT100") == "1" {
+		os.Exit(100)
+	}
+
+	cmd := exec.Command(os.Args[0], "-test.run=TestRunYumUpdateWithSecurityWithExclusives")
+	cmd.Env = append(os.Environ(), "EXIT100=1")
+	err := cmd.Run()
+
+	mockCtrl := gomock.NewController(t)
+	defer mockCtrl.Finish()
+
+	mockCommandRunner := mocks.NewMockCommandRunner(mockCtrl)
+	packages.SetCommandRunner(mockCommandRunner)
+	checkUpdateCall := mockCommandRunner.EXPECT().Run(ctx, exec.Command("/usr/bin/yum", []string{"check-update", "--assumeyes"}...)).Return([]byte("TestYumUpdatesError"), err).Times(1)
+	// yum install call to install package, make sure only 2 packages are installed.
+	mockCommandRunner.EXPECT().Run(ctx, exec.Command("/usr/bin/yum", []string{"install", "--assumeyes", "foo", "bar"}...)).After(checkUpdateCall).Return([]byte("install successful"), nil).Times(1)
+
+	mockPtyCommandRunner := mocks.NewMockCommandRunner(mockCtrl)
+	packages.SetPtyCommandRunner(mockPtyCommandRunner)
+	mockPtyCommandRunner.EXPECT().Run(ctx, exec.Command("/usr/bin/yum", []string{"update", "--assumeno", "--cacheonly", "--security"}...)).Return(data, nil).Times(1)
+
+	err = RunYumUpdate(ctx, YumUpdateMinimal(false), YumUpdateSecurity(true), YumExclusivePackages(exclusivePackages))
+	if err != nil {
+		t.Errorf("did not expect error: %+v", err)
+	}
+}

--- a/packages/packages.go
+++ b/packages/packages.go
@@ -115,3 +115,14 @@ func (p *defaultRunner) Run(ctx context.Context, cmd *exec.Cmd) ([]byte, error) 
 	clog.Debugf(ctx, "Running %q with args %q\n", cmd.Path, cmd.Args[1:])
 	return cmd.CombinedOutput()
 }
+
+// SetCommandRunner allows external clients to set a custom commandRunner.
+func SetCommandRunner(commandRunner util.CommandRunner) {
+	runner = commandRunner
+}
+
+// SetPtyCommandRunner allows external clients to set a custom
+// custom commandRunner.
+func SetPtyCommandRunner(commandRunner util.CommandRunner) {
+	ptyrunner = commandRunner
+}

--- a/packages/yum_test.go
+++ b/packages/yum_test.go
@@ -17,6 +17,7 @@ package packages
 import (
 	"context"
 	"errors"
+	"os"
 	"os/exec"
 	"reflect"
 	"testing"
@@ -135,6 +136,44 @@ func TestYumUpdatesMinimalWithSecurity(t *testing.T) {
 	}
 }
 
+func TestYumUpdatesWithSecurityWithExcludes(t *testing.T) {
+	data := []byte(`
+	=================================================================================================================================================================================
+	Package                                      Arch                           Version                                              Repository                                Size
+	=================================================================================================================================================================================
+	Installing:
+    kernel                                    x86_64                         2.6.32-754.24.3.el6                                  updates                                   32 M
+	    replacing kernel.x86_64 1.0.0-4
+	Upgrading:
+	  foo                                       noarch                         2.0.0-1                                              BaseOS                                   361 k
+	  bar                                       x86_64                         2.0.0-1                                              repo                                      10 M
+	Obsoleting:
+	  baz                                       noarch                         2.0.0-1                                              repo                                      10 M
+`)
+
+	// the mock data returned by mockcommandrunner will not include this
+	// package anyways. The purpose of this test is to make sure that
+	// when customer specifies excluded packages, we set the --exclude flag
+	// in the yum command.
+	excludedPackages := []string{"ex-pkg1", "ex-pkg2"}
+	ctx := context.Background()
+	mockCtrl := gomock.NewController(t)
+	defer mockCtrl.Finish()
+
+	mockCommandRunner := mocks.NewMockCommandRunner(mockCtrl)
+	ptyrunner = mockCommandRunner
+	mockCommandRunner.EXPECT().Run(ctx, exec.Command("/usr/bin/yum", []string{"update", "--assumeno", "--cacheonly", "--security", "--exclude", excludedPackages[0], "--exclude", excludedPackages[1]}...)).Return(data, nil).Times(1)
+
+	ret, err := listAndParseYumPackages(ctx, YumUpdateMinimal(false), YumUpdateSecurity(true), YumExcludes(excludedPackages))
+	if err != nil {
+		t.Errorf("did not expect error: %+v", err)
+	}
+
+	if len(ret) != 3 {
+		t.Errorf("unexpected number of updates.")
+	}
+}
+
 func contains(names []string, name string) bool {
 	for _, n := range names {
 		if n == name {
@@ -192,5 +231,46 @@ func TestParseYumUpdates(t *testing.T) {
 				t.Errorf("parseYumUpdates() = %v, want %v", got, tt.want)
 			}
 		})
+	}
+}
+
+func TestYumUpdatesExitCode100(t *testing.T) {
+	data := []byte(`
+	=================================================================================================================================================================================
+	Package                                      Arch                           Version                                              Repository                                Size
+    =================================================================================================================================================================================
+    Upgrading:
+      foo                                       noarch                         2.0.0-1                           BaseOS                                   361 k
+    blah
+`)
+	excludedPackages := []string{"ex-pkg1", "ex-pkg2"}
+	ctx := context.Background()
+
+	if os.Getenv("EXIT100") == "1" {
+		os.Exit(100)
+	}
+
+	cmd := exec.Command(os.Args[0], "-test.run=TestYumUpdatesExitCode100")
+	cmd.Env = append(os.Environ(), "EXIT100=1")
+	err := cmd.Run()
+
+	mockCtrl := gomock.NewController(t)
+	defer mockCtrl.Finish()
+
+	mockCommandRunner := mocks.NewMockCommandRunner(mockCtrl)
+	runner = mockCommandRunner
+	mockCommandRunner.EXPECT().Run(ctx, exec.Command("/usr/bin/yum", []string{"check-update", "--assumeyes"}...)).Return([]byte("TestYumUpdatesError"), err).Times(1)
+
+	ptyrunner = mockCommandRunner
+	mockCommandRunner.EXPECT().Run(ctx, exec.Command("/usr/bin/yum", []string{"update", "--assumeno", "--cacheonly", "--exclude", excludedPackages[0], "--exclude", excludedPackages[1]}...)).Return(data, nil).Times(1)
+
+	ret, err := YumUpdates(ctx, YumExcludes(excludedPackages))
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+
+	want := []PkgInfo{{"foo", "all", "2.0.0-1"}}
+	if !reflect.DeepEqual(ret, want) {
+		t.Errorf("YumUpdates() = %v, want %v", ret, want)
 	}
 }


### PR DESCRIPTION
the agent uses `yum update --asssumeno` to get the list of update'ble packages. with version-locked packages, yum update thinks that it has to update the version-locked packages, which is a conflict and hence bails out the execution, eventually ending up in failed patch-jobs.

with this fix, customers can specify the version-locked packages in the list of excludes. This will end up in `yum update --assumeno` succeeding and also returning the list of update'ble packages excluding the version-locked packages.

Also, added unit tests for exclusive installs.