### PR TITLE
Make sure we retry on failed Windows Updates

### DIFF
--- a/agentendpoint/patch_windows.go
+++ b/agentendpoint/patch_windows.go
@@ -118,6 +118,8 @@ func (r *patchTask) wuaUpdates(ctx context.Context) error {
 		count, err := r.installWUAUpdates(ctx, cf)
 		if err != nil {
 			clog.Errorf(ctx, "Error installing Windows updates (attempt %d): %v", i, err)
+			time.Sleep(60 * time.Second)
+			continue
 		}
 		if count == 0 {
 			return nil


### PR DESCRIPTION
On a WUA error keep retrying for the full 10 cycles on any errors sleeping 60s between retries.