### PR TITLE
add initial e2e tests for inventory reporting

### DIFF
--- a/e2e_tests/go.sum
+++ b/e2e_tests/go.sum
@@ -65,15 +65,11 @@ github.com/GoogleCloudPlatform/compute-image-tools/daisy v0.0.0-20200114232830-6
 github.com/GoogleCloudPlatform/compute-image-tools/daisy v0.0.0-20200214212030-cdab85f8f241/go.mod h1:6xFWwnAALibczYyaAbXDaQSRIyqZ+A/uzJeGcr3kvcQ=
 github.com/GoogleCloudPlatform/compute-image-tools/daisy v0.0.0-20200406182414-bf9021434372/go.mod h1:OMlTSl6FloIMDs+kZxW4B5fVlj4RudzYDvKEQ+sH15U=
 github.com/GoogleCloudPlatform/compute-image-tools/daisy v0.0.0-20200721213208-00ba2b996712/go.mod h1:OMlTSl6FloIMDs+kZxW4B5fVlj4RudzYDvKEQ+sH15U=
-github.com/GoogleCloudPlatform/compute-image-tools/daisy v0.0.0-20200723151410-725b43e42fe7 h1:p7Amym84L7kpxIJbxvpIObiCIQaS/JU6osl17T3O650=
-github.com/GoogleCloudPlatform/compute-image-tools/daisy v0.0.0-20200723151410-725b43e42fe7/go.mod h1:OMlTSl6FloIMDs+kZxW4B5fVlj4RudzYDvKEQ+sH15U=
 github.com/GoogleCloudPlatform/compute-image-tools/daisy v0.0.0-20200805192452-5b81051e3e71/go.mod h1:OMlTSl6FloIMDs+kZxW4B5fVlj4RudzYDvKEQ+sH15U=
 github.com/GoogleCloudPlatform/compute-image-tools/daisy v0.0.0-20200806162442-cbe93c2f2b04 h1:bREkuvb9ZJYMestC3GMfPGvYSDpPU52jf/234EqnX6A=
 github.com/GoogleCloudPlatform/compute-image-tools/daisy v0.0.0-20200806162442-cbe93c2f2b04/go.mod h1:OMlTSl6FloIMDs+kZxW4B5fVlj4RudzYDvKEQ+sH15U=
 github.com/GoogleCloudPlatform/compute-image-tools/go/e2e_test_utils v0.0.0-20200114232830-6d2d59acb179/go.mod h1:2hxlZPfWalIdOXnzbPATwW+Rs7FMMNWD5QnHDE49QZA=
 github.com/GoogleCloudPlatform/compute-image-tools/go/e2e_test_utils v0.0.0-20200128181915-c0775e429077/go.mod h1:2hxlZPfWalIdOXnzbPATwW+Rs7FMMNWD5QnHDE49QZA=
-github.com/GoogleCloudPlatform/compute-image-tools/go/e2e_test_utils v0.0.0-20200723151410-725b43e42fe7 h1:blSsMaIlRTW28RgXBwY39PVP+ku071KtvNwg1npfU9Q=
-github.com/GoogleCloudPlatform/compute-image-tools/go/e2e_test_utils v0.0.0-20200723151410-725b43e42fe7/go.mod h1:2hxlZPfWalIdOXnzbPATwW+Rs7FMMNWD5QnHDE49QZA=
 github.com/GoogleCloudPlatform/compute-image-tools/go/e2e_test_utils v0.0.0-20200806162442-cbe93c2f2b04 h1:yLzl1dXe8RaxfD1DsYaMVEH2MTCK4xx2CzVsh8Nn/pM=
 github.com/GoogleCloudPlatform/compute-image-tools/go/e2e_test_utils v0.0.0-20200806162442-cbe93c2f2b04/go.mod h1:93wnO6RFVF68ebG+Lfz/o4ial0dnufRnFznlvp8KUdM=
 github.com/GoogleCloudPlatform/compute-image-tools/mocks v0.0.0-20200206014411-426b6301f679/go.mod h1:zDumkSJOQQ31fB0OWcg5h5zlVhU92LvYNXkpGQh2jz8=
