### PR TITLE
Update test Windows images

### DIFF
--- a/e2e_tests/utils/utils.go
+++ b/e2e_tests/utils/utils.go
@@ -272,9 +272,9 @@ var HeadWindowsImages = map[string]string{
 	"windows-cloud/windows-2016-core":    "projects/windows-cloud/global/images/family/windows-2016-core",
 	"windows-cloud/windows-2019":         "projects/windows-cloud/global/images/family/windows-2019",
 	"windows-cloud/windows-2019-core":    "projects/windows-cloud/global/images/family/windows-2019-core",
-	"windows-cloud/windows-1809-core":    "projects/windows-cloud/global/images/family/windows-1809-core",
 	"windows-cloud/windows-1903-core":    "projects/windows-cloud/global/images/family/windows-1903-core",
 	"windows-cloud/windows-1909-core":    "projects/windows-cloud/global/images/family/windows-1909-core",
+	"windows-cloud/windows-2004-core":    "projects/windows-cloud/global/images/family/windows-2004-core",
 }
 
 // OldWindowsImages is a map of names to image paths for old Windows images.
@@ -285,9 +285,6 @@ var OldWindowsImages = map[string]string{
 	"old/windows-2016-core":    "projects/windows-cloud/global/images/windows-server-2016-dc-core-v20191008",
 	"old/windows-2019":         "projects/windows-cloud/global/images/windows-server-2019-dc-v20191008",
 	"old/windows-2019-core":    "projects/windows-cloud/global/images/windows-server-2019-dc-core-v20191008",
-	"old/windows-1809-core":    "projects/windows-cloud/global/images/windows-server-1809-dc-core-v20191008",
-	"old/windows-1903-core":    "projects/windows-cloud/global/images/windows-server-1903-dc-core-v20191008",
-	"old/windows-1909-core":    "projects/windows-cloud/global/images/windows-server-1909-dc-core-v20191210",
 }
 
 // HeadCOSImages is a map of names to image paths for public COS image families.


### PR DESCRIPTION
Remove EOL 1809 image
Add 2004 image
Remove semiannual images from HEAD tests as they don't add much.