### PR TITLE
Fix panic if any osinfo calls fail

### DIFF
--- a/osinfo/osinfo_linux.go
+++ b/osinfo/osinfo_linux.go
@@ -110,7 +110,7 @@ func Get() (*OSInfo, error) {
 
 	var uts unix.Utsname
 	if err := unix.Uname(&uts); err != nil {
-		return nil, fmt.Errorf("unix.Uname error: %v", err)
+		return oi, fmt.Errorf("unix.Uname error: %v", err)
 	}
 	// unix.Utsname Fields are [65]byte so we need to trim any trailing null characters.
 	oi.Hostname = string(bytes.TrimRight(uts.Nodename[:], "\x00"))

--- a/osinfo/osinfo_windows.go
+++ b/osinfo/osinfo_windows.go
@@ -159,6 +159,9 @@ func Get() (*OSInfo, error) {
 	if err := wmi.Query(query, &ops); err != nil {
 		return oi, fmt.Errorf("wmi.Query(%q) error: %v", query, err)
 	}
+	if len(ops) == 0 {
+		return oi, fmt.Errorf("wmi.Query(%q) nil output", query)
+	}
 	oi.LongName = ops[0].Caption
 	oi.Version = ops[0].Version
 

--- a/packages/qfe_windows.go
+++ b/packages/qfe_windows.go
@@ -15,21 +15,23 @@ package packages
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/GoogleCloudPlatform/osconfig/clog"
 	"github.com/StackExchange/wmi"
 )
 
-type win32_QuickFixEngineering struct {
+type win32QuickFixEngineering struct {
 	Caption, Description, HotFixID, InstalledOn string
 }
 
 // QuickFixEngineering queries the wmi object win32_QuickFixEngineering for a list of installed updates.
 func QuickFixEngineering(ctx context.Context) ([]QFEPackage, error) {
-	var updts []win32_QuickFixEngineering
+	var updts []win32QuickFixEngineering
 	clog.Debugf(ctx, "Querying WMI for installed QuickFixEngineering updates.")
-	if err := wmi.Query(wmi.CreateQuery(&updts, ""), &updts); err != nil {
-		return nil, err
+	query := "SELECT Caption, Description, HotFixID, InstalledOn FROM Win32_QuickFixEngineering"
+	if err := wmi.Query(query, &updts); err != nil {
+		return nil, fmt.Errorf("wmi.Query(%q) error: %v", query, err)
 	}
 	var qfe []QFEPackage
 	for _, update := range updts {


### PR DESCRIPTION
Add more error details to WIndows inventory calls
Record osinfo details wven if some functions return errors.
Reorder windows osinfo functions in order of most likely to not return error.