@@ -85,8 +81,6 @@ github.com/GoogleCloudPlatform/osconfig v0.0.0-20200113163233-44035fcbfdd9/go.mo
 github.com/GoogleCloudPlatform/osconfig v0.0.0-20200115000133-a7c6fc334759/go.mod h1:nljBbLz4lHbiK1P6TwNhW0tanjfrRMYgtvLnLTIxygk=
 github.com/GoogleCloudPlatform/osconfig v0.0.0-20200211005319-080372593330/go.mod h1:nT1RIv+FL9qTdvhWYUd85m6Vpcy2fi7ZpLwS6Yuflb0=
 github.com/GoogleCloudPlatform/osconfig v0.0.0-20200721210327-c9ab1b6aeb02/go.mod h1:nfw/IdEPsQueLEhAFL9anXqtORP0hQoCF0P1sd+X398=
-github.com/GoogleCloudPlatform/osconfig v0.0.0-20200722232728-c3c97bc79cc2 h1:JItMdOwmNT8U18WqkKJfdDOIdjVws+J6xuEGiPrfDME=
-github.com/GoogleCloudPlatform/osconfig v0.0.0-20200722232728-c3c97bc79cc2/go.mod h1:ydaYKK5Rf5EzdjmlxUe8m7/kcvP9LO65N9w0YGAgJv8=
 github.com/GoogleCloudPlatform/osconfig v0.0.0-20200805223003-f44a6489e0f4 h1:BrwCk13QXvcAFJns0/FQkeQQ65Ed3SVWxSIr1o2+YFs=
 github.com/GoogleCloudPlatform/osconfig v0.0.0-20200805223003-f44a6489e0f4/go.mod h1:sgtF91LRn9rYWV9OTLSW7ZSAxXctyKWx7tNTNKk4+hA=
 github.com/GoogleCloudPlatform/osconfig/e2e_tests v0.0.0-20200128231920-2ddeb2407498/go.mod h1:YHx1ltdJOZNKtDNUBBIwzyiq4Kh4EwQWm1NOcMEU/OA=
@@ -369,8 +363,6 @@ golang.org/x/sys v0.0.0-20200722175500-76b94024e4b6/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20200803210538-64077c9b5642/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200805065543-0cf7623e9dbd h1:wefLe/3g5tC0FcXw3NneLA5tHgbyouyZlfcSjNfOdgk=
 golang.org/x/sys v0.0.0-20200805065543-0cf7623e9dbd/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.0.0-20200806125547-5acd03effb82 h1:6cBnXxYO+CiRVrChvCosSv7magqTPbyAgz1M8iOv5wM=
-golang.org/x/sys v0.0.0-20200806125547-5acd03effb82/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/text v0.0.0-20170915032832-14c0d48ead0c/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.1-0.20180807135948-17ff2d5776d2/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
@@ -525,8 +517,6 @@ google.golang.org/genproto v0.0.0-20200729003335-053ba62fc06f/go.mod h1:FWY/as6D
 google.golang.org/genproto v0.0.0-20200804131852-c06518451d9c/go.mod h1:FWY/as6DDZQgahTzZj3fqbO1CbirC29ZNUFHwi0/+no=
 google.golang.org/genproto v0.0.0-20200804151602-45615f50871c h1:TQlznJ1HicL4W+4znnmEEyr2A6ncsbY9Il37TcoDWYY=
 google.golang.org/genproto v0.0.0-20200804151602-45615f50871c/go.mod h1:FWY/as6DDZQgahTzZj3fqbO1CbirC29ZNUFHwi0/+no=
-google.golang.org/genproto v0.0.0-20200806141610-86f49bd18e98 h1:LCO0fg4kb6WwkXQXRQQgUYsFeFb5taTX5WAx5O/Vt28=
-google.golang.org/genproto v0.0.0-20200806141610-86f49bd18e98/go.mod h1:FWY/as6DDZQgahTzZj3fqbO1CbirC29ZNUFHwi0/+no=
 google.golang.org/grpc v1.19.0/go.mod h1:mqu4LbDTu4XGKhr4mRzUsmM4RtVoemTSY81AxZiDr8c=
 google.golang.org/grpc v1.20.1/go.mod h1:10oTOabMzJvdu6/UiuZezV6QK5dSlG84ov/aaiqXj38=
 google.golang.org/grpc v1.21.1/go.mod h1:oYelfM1adQP15Ek0mdvEgi9Df8B9CZIaU1084ijfRaM=

