### PR TITLE
Change metadata http client to ignore http proxies

### DIFF
--- a/agentconfig/agentconfig.go
+++ b/agentconfig/agentconfig.go
@@ -94,6 +94,15 @@ var (
 	capabilities = []string{"PATCH_GA", "GUEST_POLICY_BETA"}
 
 	osConfigWatchConfigTimeout = 10 * time.Minute
+
+	defaultClient = &http.Client{
+		Transport: &http.Transport{
+			Dial: (&net.Dialer{
+				Timeout:   2 * time.Second,
+				KeepAlive: 30 * time.Second,
+			}).Dial,
+		},
+	}
 )
 
 type config struct {
@@ -366,7 +375,7 @@ func getMetadata(suffix string) ([]byte, string, error) {
 		return nil, "", err
 	}
 	req.Header.Add("Metadata-Flavor", "Google")
-	resp, err := http.DefaultClient.Do(req)
+	resp, err := defaultClient.Do(req)
 	if err != nil {
 		return nil, "", err
 	}


### PR DESCRIPTION
The default HTTP client includes [Proxy: ProxyFromEnvironment](http://go/godoc/net/http/#RoundTripper). This change makes our http client work the same as it does in the [metadata library](https://github.com/googleapis/google-cloud-go/blob/v0.81.0/compute/metadata/metadata.go#L64-L71).


