### PR TITLE
Fix WatchMetadata web error handling, fix clog CallDepth

### DIFF
--- a/clog/clog.go
+++ b/clog/clog.go
@@ -35,8 +35,9 @@ type log struct {
 }
 
 func (l *log) log(msg string, sev logger.Severity) {
-	// Default CallDepth fro Log is 2, add 2 for this function and the calling log function.
-	logger.Log(logger.LogEntry{Message: msg, Severity: sev, CallDepth: 4, Labels: l.labels})
+	// Set CallDepth 3, one for logger.Log, one for this function, and one for
+	// the calling clog function.
+	logger.Log(logger.LogEntry{Message: msg, Severity: sev, CallDepth: 3, Labels: l.labels})
 }
 
 // Debugf simulates logger.Debugf and adds context labels.

--- a/config/config.go
+++ b/config/config.go
@@ -19,7 +19,6 @@ import (
 	"context"
 	"crypto/sha256"
 	"encoding/json"
-	"errors"
 	"flag"
 	"fmt"
 	"io/ioutil"
@@ -333,10 +332,10 @@ func setSVCEndpoint(md metadataJSON, c *config) {
 func formatMetadataError(err error) error {
 	if urlErr, ok := err.(*url.Error); ok {
 		if _, ok := urlErr.Err.(*net.DNSError); ok {
-			return errors.New("DNS error when requesting metadata, check DNS settings and ensure metadata.google.internal is setup in your hosts file")
+			return fmt.Errorf("DNS error when requesting metadata, check DNS settings and ensure metadata.google.internal is setup in your hosts file: %w", err)
 		}
 		if _, ok := urlErr.Err.(*net.OpError); ok {
-			return errors.New("network error when requesting metadata, make sure your instance has an active network and can reach the metadata server")
+			return fmt.Errorf("network error when requesting metadata, make sure your instance has an active network and can reach the metadata server: %w", err)
 		}
 	}
 	return err
@@ -383,7 +382,10 @@ func getMetadata(suffix string) ([]byte, string, error) {
 func WatchConfig(ctx context.Context) error {
 	var md []byte
 	var webError error
-	ticker := time.NewTicker(osConfigWatchConfigTimeout)
+	// Max watch time, after this WatchConfig will return.
+	timeout := time.NewTicker(osConfigWatchConfigTimeout)
+	// Min watch loop time.
+	loopTicker := time.NewTicker(5 * time.Second)
 	eTag := lEtag.get()
 	webErrorCount := 0
 	for {
@@ -406,21 +408,21 @@ func WatchConfig(ctx context.Context) error {
 			agentConfigMx.Unlock()
 		}
 
-		// Try up to 3 times to wait for slow network initialization, after
+		// Try up to 12 times (60s) to wait for slow network initialization, after
 		// that resort to using defaults and returning the error.
 		if webError != nil {
-			if webErrorCount == 2 {
+			if webErrorCount == 12 {
 				return formatMetadataError(webError)
 			}
 			webErrorCount++
 		}
 
 		select {
-		case <-ticker.C:
-			return nil
+		case <-timeout.C:
+			return webError
 		case <-ctx.Done():
 			return nil
-		default:
+		case <-loopTicker.C:
 			continue
 		}
 	}


### PR DESCRIPTION
We need to actually wait for slow network bringup, make sure WatchMetadata doesn't loop faster than 5s, wait up to 60s for slow network
logger.Log has an incorrect default call depth of 2, my calculation based on this was therefore incorrect. 