--- a/e2e_tests/main.go
+++ b/e2e_tests/main.go
@@ -33,6 +33,7 @@ import (
 	gcpclients "github.com/GoogleCloudPlatform/osconfig/e2e_tests/gcp_clients"
 	"github.com/GoogleCloudPlatform/osconfig/e2e_tests/test_suites/guestpolicies"
 	"github.com/GoogleCloudPlatform/osconfig/e2e_tests/test_suites/inventory"
+	"github.com/GoogleCloudPlatform/osconfig/e2e_tests/test_suites/inventoryreporting"
 	"github.com/GoogleCloudPlatform/osconfig/e2e_tests/test_suites/patch"
 
 	_ "google.golang.org/genproto/googleapis/rpc/errdetails"
@@ -41,6 +42,7 @@ import (
 var testFunctions = []func(context.Context, *sync.WaitGroup, chan *junitxml.TestSuite, *log.Logger, *regexp.Regexp, *regexp.Regexp){
 	guestpolicies.TestSuite,
 	inventory.TestSuite,
+	inventoryreporting.TestSuite,
 	patch.TestSuite,
 }
 

--- a/e2e_tests/test_suites/inventory/inventory.go
+++ b/e2e_tests/test_suites/inventory/inventory.go
@@ -272,10 +272,10 @@ func inventoryTestCase(ctx context.Context, testSetup *inventoryTestSetup, tests
 		return
 	}
 
-	logger.Printf("Running TestCase '%s.%q'", gatherInventoryTest.Classname, gatherInventoryTest.Name)
+	logger.Printf("Running TestCase %q", gatherInventoryTest.Name)
 	ga, ok := runGatherInventoryTest(ctx, testSetup, gatherInventoryTest, &logwg)
 	gatherInventoryTest.Finish(tests)
-	logger.Printf("TestCase '%s.%q' finished", gatherInventoryTest.Classname, gatherInventoryTest.Name)
+	logger.Printf("TestCase %q finished", gatherInventoryTest.Name)
 	if !ok {
 		hostnameTest.WriteFailure("Setup Failure")
 		hostnameTest.Finish(tests)
@@ -298,10 +298,10 @@ func inventoryTestCase(ctx context.Context, testSetup *inventoryTestSetup, tests
 		} else if tc.FilterTestCase(regex) {
 			tc.Finish(tests)
 		} else {
-			logger.Printf("Running TestCase '%q'", tc.Name)
+			logger.Printf("Running TestCase %q", tc.Name)
 			f(ga, testSetup, tc)
 			tc.Finish(tests)
-			logger.Printf("TestCase '%q' finished in %fs", tc.Name, tc.Time)
+			logger.Printf("TestCase %q finished in %fs", tc.Name, tc.Time)
 		}
 	}
 	logwg.Wait()

--- a/e2e_tests/test_suites/inventoryreporting/inventory_reporting.go
+++ b/e2e_tests/test_suites/inventoryreporting/inventory_reporting.go
@@ -1,0 +1,167 @@
+//  Copyright 2020 Google Inc. All Rights Reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
+package inventoryreporting
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"path"
+	"regexp"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/GoogleCloudPlatform/compute-image-tools/go/e2e_test_utils/junitxml"
+	"github.com/GoogleCloudPlatform/osconfig/e2e_tests/compute"
+	"github.com/GoogleCloudPlatform/osconfig/e2e_tests/config"
+	gcpclients "github.com/GoogleCloudPlatform/osconfig/e2e_tests/gcp_clients"
+	testconfig "github.com/GoogleCloudPlatform/osconfig/e2e_tests/test_config"
+	"github.com/GoogleCloudPlatform/osconfig/e2e_tests/utils"
+	api "google.golang.org/api/compute/v1"
+)
+
+const (
+	testSuiteName = "OSInventoryReporting"
+)
+
+// TestSuite is an OSInventoryReporting test suite.
+func TestSuite(ctx context.Context, tswg *sync.WaitGroup, testSuites chan *junitxml.TestSuite, logger *log.Logger, testSuiteRegex, testCaseRegex *regexp.Regexp) {
+	defer tswg.Done()
+
+	if testSuiteRegex != nil && !testSuiteRegex.MatchString(testSuiteName) {
+		return
+	}
+
+	testSuite := junitxml.NewTestSuite(testSuiteName)
+	defer testSuite.Finish(testSuites)
+
+	logger.Printf("Running TestSuite %q", testSuite.Name)
+
+	var wg sync.WaitGroup
+	tests := make(chan *junitxml.TestCase)
+	for _, setup := range headImageTestSetup() {
+		wg.Add(1)
+		go inventoryReportingTestCase(ctx, setup, tests, &wg, logger, testCaseRegex)
+	}
+
+	go func() {
+		wg.Wait()
+		close(tests)
+	}()
+
+	for ret := range tests {
+		testSuite.TestCase = append(testSuite.TestCase, ret)
+	}
+
+	logger.Printf("Finished TestSuite %q", testSuite.Name)
+}
+
+func runInventoryReportingTest(ctx context.Context, testSetup *inventoryTestSetup, testCase *junitxml.TestCase, logwg *sync.WaitGroup) {
+	testCase.Logf("Creating compute client")
+
+	computeClient, err := gcpclients.GetComputeClient()
+	if err != nil {
+		testCase.WriteFailure("Error getting compute client: %v", err)
+		return
+	}
+
+	testSetup.hostname = fmt.Sprintf("inventoryreporting-test-%s-%s", path.Base(testSetup.testName), utils.RandString(5))
+
+	var metadataItems []*api.MetadataItems
+	metadataItems = append(metadataItems, testSetup.startup)
+	metadataItems = append(metadataItems, compute.BuildInstanceMetadataItem("enable-os-inventory", "true"))
+	metadataItems = append(metadataItems, compute.BuildInstanceMetadataItem("osconfig-disabled-features", "tasks,guestpolicies"))
+	metadataItems = append(metadataItems, compute.BuildInstanceMetadataItem("osconfig-enabled-prerelease-features", "inventoryreporting"))
+
+	testProjectConfig := testconfig.GetProject()
+	zone := testProjectConfig.AcquireZone()
+	defer testProjectConfig.ReleaseZone(zone)
+
+	testCase.Logf("Creating instance %q with image %q", testSetup.hostname, testSetup.image)
+	inst, err := utils.CreateComputeInstance(metadataItems, computeClient, testSetup.machineType, testSetup.image, testSetup.hostname, testProjectConfig.TestProjectID, zone, testProjectConfig.ServiceAccountEmail, testProjectConfig.ServiceAccountScopes)
+	if err != nil {
+		testCase.WriteFailure("Error creating instance: %v", err)
+		return
+	}
+	defer inst.Cleanup()
+	defer inst.RecordSerialOutput(ctx, path.Join(*config.OutDir, testSuiteName), 1)
+
+	testCase.Logf("Waiting for agent install to complete")
+	if _, err := inst.WaitForGuestAttributes("osconfig_tests/install_done", 5*time.Second, 10*time.Minute); err != nil {
+		testCase.WriteFailure("Error waiting for osconfig agent install: %v", err)
+		return
+	}
+
+	// Build regexes for verification.
+	positivePatterns := []string{
+		`.*Calling ReportInventory with request.*`,
+		fmt.Sprintf(`.*"hostname":.*"%s".*`, testSetup.hostname),
+		fmt.Sprintf(`.*"short_name":.*"%s".*`, testSetup.shortName),
+		fmt.Sprintf(`.*(%s)+.*`, strings.Join(testSetup.packageType, "|")),
+		`.*Finished task "Report OSInventory".*`,
+	}
+	positiveRegexes, err := compileRegex(positivePatterns)
+	if err != nil {
+		testCase.WriteFailure("Error compiling ReportInventory RPC payload regex: %v", err)
+		return
+	}
+
+	negativePatterns := []string{
+		".*Error reporting inventory.*",
+	}
+	negativeRegexes, err := compileRegex(negativePatterns)
+	if err != nil {
+		testCase.WriteFailure("Error compiling ReportInventory negative regex: %v", err)
+		return
+	}
+
+	// Verify a successful ReportingInventory call.
+	if err := inst.WaitForSerialOutput(positiveRegexes, negativeRegexes, 1, 10*time.Second, testSetup.timeout); err != nil {
+		testCase.WriteFailure("Error verifying a successful ReportInventory call: %v", err)
+		return
+	}
+}
+
+func inventoryReportingTestCase(ctx context.Context, testSetup *inventoryTestSetup, tc chan *junitxml.TestCase, wg *sync.WaitGroup, logger *log.Logger, regex *regexp.Regexp) {
+	defer wg.Done()
+
+	var logwg sync.WaitGroup
+	inventoryTest := junitxml.NewTestCase(testSuiteName, fmt.Sprintf("[Report inventory] [%s]", testSetup.testName))
+
+	if inventoryTest.FilterTestCase(regex) {
+		inventoryTest.Finish(tc)
+		return
+	}
+
+	logger.Printf("Running TestCase %q", inventoryTest.Name)
+	runInventoryReportingTest(ctx, testSetup, inventoryTest, &logwg)
+	inventoryTest.Finish(tc)
+	logger.Printf("TestCase %q finished", inventoryTest.Name)
+
+	logwg.Wait()
+}
+
+func compileRegex(patterns []string) ([]*regexp.Regexp, error) {
+	var regexes []*regexp.Regexp
+	for _, pattern := range patterns {
+		regex, err := regexp.Compile(pattern)
+		if err != nil {
+			return nil, err
+		}
+		regexes = append(regexes, regex)
+	}
+	return regexes, nil
+}

--- a/e2e_tests/test_suites/inventoryreporting/test_setup.go
+++ b/e2e_tests/test_suites/inventoryreporting/test_setup.go
@@ -1,0 +1,131 @@
+//  Copyright 2020 Google Inc. All Rights Reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
+package inventoryreporting
+
+import (
+	"strings"
+	"time"
+
+	"github.com/GoogleCloudPlatform/osconfig/e2e_tests/compute"
+	"github.com/GoogleCloudPlatform/osconfig/e2e_tests/config"
+	"github.com/GoogleCloudPlatform/osconfig/e2e_tests/utils"
+	computeAPI "google.golang.org/api/compute/v1"
+)
+
+type inventoryTestSetup struct {
+	testName    string
+	hostname    string
+	image       string
+	packageType []string
+	shortName   string
+	startup     *computeAPI.MetadataItems
+	machineType string
+	timeout     time.Duration
+}
+
+var (
+	windowsSetup = &inventoryTestSetup{
+		packageType: []string{"googet", "wua", "qfe"},
+		shortName:   "windows",
+
+		startup:     compute.BuildInstanceMetadataItem("windows-startup-script-ps1", utils.InstallOSConfigGooGet()),
+		machineType: "e2-standard-4",
+		timeout:     25 * time.Minute,
+	}
+
+	aptSetup = &inventoryTestSetup{
+		packageType: []string{"deb"},
+		startup:     compute.BuildInstanceMetadataItem("startup-script", utils.InstallOSConfigDeb()),
+		machineType: "e2-standard-2",
+		timeout:     10 * time.Minute,
+	}
+
+	el6Setup = &inventoryTestSetup{
+		packageType: []string{"rpm"},
+		startup:     compute.BuildInstanceMetadataItem("startup-script", utils.InstallOSConfigEL6()),
+		machineType: "e2-standard-2",
+		timeout:     10 * time.Minute,
+	}
+
+	el7Setup = &inventoryTestSetup{
+		packageType: []string{"rpm"},
+		startup:     compute.BuildInstanceMetadataItem("startup-script", utils.InstallOSConfigEL7()),
+		machineType: "e2-standard-2",
+		timeout:     10 * time.Minute,
+	}
+
+	el8Setup = &inventoryTestSetup{
+		packageType: []string{"rpm"},
+		startup:     compute.BuildInstanceMetadataItem("startup-script", utils.InstallOSConfigEL8()),
+		machineType: "e2-standard-2",
+		timeout:     10 * time.Minute,
+	}
+
+	suseSetup = &inventoryTestSetup{
+		packageType: []string{"zypper"},
+		startup:     compute.BuildInstanceMetadataItem("startup-script", utils.InstallOSConfigSUSE()),
+		machineType: "e2-standard-2",
+		timeout:     15 * time.Minute,
+	}
+
+	cosSetup = &inventoryTestSetup{
+		startup:     compute.BuildInstanceMetadataItem("startup-script", utils.CurlPost),
+		machineType: "e2-standard-2",
+		timeout:     5 * time.Minute,
+	}
+)
+
+func headImageTestSetup() (setup []*inventoryTestSetup) {
+	// This maps a specific inventoryTestSetup to test setup names and associated images.
+	headTestSetupMapping := map[*inventoryTestSetup]map[string]string{
+		windowsSetup: utils.HeadWindowsImages,
+		el6Setup:     utils.HeadEL6Images,
+		el7Setup:     utils.HeadEL7Images,
+		el8Setup:     utils.HeadEL8Images,
+		aptSetup:     utils.HeadAptImages,
+		suseSetup:    utils.HeadSUSEImages,
+	}
+
+	// TODO: remove this hack and setup specific test suites for each test type.
+	// This ensures we only run cos tests on the "head image" tests.
+	if config.AgentRepo() == "" {
+		headTestSetupMapping[cosSetup] = utils.HeadCOSImages
+	}
+
+	for s, m := range headTestSetupMapping {
+		for name, image := range m {
+			new := inventoryTestSetup(*s)
+			new.testName = name
+			new.image = image
+			if strings.Contains(name, "centos") {
+				new.shortName = "centos"
+			} else if strings.Contains(name, "rhel") {
+				new.shortName = "rhel"
+			} else if strings.Contains(name, "debian") {
+				new.shortName = "debian"
+			} else if strings.Contains(name, "ubuntu") {
+				new.shortName = "ubuntu"
+			} else if strings.Contains(name, "sles") {
+				new.shortName = "sles"
+			} else if strings.Contains(name, "opensuse-leap") {
+				new.shortName = "opensuse-leap"
+			} else if strings.Contains(name, "cos") {
+				new.shortName = "cos"
+			}
+			setup = append(setup, &new)
+		}
+	}
+	return
+}

--- a/go.sum
+++ b/go.sum
@@ -448,6 +448,7 @@ golang.org/x/tools v0.0.0-20200817023811-d00afeaade8f h1:33yHANSyO/TeglgY9rBhUpX
 golang.org/x/tools v0.0.0-20200817023811-d00afeaade8f/go.mod h1:njjCfa9FT2d7l9Bc6FUM5FLjQPp3cFF28FI3qnDFljA=
 golang.org/x/tools v0.0.0-20200825202427-b303f430e36d/go.mod h1:njjCfa9FT2d7l9Bc6FUM5FLjQPp3cFF28FI3qnDFljA=
 golang.org/x/tools v0.0.0-20200904185747-39188db58858/go.mod h1:Cj7w3i3Rnn0Xh82ur9kSqwfTHTeVxaDqrfMjpcNT6bE=
+golang.org/x/tools v0.0.0-20200929161345-d7fc70abf50f h1:18s2P7JILnVhIF2+ZtGJQ9czV5bvTsb13/UGtNPDbjA=
 golang.org/x/tools v0.0.0-20200929161345-d7fc70abf50f/go.mod h1:z6u4i615ZeAfBE4XtMziQW1fSVJXACjjbWkB/mvPzlU=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=


### PR DESCRIPTION
Created a new test suite for inventory reporting. Test case does basic validations on the corresponding RPC invocation and its payload. Test setup was branched from the inventory test suite.

The WaitForSerialOutput verification function was referenced from https://github.com/GoogleCloudPlatform/osconfig/commit/9a3f7f3c83544dba6fbf4ecb0b6f1be6ad2dc693#diff-c54902af2d84c9ff1ed5525e24a7e3f3R52 and modified to support a list of regular expressions as one of the inputs.

/hold Waiting for the backend RPC visibility issue to be fixed.
/assign @adjackura @ryanwe 
/woof