### PR TITLE
Set RPM package gpgcheck=0 until osconfig allows API control.

### DIFF
--- a/policies/yum.go
+++ b/policies/yum.go
@@ -35,14 +35,14 @@ func yumRepositories(ctx context.Context, repos []*agentendpointpb.YumRepository
 		name=repo1-name
 		baseurl=https://repo1-url
 		enabled=1
-		gpgcheck=1
+		gpgcheck=0
 		repo_gpgcheck=1
 		gpgkey=http://repo1-url/gpg
 		[repo2]
 		display_name=repo2-name
 		baseurl=https://repo2-url
 		enabled=1
-		gpgcheck=1
+		gpgcheck=0
 		repo_gpgcheck=1
 	*/
 	var buf bytes.Buffer
@@ -55,7 +55,7 @@ func yumRepositories(ctx context.Context, repos []*agentendpointpb.YumRepository
 			buf.WriteString(fmt.Sprintf("name=%s\n", repo.DisplayName))
 		}
 		buf.WriteString(fmt.Sprintf("baseurl=%s\n", repo.BaseUrl))
-		buf.WriteString("enabled=1\ngpgcheck=1\nrepo_gpgcheck=1\n")
+		buf.WriteString("enabled=1\ngpgcheck=0\nrepo_gpgcheck=1\n")
 		if len(repo.GpgKeys) > 0 {
 			buf.WriteString(fmt.Sprintf("gpgkey=%s\n", repo.GpgKeys[0]))
 			for _, k := range repo.GpgKeys[1:] {

--- a/policies/yum_test.go
+++ b/policies/yum_test.go
@@ -57,7 +57,7 @@ func TestYumRepositories(t *testing.T) {
 			[]*agentendpointpb.YumRepository{
 				{BaseUrl: "http://repo1-url/", Id: "id"},
 			},
-			"# Repo file managed by Google OSConfig agent\n\n[id]\nname=id\nbaseurl=http://repo1-url/\nenabled=1\ngpgcheck=1\nrepo_gpgcheck=1\n",
+			"# Repo file managed by Google OSConfig agent\n\n[id]\nname=id\nbaseurl=http://repo1-url/\nenabled=1\ngpgcheck=0\nrepo_gpgcheck=1\n",
 		},
 		{
 			"2 repos",
@@ -65,7 +65,7 @@ func TestYumRepositories(t *testing.T) {
 				{BaseUrl: "http://repo1-url/", Id: "id1", DisplayName: "displayName1", GpgKeys: []string{"https://url/key"}},
 				{BaseUrl: "http://repo1-url/", Id: "id2", DisplayName: "displayName2", GpgKeys: []string{"https://url/key1", "https://url/key2"}},
 			},
-			"# Repo file managed by Google OSConfig agent\n\n[id1]\nname=displayName1\nbaseurl=http://repo1-url/\nenabled=1\ngpgcheck=1\nrepo_gpgcheck=1\ngpgkey=https://url/key\n\n[id2]\nname=displayName2\nbaseurl=http://repo1-url/\nenabled=1\ngpgcheck=1\nrepo_gpgcheck=1\ngpgkey=https://url/key1\n       https://url/key2\n",
+			"# Repo file managed by Google OSConfig agent\n\n[id1]\nname=displayName1\nbaseurl=http://repo1-url/\nenabled=1\ngpgcheck=0\nrepo_gpgcheck=1\ngpgkey=https://url/key\n\n[id2]\nname=displayName2\nbaseurl=http://repo1-url/\nenabled=1\ngpgcheck=0\nrepo_gpgcheck=1\ngpgkey=https://url/key1\n       https://url/key2\n",
 		},
 	}
 

--- a/policies/zypper.go
+++ b/policies/zypper.go
@@ -35,14 +35,14 @@ func zypperRepositories(ctx context.Context, repos []*agentendpointpb.ZypperRepo
 		name=repo1-name
 		baseurl=https://repo1-url
 		enabled=1
-		gpgcheck=1
+		gpgcheck=0
 		repo_gpgcheck=1
 		gpgkey=http://repo1-url/gpg
 		[repo2]
 		display_name=repo2-name
 		baseurl=https://repo2-url
 		enabled=1
-		gpgcheck=1
+		gpgcheck=0
 		repo_gpgcheck=1
 	*/
 	var buf bytes.Buffer
@@ -55,7 +55,7 @@ func zypperRepositories(ctx context.Context, repos []*agentendpointpb.ZypperRepo
 			buf.WriteString(fmt.Sprintf("name=%s\n", repo.DisplayName))
 		}
 		buf.WriteString(fmt.Sprintf("baseurl=%s\n", repo.BaseUrl))
-		buf.WriteString("enabled=1\ngpgcheck=1\nrepo_gpgcheck=1\n")
+		buf.WriteString("enabled=1\ngpgcheck=0\nrepo_gpgcheck=1\n")
 		if len(repo.GpgKeys) > 0 {
 			buf.WriteString(fmt.Sprintf("gpgkey=%s\n", repo.GpgKeys[0]))
 			for _, k := range repo.GpgKeys[1:] {

--- a/policies/zypper_test.go
+++ b/policies/zypper_test.go
@@ -57,7 +57,7 @@ func TestZypperRepositories(t *testing.T) {
 			[]*agentendpointpb.ZypperRepository{
 				{BaseUrl: "http://repo1-url/", Id: "id"},
 			},
-			"# Repo file managed by Google OSConfig agent\n\n[id]\nname=id\nbaseurl=http://repo1-url/\nenabled=1\ngpgcheck=1\nrepo_gpgcheck=1\n",
+			"# Repo file managed by Google OSConfig agent\n\n[id]\nname=id\nbaseurl=http://repo1-url/\nenabled=1\ngpgcheck=0\nrepo_gpgcheck=1\n",
 		},
 		{
 			"2 repos",
@@ -65,7 +65,7 @@ func TestZypperRepositories(t *testing.T) {
 				{BaseUrl: "http://repo1-url/", Id: "id1", DisplayName: "displayName1", GpgKeys: []string{"https://url/key"}},
 				{BaseUrl: "http://repo1-url/", Id: "id2", DisplayName: "displayName2", GpgKeys: []string{"https://url/key1", "https://url/key2"}},
 			},
-			"# Repo file managed by Google OSConfig agent\n\n[id1]\nname=displayName1\nbaseurl=http://repo1-url/\nenabled=1\ngpgcheck=1\nrepo_gpgcheck=1\ngpgkey=https://url/key\n\n[id2]\nname=displayName2\nbaseurl=http://repo1-url/\nenabled=1\ngpgcheck=1\nrepo_gpgcheck=1\ngpgkey=https://url/key1\n       https://url/key2\n",
+			"# Repo file managed by Google OSConfig agent\n\n[id1]\nname=displayName1\nbaseurl=http://repo1-url/\nenabled=1\ngpgcheck=0\nrepo_gpgcheck=1\ngpgkey=https://url/key\n\n[id2]\nname=displayName2\nbaseurl=http://repo1-url/\nenabled=1\ngpgcheck=0\nrepo_gpgcheck=1\ngpgkey=https://url/key1\n       https://url/key2\n",
 		},
 	}
 


### PR DESCRIPTION
Right now the barrier to entry for RPM-based distros is higher than DEB-based ones in osconfig, as both package and repository signing are enabled by default for RPM-based distros, while only repository signing is enabled by default for DEB-based ones[1]. Leaving individual RPM GPG signing disabled IMO is a more reasonable default, at least until OSConfig allows this option to be set via the API. Repository GPG signing remains as-is.

[1] https://blog.packagecloud.io/eng/2014/10/28/howto-gpg-sign-verify-deb-packages-apt-repositories/