### PR TITLE
e2e_tests: move to using inventory api for inventory reporting

### DIFF
--- a/e2e_tests/compute/instance.go
+++ b/e2e_tests/compute/instance.go
@@ -48,7 +48,7 @@ func (i *Instance) Cleanup() {
 // WaitForGuestAttributes waits for guest attribute (queryPath, variableKey) to appear.
 func (i *Instance) WaitForGuestAttributes(queryPath string, interval, timeout time.Duration) ([]*computeApiBeta.GuestAttributesEntry, error) {
 	tick := time.Tick(interval)
-	timedout := time.Tick(timeout)
+	timedout := time.After(timeout)
 	for {
 		select {
 		case <-timedout:
@@ -110,7 +110,7 @@ func (i *Instance) WaitForSerialOutput(positiveRegexes []*regexp.Regexp, negativ
 	var errs int
 	matches := make([]bool, len(positiveRegexes))
 	tick := time.Tick(interval)
-	timedout := time.Tick(timeout)
+	timedout := time.After(timeout)
 	for {
 		select {
 		case <-timedout:


### PR DESCRIPTION
We no longer need to scrape serial output to determine of inventory was reported.