### PR TITLE
Gather inventory 3-5min after agent start

### DIFF
--- a/e2e_tests/test_suites/inventory/inventory.go
+++ b/e2e_tests/test_suites/inventory/inventory.go
@@ -89,7 +89,9 @@ func runGatherInventoryTest(ctx context.Context, testSetup *inventoryTestSetup, 
 
 	var metadataItems []*api.MetadataItems
 	metadataItems = append(metadataItems, testSetup.startup)
-	metadataItems = append(metadataItems, compute.BuildInstanceMetadataItem("enable-os-inventory", "true"))
+	metadataItems = append(metadataItems, compute.BuildInstanceMetadataItem("enable-osconfig", "true"))
+	metadataItems = append(metadataItems, compute.BuildInstanceMetadataItem("osconfig-disabled-features", "tasks,guestpolicies"))
+	metadataItems = append(metadataItems, compute.BuildInstanceMetadataItem("osconfig-poll-interval", "30s"))
 
 	testProjectConfig := testconfig.GetProject()
 	zone := testProjectConfig.AcquireZone()

--- a/e2e_tests/test_suites/inventoryreporting/inventory_reporting.go
+++ b/e2e_tests/test_suites/inventoryreporting/inventory_reporting.go
@@ -82,8 +82,9 @@ func runInventoryReportingTest(ctx context.Context, testSetup *inventoryTestSetu
 
 	var metadataItems []*api.MetadataItems
 	metadataItems = append(metadataItems, testSetup.startup)
-	metadataItems = append(metadataItems, compute.BuildInstanceMetadataItem("enable-os-inventory", "true"))
+	metadataItems = append(metadataItems, compute.BuildInstanceMetadataItem("enable-osconfig", "true"))
 	metadataItems = append(metadataItems, compute.BuildInstanceMetadataItem("osconfig-disabled-features", "tasks,guestpolicies"))
+	metadataItems = append(metadataItems, compute.BuildInstanceMetadataItem("osconfig-poll-interval", "30s"))
 
 	testProjectConfig := testconfig.GetProject()
 	zone := testProjectConfig.AcquireZone()


### PR DESCRIPTION
On agent first start wait somewhere between 3 and 5 minutes before collecting inventory, after that collect inventory as normal.
Update inventory tests to account for this slow inventory start
Make sure we run RegisterAgent before any other actions.