### PR TITLE
Config task: only run post check on resources that have already been evaluated

### DIFF
--- a/agentendpoint/config_task_test.go
+++ b/agentendpoint/config_task_test.go
@@ -222,8 +222,8 @@ func TestRunApplyConfig(t *testing.T) {
 	ctx := context.Background()
 	sameStateTimeWindow = 0
 	res := &testResource{}
-	newResource = func(r *agentendpointpb.OSPolicy_Resource) resourceIface {
-		return resourceIface(res)
+	newResource = func(r *agentendpointpb.OSPolicy_Resource) *resource {
+		return &resource{resourceIface: resourceIface(res)}
 	}
 
 	testConfig := &agentendpointpb.ApplyConfigTask{


### PR DESCRIPTION
When any resource is enforced mark all previous resources (for all policies) as needing post check.
With this change any resource that is evaluated AFTER the last resource that was "enforced" the agent will not re check.