### PR TITLE
Cleanup policy code, set API retry time to 30s

### DIFF
--- a/agentendpoint/agentendpoint_beta.go
+++ b/agentendpoint/agentendpoint_beta.go
@@ -95,7 +95,8 @@ func (c *BetaClient) LookupEffectiveGuestPolicies(ctx context.Context) (res *age
 	clog.Debugf(ctx, "Calling LookupEffectiveGuestPolicies with request:\n%s", util.PrettyFmt(req))
 	req.InstanceIdToken = token
 
-	if err := retryutil.RetryAPICall(ctx, apiRetrySec*time.Second, "LookupEffectiveGuestPolicies", func() error {
+	// Only retry up to 30s for LookupEffectiveGuestPolicies in order to not hang up local configs.
+	if err := retryutil.RetryAPICall(ctx, 30*time.Second, "LookupEffectiveGuestPolicies", func() error {
 		res, err = c.raw.LookupEffectiveGuestPolicy(ctx, req)
 		if err != nil {
 			return err

--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,6 @@ require (
 	github.com/go-ole/go-ole v1.2.4
 	github.com/golang/mock v1.4.4
 	github.com/google/go-cmp v0.5.2
-	github.com/kylelemons/godebug v1.1.0
 	github.com/tarm/serial v0.0.0-20180830185346-98f6abe2eb07
 	github.com/ulikunitz/xz v0.5.8
 	golang.org/x/crypto v0.0.0-20200820211705-5c72a883971a

--- a/go.sum
+++ b/go.sum
@@ -109,6 +109,7 @@ github.com/golang/mock v1.4.0/go.mod h1:UOMv5ysSaYNkG+OFQykRIcU/QvvxJf3p21QfJ2Bt
 github.com/golang/mock v1.4.1/go.mod h1:UOMv5ysSaYNkG+OFQykRIcU/QvvxJf3p21QfJ2Bt3cw=
 github.com/golang/mock v1.4.3 h1:GV+pQPG/EUUbkh47niozDcADz6go/dUwhVzdUQHIVRw=
 github.com/golang/mock v1.4.3/go.mod h1:UOMv5ysSaYNkG+OFQykRIcU/QvvxJf3p21QfJ2Bt3cw=
+github.com/golang/mock v1.4.4 h1:l75CXGRSwbaYNpl/Z2X1XIIAMSCquvXgpVZDhwEIJsc=
 github.com/golang/mock v1.4.4/go.mod h1:l3mdAwkq5BuhzHwde/uurv3sEJeZMXNpwsxVWU71h+4=
 github.com/golang/protobuf v1.2.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/golang/protobuf v1.3.1/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
@@ -180,8 +181,6 @@ github.com/kr/pty v1.1.1 h1:VkoXIwSboBpnk99O/KFauAEILuNHv5DVFKZMBN/gUgw=
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/text v0.1.0 h1:45sCR5RtlFHMR4UwH9sdQ5TC8v0qDQCHnXt+kaKSTVE=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
-github.com/kylelemons/godebug v1.1.0 h1:RPNrshWIDI6G2gRW9EHilWtl7Z6Sb1BR0xunSBf0SNc=
-github.com/kylelemons/godebug v1.1.0/go.mod h1:9/0rRGxNHcop5bhtWyNeEfOS8JIWk580+fNqagV/RAw=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/prometheus/client_model v0.0.0-20190812154241-14fe0d1b01d4 h1:gQz4mCbXsO+nc9n1hCxHcGA3Zx3Eo+UHZoInFGUIXNM=
@@ -194,8 +193,6 @@ github.com/stretchr/testify v1.4.0 h1:2E4SXV/wtOkTonXsotYi4li6zVWxYlZuYNCXe9XRJy
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
 github.com/tarm/serial v0.0.0-20180830185346-98f6abe2eb07 h1:UyzmZLoiDWMRywV4DUYb9Fbt8uiOSooupjTq10vpvnU=
 github.com/tarm/serial v0.0.0-20180830185346-98f6abe2eb07/go.mod h1:kDXzergiv9cbyO7IOYJZWg1U88JhDg3PB6klq9Hg2pA=
-github.com/ulikunitz/xz v0.5.7 h1:YvTNdFzX6+W5m9msiYg/zpkSURPPtOlzbqYjrFn7Yt4=
-github.com/ulikunitz/xz v0.5.7/go.mod h1:nbz6k7qbPmH4IRqmfOplQw/tblSgqTqBwxkY0oWt/14=
 github.com/ulikunitz/xz v0.5.8 h1:ERv8V6GKqVi23rgu5cj9pVfVzJbOqAY2Ntl88O6c2nQ=
 github.com/ulikunitz/xz v0.5.8/go.mod h1:nbz6k7qbPmH4IRqmfOplQw/tblSgqTqBwxkY0oWt/14=
 github.com/yuin/goldmark v1.1.25 h1:isv+Q6HQAmmL2Ofcmg8QauBmDPlUUnSoNhEcC940Rds=
@@ -218,8 +215,6 @@ golang.org/x/crypto v0.0.0-20190605123033-f99c8df09eb5/go.mod h1:yigFU9vqHzYiE8U
 golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9 h1:psW17arqaxU48Z5kZ0CQnkZWQJsqcURM6tKiBApRjXI=
 golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
-golang.org/x/crypto v0.0.0-20200728195943-123391ffb6de h1:ikNHVSjEfnvz6sxdSPCaPt572qowuyMDMJLLm3Db3ig=
-golang.org/x/crypto v0.0.0-20200728195943-123391ffb6de/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/crypto v0.0.0-20200820211705-5c72a883971a h1:vclmkQCjlDX5OydZ9wv8rBCcS0QyQY66Mpf/7BZbInM=
 golang.org/x/crypto v0.0.0-20200820211705-5c72a883971a/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
@@ -349,8 +344,6 @@ golang.org/x/sys v0.0.0-20200515095857-1151b9dac4a9/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20200523222454-059865788121 h1:rITEj+UZHYC927n8GT97eC3zrpzXdb/voyeOuVKS46o=
 golang.org/x/sys v0.0.0-20200523222454-059865788121/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200803210538-64077c9b5642/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.0.0-20200806125547-5acd03effb82 h1:6cBnXxYO+CiRVrChvCosSv7magqTPbyAgz1M8iOv5wM=
-golang.org/x/sys v0.0.0-20200806125547-5acd03effb82/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200824131525-c12d262b63d8 h1:AvbQYmiaaaza3cW3QXRyPo5kYgpFIzOAfeAAN7m3qQ4=
 golang.org/x/sys v0.0.0-20200824131525-c12d262b63d8/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/text v0.0.0-20170915032832-14c0d48ead0c/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
@@ -490,8 +483,6 @@ google.golang.org/genproto v0.0.0-20200618031413-b414f8b61790/go.mod h1:jDfRM7Fc
 google.golang.org/genproto v0.0.0-20200729003335-053ba62fc06f h1:ohwtWcCwB/fZUxh/vjazHorYmBnua3NmY3CAjwC7mEA=
 google.golang.org/genproto v0.0.0-20200729003335-053ba62fc06f/go.mod h1:FWY/as6DDZQgahTzZj3fqbO1CbirC29ZNUFHwi0/+no=
 google.golang.org/genproto v0.0.0-20200804131852-c06518451d9c/go.mod h1:FWY/as6DDZQgahTzZj3fqbO1CbirC29ZNUFHwi0/+no=
-google.golang.org/genproto v0.0.0-20200806141610-86f49bd18e98 h1:LCO0fg4kb6WwkXQXRQQgUYsFeFb5taTX5WAx5O/Vt28=
-google.golang.org/genproto v0.0.0-20200806141610-86f49bd18e98/go.mod h1:FWY/as6DDZQgahTzZj3fqbO1CbirC29ZNUFHwi0/+no=
 google.golang.org/genproto v0.0.0-20200815001618-f69a88009b70 h1:wboULUXGF3c5qdUnKp+6gLAccE6PRpa/czkYvQ4UXv8=
 google.golang.org/genproto v0.0.0-20200815001618-f69a88009b70/go.mod h1:FWY/as6DDZQgahTzZj3fqbO1CbirC29ZNUFHwi0/+no=
 google.golang.org/grpc v1.19.0/go.mod h1:mqu4LbDTu4XGKhr4mRzUsmM4RtVoemTSY81AxZiDr8c=

--- a/packages/zypper_test.go
+++ b/packages/zypper_test.go
@@ -23,11 +23,6 @@ import (
 
 	utilmocks "github.com/GoogleCloudPlatform/osconfig/util/mocks"
 	"github.com/golang/mock/gomock"
-	"github.com/kylelemons/godebug/pretty"
-)
-
-var (
-	dump = &pretty.Config{IncludeUnexported: true}
 )
 
 func TestZypperInstalls(t *testing.T) {

--- a/policies/googet.go
+++ b/policies/googet.go
@@ -47,16 +47,25 @@ func googetRepositories(ctx context.Context, repos []*agentendpointpb.GooReposit
 }
 
 func googetChanges(ctx context.Context, gooInstalled, gooRemoved, gooUpdated []*agentendpointpb.Package) error {
+	var err error
 	var errs []string
 
-	installed, err := packages.InstalledGooGetPackages(ctx)
-	if err != nil {
-		return err
+	var installed []packages.PkgInfo
+	if len(gooInstalled) > 0 || len(gooUpdated) > 0 || len(gooRemoved) > 0 {
+		installed, err = packages.InstalledGooGetPackages(ctx)
+		if err != nil {
+			return err
+		}
 	}
-	updates, err := packages.GooGetUpdates(ctx)
-	if err != nil {
-		return err
+
+	var updates []packages.PkgInfo
+	if len(gooUpdated) > 0 {
+		updates, err = packages.GooGetUpdates(ctx)
+		if err != nil {
+			return err
+		}
 	}
+
 	changes := getNecessaryChanges(installed, updates, gooInstalled, gooRemoved, gooUpdated)
 
 	if changes.packagesToInstall != nil {

--- a/policies/policies.go
+++ b/policies/policies.go
@@ -22,7 +22,6 @@ import (
 	"hash"
 	"io"
 	"os"
-	"path/filepath"
 	"time"
 
 	"github.com/GoogleCloudPlatform/osconfig/agentendpoint"
@@ -168,12 +167,6 @@ func setConfig(ctx context.Context, egp *agentendpointpb.EffectiveGuestPolicy) {
 	}
 
 	if packages.GooGetExists {
-		if _, err := os.Stat(config.GooGetRepoFilePath()); os.IsNotExist(err) {
-			clog.Debugf(ctx, "Repo file does not exist, will create one...")
-			if err := os.MkdirAll(filepath.Dir(config.GooGetRepoFilePath()), 07550); err != nil {
-				clog.Errorf(ctx, "Error creating repo file: %v", err)
-			}
-		}
 		if err := googetRepositories(ctx, gooRepos, config.GooGetRepoFilePath()); err != nil {
 			clog.Errorf(ctx, "Error writing googet repo file: %v", err)
 		}
@@ -185,12 +178,6 @@ func setConfig(ctx context.Context, egp *agentendpointpb.EffectiveGuestPolicy) {
 	}
 
 	if packages.AptExists {
-		if _, err := os.Stat(config.AptRepoFilePath()); os.IsNotExist(err) {
-			clog.Debugf(ctx, "Repo file does not exist, will create one...")
-			if err := os.MkdirAll(filepath.Dir(config.AptRepoFilePath()), 07550); err != nil {
-				clog.Errorf(ctx, "Error creating repo file: %v", err)
-			}
-		}
 		if err := aptRepositories(ctx, aptRepos, config.AptRepoFilePath()); err != nil {
 			clog.Errorf(ctx, "Error writing apt repo file: %v", err)
 		}
@@ -202,12 +189,6 @@ func setConfig(ctx context.Context, egp *agentendpointpb.EffectiveGuestPolicy) {
 	}
 
 	if packages.YumExists {
-		if _, err := os.Stat(config.YumRepoFilePath()); os.IsNotExist(err) {
-			clog.Debugf(ctx, "Repo file does not exist, will create one...")
-			if err := os.MkdirAll(filepath.Dir(config.YumRepoFilePath()), 07550); err != nil {
-				clog.Errorf(ctx, "Error creating repo file: %v", err)
-			}
-		}
 		if err := yumRepositories(ctx, yumRepos, config.YumRepoFilePath()); err != nil {
 			clog.Errorf(ctx, "Error writing yum repo file: %v", err)
 		}
@@ -219,12 +200,6 @@ func setConfig(ctx context.Context, egp *agentendpointpb.EffectiveGuestPolicy) {
 	}
 
 	if packages.ZypperExists {
-		if _, err := os.Stat(config.ZypperRepoFilePath()); os.IsNotExist(err) {
-			clog.Debugf(ctx, "Repo file does not exist, will create one...")
-			if err := os.MkdirAll(filepath.Dir(config.ZypperRepoFilePath()), 07550); err != nil {
-				clog.Errorf(ctx, "Error creating repo file: %v", err)
-			}
-		}
 		if err := zypperRepositories(ctx, zypperRepos, config.ZypperRepoFilePath()); err != nil {
 			clog.Errorf(ctx, "Error writing zypper repo file: %v", err)
 		}

--- a/policies/yum.go
+++ b/policies/yum.go
@@ -68,16 +68,25 @@ func yumRepositories(ctx context.Context, repos []*agentendpointpb.YumRepository
 }
 
 func yumChanges(ctx context.Context, yumInstalled, yumRemoved, yumUpdated []*agentendpointpb.Package) error {
+	var err error
 	var errs []string
 
-	installed, err := packages.InstalledRPMPackages(ctx)
-	if err != nil {
-		return err
+	var installed []packages.PkgInfo
+	if len(yumInstalled) > 0 || len(yumUpdated) > 0 || len(yumRemoved) > 0 {
+		installed, err = packages.InstalledRPMPackages(ctx)
+		if err != nil {
+			return err
+		}
 	}
-	updates, err := packages.YumUpdates(ctx)
-	if err != nil {
-		return err
+
+	var updates []packages.PkgInfo
+	if len(yumUpdated) > 0 {
+		updates, err = packages.YumUpdates(ctx)
+		if err != nil {
+			return err
+		}
 	}
+
 	changes := getNecessaryChanges(installed, updates, yumInstalled, yumRemoved, yumUpdated)
 
 	if changes.packagesToInstall != nil {

--- a/policies/zypper.go
+++ b/policies/zypper.go
@@ -68,16 +68,25 @@ func zypperRepositories(ctx context.Context, repos []*agentendpointpb.ZypperRepo
 }
 
 func zypperChanges(ctx context.Context, zypperInstalled, zypperRemoved, zypperUpdated []*agentendpointpb.Package) error {
+	var err error
 	var errs []string
 
-	installed, err := packages.InstalledRPMPackages(ctx)
-	if err != nil {
-		return err
+	var installed []packages.PkgInfo
+	if len(zypperInstalled) > 0 || len(zypperUpdated) > 0 || len(zypperRemoved) > 0 {
+		installed, err = packages.InstalledRPMPackages(ctx)
+		if err != nil {
+			return err
+		}
 	}
-	updates, err := packages.ZypperUpdates(ctx)
-	if err != nil {
-		return err
+
+	var updates []packages.PkgInfo
+	if len(zypperUpdated) > 0 {
+		updates, err = packages.ZypperUpdates(ctx)
+		if err != nil {
+			return err
+		}
 	}
+
 	changes := getNecessaryChanges(installed, updates, zypperInstalled, zypperRemoved, zypperUpdated)
 
 	if changes.packagesToInstall != nil {


### PR DESCRIPTION
Set LookupEffectiveGuestPolicies retry time to 30s, this allows local configs to still run in a timely manner even if there is some service issue. Since GuestPolciies run every 10min they should get reapplied pretty soon anyway.
Cleaned up unneeded step of creating a blank repo file as the *Repositories functions will do that themselves
For GuestPolicies only gather package inventory when needed