### PR TITLE
Make inventory WUAUpdates call spawn a new process, retry on metadata unmarshal error

### DIFF
--- a/agentendpoint/inventory.go
+++ b/agentendpoint/inventory.go
@@ -100,8 +100,11 @@ func formatInventory(ctx context.Context, state *inventory.InstanceInventory) *a
 	return &agentendpointpb.Inventory{OsInfo: osInfo, InstalledPackages: installedPackages, AvailablePackages: availablePackages}
 }
 
-func formatPackages(ctx context.Context, packages packages.Packages, shortName string) []*agentendpointpb.Inventory_SoftwarePackage {
+func formatPackages(ctx context.Context, packages *packages.Packages, shortName string) []*agentendpointpb.Inventory_SoftwarePackage {
 	var softwarePackages []*agentendpointpb.Inventory_SoftwarePackage
+	if packages == nil {
+		return softwarePackages
+	}
 	if packages.Apt != nil {
 		for _, pkg := range packages.Apt {
 			softwarePackages = append(softwarePackages, &agentendpointpb.Inventory_SoftwarePackage{

--- a/agentendpoint/inventory.go
+++ b/agentendpoint/inventory.go
@@ -47,10 +47,13 @@ func write(ctx context.Context, state *inventory.InstanceInventory, url string) 
 			if err := attributes.PostAttribute(u, strings.NewReader(f.String())); err != nil {
 				clog.Errorf(ctx, "postAttribute error: %v", err)
 			}
-		case reflect.Struct:
-			clog.Debugf(ctx, "postAttributeCompressed %s: %+v", u, f)
-			if err := attributes.PostAttributeCompressed(u, f.Interface()); err != nil {
-				clog.Errorf(ctx, "postAttributeCompressed error: %v", err)
+		case reflect.Ptr:
+			switch reflect.Indirect(f).Kind() {
+			case reflect.Struct:
+				clog.Debugf(ctx, "postAttributeCompressed %s: %+v", u, f)
+				if err := attributes.PostAttributeCompressed(u, f.Interface()); err != nil {
+					clog.Errorf(ctx, "postAttributeCompressed error: %v", err)
+				}
 			}
 		}
 	}

--- a/agentendpoint/inventory.go
+++ b/agentendpoint/inventory.go
@@ -256,7 +256,7 @@ func formatWUAPackage(pkg packages.WUAPackage) *agentendpointpb.Inventory_Softwa
 func formatQFEPackage(ctx context.Context, pkg packages.QFEPackage) *agentendpointpb.Inventory_SoftwarePackage_QfePackage {
 	installedTime, err := time.Parse("1/2/2006", pkg.InstalledOn)
 	if err != nil {
-		clog.Errorf(ctx, "Error parsing QFE InstalledOn date: %v", err)
+		clog.Warningf(ctx, "Error parsing QFE InstalledOn date: %v", err)
 	}
 
 	return &agentendpointpb.Inventory_SoftwarePackage_QfePackage{

--- a/agentendpoint/inventory_test.go
+++ b/agentendpoint/inventory_test.go
@@ -83,7 +83,7 @@ func generateInventoryState(shortName string) *inventory.InstanceInventory {
 		KernelVersion:        "KernelVersion",
 		KernelRelease:        "KernelRelease",
 		OSConfigAgentVersion: "OSConfigAgentVersion",
-		InstalledPackages: packages.Packages{
+		InstalledPackages: &packages.Packages{
 			Yum:           []packages.PkgInfo{{Name: "YumInstalledPkg", Arch: "Arch", Version: "Version"}},
 			Rpm:           []packages.PkgInfo{{Name: "RpmInstalledPkg", Arch: "Arch", Version: "Version"}},
 			Apt:           []packages.PkgInfo{{Name: "AptInstalledPkg", Arch: "Arch", Version: "Version"}},
@@ -106,7 +106,7 @@ func generateInventoryState(shortName string) *inventory.InstanceInventory {
 				LastDeploymentChangeTime: time.Date(2020, time.November, 10, 23, 0, 0, 0, time.UTC)}},
 			QFE: []packages.QFEPackage{{Caption: "QFEInstalled", Description: "Description", HotFixID: "HotFixID", InstalledOn: "9/1/2020"}},
 		},
-		PackageUpdates: packages.Packages{
+		PackageUpdates: &packages.Packages{
 			Yum:           []packages.PkgInfo{{Name: "YumPkgUpdate", Arch: "Arch", Version: "Version"}},
 			Rpm:           []packages.PkgInfo{{Name: "RpmPkgUpdate", Arch: "Arch", Version: "Version"}},
 			Apt:           []packages.PkgInfo{{Name: "AptPkgUpdate", Arch: "Arch", Version: "Version"}},
@@ -320,12 +320,12 @@ func TestWrite(t *testing.T) {
 		Architecture:  "Architecture",
 		KernelVersion: "KernelVersion",
 		Version:       "Version",
-		InstalledPackages: packages.Packages{
+		InstalledPackages: &packages.Packages{
 			Yum: []packages.PkgInfo{{Name: "Name", Arch: "Arch", Version: "Version"}},
 			WUA: []packages.WUAPackage{{Title: "Title"}},
 			QFE: []packages.QFEPackage{{HotFixID: "HotFixID"}},
 		},
-		PackageUpdates: packages.Packages{
+		PackageUpdates: &packages.Packages{
 			Apt: []packages.PkgInfo{{Name: "Name", Arch: "Arch", Version: "Version"}},
 		},
 	}

--- a/attributes/attributes.go
+++ b/attributes/attributes.go
@@ -38,6 +38,7 @@ func PostAttribute(url string, value io.Reader) error {
 	if err != nil {
 		return err
 	}
+	defer resp.Body.Close()
 	if resp.StatusCode != http.StatusOK {
 		b, err := ioutil.ReadAll(resp.Body)
 		responseErr := fmt.Sprintf(`received status code %q for request "%s %s"`, resp.Status, req.Method, req.URL.String())

--- a/attributes/attributes_test.go
+++ b/attributes/attributes_test.go
@@ -73,7 +73,7 @@ func TestPostAttributeStatusNotOk(t *testing.T) {
 func TestPostAttributeCompressedhappyCase(t *testing.T) {
 	td := packages.Packages{
 		Apt: []packages.PkgInfo{
-			packages.PkgInfo{
+			{
 				Version: "1.2.3",
 				Name:    "test-package",
 				Arch:    "amd64",

--- a/inventory/inventory.go
+++ b/inventory/inventory.go
@@ -36,8 +36,8 @@ type InstanceInventory struct {
 	KernelVersion        string
 	KernelRelease        string
 	OSConfigAgentVersion string
-	InstalledPackages    packages.Packages
-	PackageUpdates       packages.Packages
+	InstalledPackages    *packages.Packages
+	PackageUpdates       *packages.Packages
 	LastUpdated          string
 }
 

--- a/main.go
+++ b/main.go
@@ -258,6 +258,15 @@ func main() {
 	}
 
 	switch action := flag.Arg(0); action {
+	// wuaupdates just runs the packages.WUAUpdates function and returns it's output
+	// as JSON on stdout. This avoids memmory issues with the WUA api since this is
+	// called often for Windows inventory runs.
+	case "wuaupdates":
+		if err := wuaUpdates(flag.Arg(1)); err != nil {
+			fmt.Fprint(os.Stderr, err)
+			os.Exit(1)
+		}
+		os.Exit(0)
 	case "", "run":
 		runService(ctx)
 	default:

--- a/main.go
+++ b/main.go
@@ -226,6 +226,7 @@ func runServiceLoop(ctx context.Context) {
 					logger.Errorf(err.Error())
 				}
 				client.ReportInventory(ctx)
+				client.Close()
 			})
 		}
 

--- a/main.go
+++ b/main.go
@@ -260,7 +260,7 @@ func main() {
 
 	switch action := flag.Arg(0); action {
 	// wuaupdates just runs the packages.WUAUpdates function and returns it's output
-	// as JSON on stdout. This avoids memmory issues with the WUA api since this is
+	// as JSON on stdout. This avoids memory issues with the WUA api since this is
 	// called often for Windows inventory runs.
 	case "wuaupdates":
 		if err := wuaUpdates(flag.Arg(1)); err != nil {

--- a/main_linux.go
+++ b/main_linux.go
@@ -16,6 +16,7 @@ package main
 
 import (
 	"context"
+	"errors"
 	"os"
 	"path/filepath"
 	"syscall"
@@ -55,4 +56,8 @@ func obtainLock() {
 	}
 
 	deferredFuncs = append(deferredFuncs, func() { syscall.Flock(int(f.Fd()), syscall.LOCK_UN); f.Close(); os.Remove(lockFile) })
+}
+
+func wuaUpdates(_ string) error {
+	return errors.New("wuaUpdates not implemented on linux")
 }

--- a/main_windows.go
+++ b/main_windows.go
@@ -16,13 +16,16 @@ package main
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
+	"fmt"
 	"os"
 	"path/filepath"
 	"syscall"
 	"unsafe"
 
 	"github.com/GoogleCloudPlatform/guest-logging-go/logger"
+	"github.com/GoogleCloudPlatform/osconfig/packages"
 	"golang.org/x/sys/windows"
 	"golang.org/x/sys/windows/svc"
 )
@@ -129,4 +132,17 @@ func runService(ctx context.Context) {
 	if err := svc.Run(serviceName, &service{run: run, ctx: ctx}); err != nil {
 		logger.Fatalf("svc.Run error: %v", err)
 	}
+}
+
+func wuaUpdates(query string) error {
+	updts, err := packages.WUAUpdates(query)
+	if err != nil {
+		return err
+	}
+	data, err := json.Marshal(updts)
+	if err != nil {
+		return err
+	}
+	fmt.Fprint(os.Stdout, string(data))
+	return nil
 }

--- a/packages/packages_linux.go
+++ b/packages/packages_linux.go
@@ -25,7 +25,7 @@ import (
 
 // GetPackageUpdates gets all available package updates from any known
 // installed package manager.
-func GetPackageUpdates(ctx context.Context) (Packages, error) {
+func GetPackageUpdates(ctx context.Context) (*Packages, error) {
 	pkgs := Packages{}
 	var errs []string
 	if AptExists {
@@ -89,12 +89,12 @@ func GetPackageUpdates(ctx context.Context) (Packages, error) {
 	if len(errs) != 0 {
 		err = errors.New(strings.Join(errs, "\n"))
 	}
-	return pkgs, err
+	return &pkgs, err
 }
 
 // GetInstalledPackages gets all installed packages from any known installed
 // package manager.
-func GetInstalledPackages(ctx context.Context) (Packages, error) {
+func GetInstalledPackages(ctx context.Context) (*Packages, error) {
 	pkgs := Packages{}
 	var errs []string
 	if util.Exists(rpmquery) {
@@ -160,5 +160,5 @@ func GetInstalledPackages(ctx context.Context) (Packages, error) {
 	if len(errs) != 0 {
 		err = errors.New(strings.Join(errs, "\n"))
 	}
-	return pkgs, err
+	return &pkgs, err
 }

--- a/packages/packages_windows.go
+++ b/packages/packages_windows.go
@@ -48,7 +48,7 @@ func wuaUpdates(ctx context.Context, query string) ([]WUAPackage, error) {
 
 // GetPackageUpdates gets available package updates GooGet as well as any
 // available updates from Windows Update Agent.
-func GetPackageUpdates(ctx context.Context) (Packages, error) {
+func GetPackageUpdates(ctx context.Context) (*Packages, error) {
 	var pkgs Packages
 	var errs []string
 
@@ -75,12 +75,12 @@ func GetPackageUpdates(ctx context.Context) (Packages, error) {
 	if len(errs) != 0 {
 		err = errors.New(strings.Join(errs, "\n"))
 	}
-	return pkgs, err
+	return &pkgs, err
 }
 
 // GetInstalledPackages gets all installed GooGet packages and Windows updates.
 // Windows updates are read from Windows Update Agent and Win32_QuickFixEngineering.
-func GetInstalledPackages(ctx context.Context) (Packages, error) {
+func GetInstalledPackages(ctx context.Context) (*Packages, error) {
 	var pkgs Packages
 	var errs []string
 
@@ -115,5 +115,5 @@ func GetInstalledPackages(ctx context.Context) (Packages, error) {
 	if len(errs) != 0 {
 		err = errors.New(strings.Join(errs, "\n"))
 	}
-	return pkgs, err
+	return &pkgs, err
 }

--- a/packages/packages_windows.go
+++ b/packages/packages_windows.go
@@ -26,7 +26,7 @@ import (
 	"github.com/GoogleCloudPlatform/osconfig/util"
 )
 
-// In order to work around memmory issues with the WUA library we spawn a
+// In order to work around memory issues with the WUA library we spawn a
 // new process for these inventory queries.
 func wuaUpdates(ctx context.Context, query string) ([]WUAPackage, error) {
 	exe, err := os.Executable()

--- a/packages/packages_windows.go
+++ b/packages/packages_windows.go
@@ -15,13 +15,36 @@ package packages
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
+	"os"
+	"os/exec"
 	"strings"
 
 	"github.com/GoogleCloudPlatform/osconfig/clog"
 	"github.com/GoogleCloudPlatform/osconfig/util"
 )
+
+// In order to work around memmory issues with the WUA library we spawn a
+// new process for these inventory queries.
+func wuaUpdates(ctx context.Context, query string) ([]WUAPackage, error) {
+	exe, err := os.Executable()
+	if err != nil {
+		return nil, err
+	}
+
+	var wua []WUAPackage
+	stdout, stderr, err := runner.Run(ctx, exec.Command(exe, "wuaupdates", query))
+	if err != nil {
+		return nil, fmt.Errorf("error running agent to query for WUA updates, err: %v, stderr: %q ", err, stderr)
+	}
+	if err := json.Unmarshal(stdout, &wua); err != nil {
+		return nil, err
+	}
+
+	return wua, nil
+}
 
 // GetPackageUpdates gets available package updates GooGet as well as any
 // available updates from Windows Update Agent.
@@ -38,9 +61,10 @@ func GetPackageUpdates(ctx context.Context) (Packages, error) {
 			pkgs.GooGet = googet
 		}
 	}
+
 	clog.Debugf(ctx, "Searching for available WUA updates.")
-	if wua, err := WUAUpdates("IsInstalled=0"); err != nil {
-		msg := fmt.Sprintf("error listing available Windows updates: %v", err)
+	if wua, err := wuaUpdates(ctx, "IsInstalled=0"); err != nil {
+		msg := fmt.Sprintf("error listing installed Windows updates: %v", err)
 		clog.Debugf(ctx, "Error: %s", msg)
 		errs = append(errs, msg)
 	} else {
@@ -71,7 +95,7 @@ func GetInstalledPackages(ctx context.Context) (Packages, error) {
 	}
 
 	clog.Debugf(ctx, "Searching for installed WUA updates.")
-	if wua, err := WUAUpdates("IsInstalled=1"); err != nil {
+	if wua, err := wuaUpdates(ctx, "IsInstalled=1"); err != nil {
 		msg := fmt.Sprintf("error listing installed Windows updates: %v", err)
 		clog.Debugf(ctx, "Error: %s", msg)
 		errs = append(errs, msg)

--- a/packages/packages_windows.go
+++ b/packages/packages_windows.go
@@ -63,23 +63,14 @@ func GetPackageUpdates(ctx context.Context) (*Packages, error) {
 	}
 
 	clog.Debugf(ctx, "Searching for available WUA updates.")
-	if wua, err := WUAUpdates("IsInstalled=0"); err != nil {
+
+	if wua, err := wuaUpdates(ctx, "IsInstalled=0"); err != nil {
 		msg := fmt.Sprintf("error listing installed Windows updates: %v", err)
 		clog.Debugf(ctx, "Error: %s", msg)
 		errs = append(errs, msg)
 	} else {
 		pkgs.WUA = wua
 	}
-
-	/*
-		if wua, err := wuaUpdates(ctx, "IsInstalled=0"); err != nil {
-			msg := fmt.Sprintf("error listing installed Windows updates: %v", err)
-			clog.Debugf(ctx, "Error: %s", msg)
-			errs = append(errs, msg)
-		} else {
-			pkgs.WUA = wua
-		}
-	*/
 
 	var err error
 	if len(errs) != 0 {
@@ -105,23 +96,14 @@ func GetInstalledPackages(ctx context.Context) (*Packages, error) {
 	}
 
 	clog.Debugf(ctx, "Searching for installed WUA updates.")
-	if wua, err := WUAUpdates("IsInstalled=1"); err != nil {
+
+	if wua, err := wuaUpdates(ctx, "IsInstalled=1"); err != nil {
 		msg := fmt.Sprintf("error listing installed Windows updates: %v", err)
 		clog.Debugf(ctx, "Error: %s", msg)
 		errs = append(errs, msg)
 	} else {
 		pkgs.WUA = wua
 	}
-
-	/*
-		if wua, err := wuaUpdates(ctx, "IsInstalled=1"); err != nil {
-			msg := fmt.Sprintf("error listing installed Windows updates: %v", err)
-			clog.Debugf(ctx, "Error: %s", msg)
-			errs = append(errs, msg)
-		} else {
-			pkgs.WUA = wua
-		}
-	*/
 
 	if qfe, err := QuickFixEngineering(ctx); err != nil {
 		msg := fmt.Sprintf("error listing installed QuickFixEngineering updates: %v", err)

--- a/packages/packages_windows.go
+++ b/packages/packages_windows.go
@@ -63,13 +63,23 @@ func GetPackageUpdates(ctx context.Context) (*Packages, error) {
 	}
 
 	clog.Debugf(ctx, "Searching for available WUA updates.")
-	if wua, err := wuaUpdates(ctx, "IsInstalled=0"); err != nil {
+	if wua, err := WUAUpdates("IsInstalled=0"); err != nil {
 		msg := fmt.Sprintf("error listing installed Windows updates: %v", err)
 		clog.Debugf(ctx, "Error: %s", msg)
 		errs = append(errs, msg)
 	} else {
 		pkgs.WUA = wua
 	}
+
+	/*
+		if wua, err := wuaUpdates(ctx, "IsInstalled=0"); err != nil {
+			msg := fmt.Sprintf("error listing installed Windows updates: %v", err)
+			clog.Debugf(ctx, "Error: %s", msg)
+			errs = append(errs, msg)
+		} else {
+			pkgs.WUA = wua
+		}
+	*/
 
 	var err error
 	if len(errs) != 0 {
@@ -95,13 +105,23 @@ func GetInstalledPackages(ctx context.Context) (*Packages, error) {
 	}
 
 	clog.Debugf(ctx, "Searching for installed WUA updates.")
-	if wua, err := wuaUpdates(ctx, "IsInstalled=1"); err != nil {
+	if wua, err := WUAUpdates("IsInstalled=1"); err != nil {
 		msg := fmt.Sprintf("error listing installed Windows updates: %v", err)
 		clog.Debugf(ctx, "Error: %s", msg)
 		errs = append(errs, msg)
 	} else {
 		pkgs.WUA = wua
 	}
+
+	/*
+		if wua, err := wuaUpdates(ctx, "IsInstalled=1"); err != nil {
+			msg := fmt.Sprintf("error listing installed Windows updates: %v", err)
+			clog.Debugf(ctx, "Error: %s", msg)
+			errs = append(errs, msg)
+		} else {
+			pkgs.WUA = wua
+		}
+	*/
 
 	if qfe, err := QuickFixEngineering(ctx); err != nil {
 		msg := fmt.Sprintf("error listing installed QuickFixEngineering updates: %v", err)


### PR DESCRIPTION
We have issues with the WUA api leaking memory, this is an issue with the inventory calls because they run so often.  To solve this the list calls for inventory spawn a new instance of the agent to query the api, this is only implemented for inventory calls as patch calls do not run that often before an agent restart and the miniscule memory buildup per run will never be noticed.

Make sure we close clients when done with them.

The metadata unmarshal sometimes returns an error, this most often will be because of a bad send from the metadata server and can just be retried safely to avoid logging this error. (fixes #154)