### PR TITLE
e2e_tests: reduce size of instances, use pd-balanced, rerun failed tests once

### DIFF
--- a/e2e_tests/test_suites/guestpolicies/guest_policies.go
+++ b/e2e_tests/test_suites/guestpolicies/guest_policies.go
@@ -213,6 +213,17 @@ func packageManagementTestCase(ctx context.Context, testSetup *guestPolicyTestSe
 	} else {
 		logger.Printf("Running TestCase %q", tc.Name)
 		runTest(ctx, tc, testSetup, logger)
+		if tc.Failure != nil {
+			rerunTC := junitxml.NewTestCase(testSuiteName, tc.Name)
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				logger.Printf("Rerunning TestCase %q", rerunTC.Name)
+				runTest(ctx, rerunTC, testSetup, logger)
+				rerunTC.Finish(tests)
+				logger.Printf("TestCase %q finished in %fs", rerunTC.Name, rerunTC.Time)
+			}()
+		}
 		tc.Finish(tests)
 		logger.Printf("TestCase %q finished in %fs", tc.Name, tc.Time)
 	}

--- a/e2e_tests/test_suites/guestpolicies/guest_policies_test_data.go
+++ b/e2e_tests/test_suites/guestpolicies/guest_policies_test_data.go
@@ -48,7 +48,7 @@ func buildPkgInstallTestSetup(name, image, pkgManager, key string) *guestPolicyT
 	assertTimeout := 120 * time.Second
 	testName := packageInstallFunction
 	packageName := "ed"
-	machineType := "e2-standard-2"
+	machineType := "e2-medium"
 	if pkgManager == "googet" {
 		packageName = "cowsay"
 		machineType = "e2-standard-4"
@@ -87,7 +87,7 @@ func buildPkgUpdateTestSetup(name, image, pkgManager, key string) *guestPolicyTe
 	assertTimeout := 240 * time.Second
 	testName := packageUpdateFunction
 	packageName := "ed"
-	machineType := "e2-standard-2"
+	machineType := "e2-medium"
 	if pkgManager == "googet" {
 		packageName = "cowsay"
 		machineType = "e2-standard-4"
@@ -122,7 +122,7 @@ func buildPkgDoesNotUpdateTestSetup(name, image, pkgManager, key string) *guestP
 	assertTimeout := 240 * time.Second
 	testName := packageNoUpdateFunction
 	packageName := "ed"
-	machineType := "e2-standard-2"
+	machineType := "e2-medium"
 	if pkgManager == "googet" {
 		packageName = "cowsay"
 		machineType = "e2-standard-4"
@@ -158,7 +158,7 @@ func buildPkgRemoveTestSetup(name, image, pkgManager, key string) *guestPolicyTe
 	assertTimeout := 180 * time.Second
 	testName := packageRemovalFunction
 	packageName := "vim"
-	machineType := "e2-standard-2"
+	machineType := "e2-medium"
 	if pkgManager == "googet" {
 		packageName = "certgen"
 		machineType = "e2-standard-4"
@@ -194,9 +194,9 @@ func buildPkgInstallFromNewRepoTestSetup(name, image, pkgManager, key string) *g
 	assertTimeout := 120 * time.Second
 	packageName := "osconfig-agent-test"
 	testName := packageInstallFromNewRepoFunction
-	machineType := "e2-standard-2"
+	machineType := "e2-medium"
 	if pkgManager == "googet" {
-		machineType = "e2-standard-4"
+		machineType = "e2-standard-2"
 	}
 
 	instanceName := fmt.Sprintf("%s-%s-%s-%s", path.Base(name), testName, key, utils.RandString(3))
@@ -282,7 +282,7 @@ func buildRecipeInstallTestSetup(name, image, pkgManager, key string) *guestPoli
 	assertTimeout := 120 * time.Second
 	testName := recipeInstallFunction
 	recipeName := "testrecipe"
-	machineType := "e2-standard-2"
+	machineType := "e2-medium"
 	if strings.HasPrefix(image, "windows") {
 		machineType = "e2-standard-4"
 	}
@@ -325,9 +325,9 @@ func buildRecipeStepsTestSetup(name, image, pkgManager, key string) *guestPolicy
 	assertTimeout := 120 * time.Second
 	testName := recipeStepsFunction
 	recipeName := "testrecipe"
-	machineType := "e2-standard-2"
+	machineType := "e2-medium"
 	if strings.HasPrefix(image, "windows") {
-		machineType = "e2-standard-4"
+		machineType = "e2-standard-2"
 	}
 
 	instanceName := fmt.Sprintf("%s-%s-%s-%s", path.Base(name), testName, key, utils.RandString(3))
@@ -496,9 +496,9 @@ func buildMetadataPolicyTestSetup(name, image, pkgManager, key string) *guestPol
 	assertTimeout := 60 * time.Second
 	testName := metadataPolicyFunction
 	recipeName := "testrecipe"
-	machineType := "e2-standard-2"
+	machineType := "e2-medium"
 	if strings.HasPrefix(image, "windows") {
-		machineType = "e2-standard-4"
+		machineType = "e2-standard-2"
 	}
 
 	instanceName := fmt.Sprintf("%s-%s-%s-%s", path.Base(name), testName, key, utils.RandString(3))

--- a/e2e_tests/test_suites/inventoryreporting/test_setup.go
+++ b/e2e_tests/test_suites/inventoryreporting/test_setup.go
@@ -15,6 +15,7 @@
 package inventoryreporting
 
 import (
+	"errors"
 	"strings"
 	"time"
 
@@ -22,6 +23,8 @@ import (
 	"github.com/GoogleCloudPlatform/osconfig/e2e_tests/config"
 	"github.com/GoogleCloudPlatform/osconfig/e2e_tests/utils"
 	computeAPI "google.golang.org/api/compute/v1"
+
+	osconfigpb "github.com/GoogleCloudPlatform/osconfig/e2e_tests/internal/google.golang.org/genproto/googleapis/cloud/osconfig/v1alpha"
 )
 
 type inventoryTestSetup struct {
@@ -33,6 +36,7 @@ type inventoryTestSetup struct {
 	startup     *computeAPI.MetadataItems
 	machineType string
 	timeout     time.Duration
+	itemCheck   func(items map[string]*osconfigpb.Inventory_Item) error
 }
 
 var (
@@ -41,49 +45,110 @@ var (
 		shortName:   "windows",
 
 		startup:     compute.BuildInstanceMetadataItem("windows-startup-script-ps1", utils.InstallOSConfigGooGet()),
-		machineType: "e2-standard-4",
+		machineType: "e2-standard-2",
 		timeout:     25 * time.Minute,
+		itemCheck: func(items map[string]*osconfigpb.Inventory_Item) error {
+			var foundGooget bool
+			var qfeExists bool
+			var wuaExists bool
+			for _, item := range items {
+				if item.GetInstalledPackage().GetGoogetPackage().GetPackageName() == "googet" {
+					foundGooget = true
+				}
+				if item.GetInstalledPackage().GetQfePackage() != nil {
+					qfeExists = true
+				}
+				if item.GetInstalledPackage().GetWuaPackage() != nil {
+					wuaExists = true
+				}
+			}
+			if !foundGooget {
+				return errors.New("did not find 'googet' in installed packages")
+			}
+			if !qfeExists {
+				return errors.New("did not find any QFE installed package")
+			}
+			if !wuaExists {
+				return errors.New("did not find any WUA installed package")
+			}
+			return nil
+		},
 	}
 
 	aptSetup = &inventoryTestSetup{
 		packageType: []string{"deb"},
 		startup:     compute.BuildInstanceMetadataItem("startup-script", utils.InstallOSConfigDeb()),
-		machineType: "e2-standard-2",
+		machineType: "e2-medium",
 		timeout:     10 * time.Minute,
+		itemCheck: func(items map[string]*osconfigpb.Inventory_Item) error {
+			for _, item := range items {
+				if item.GetInstalledPackage().GetAptPackage().GetPackageName() == "bash" {
+					return nil
+				}
+			}
+			return errors.New("did not find 'bash' in installed packages")
+		},
+	}
+	yumBashInstalledCheck = func(items map[string]*osconfigpb.Inventory_Item) error {
+		for _, item := range items {
+			if item.GetInstalledPackage().GetYumPackage().GetPackageName() == "bash" {
+				return nil
+			}
+		}
+		return errors.New("did not find 'bash' in installed packages")
 	}
 
 	el6Setup = &inventoryTestSetup{
 		packageType: []string{"rpm"},
 		startup:     compute.BuildInstanceMetadataItem("startup-script", utils.InstallOSConfigEL6()),
-		machineType: "e2-standard-2",
+		machineType: "e2-medium",
 		timeout:     10 * time.Minute,
+		itemCheck:   yumBashInstalledCheck,
 	}
 
 	el7Setup = &inventoryTestSetup{
 		packageType: []string{"rpm"},
 		startup:     compute.BuildInstanceMetadataItem("startup-script", utils.InstallOSConfigEL7()),
-		machineType: "e2-standard-2",
+		machineType: "e2-medium",
 		timeout:     10 * time.Minute,
+		itemCheck:   yumBashInstalledCheck,
 	}
 
 	el8Setup = &inventoryTestSetup{
 		packageType: []string{"rpm"},
 		startup:     compute.BuildInstanceMetadataItem("startup-script", utils.InstallOSConfigEL8()),
-		machineType: "e2-standard-2",
+		machineType: "e2-medium",
 		timeout:     10 * time.Minute,
+		itemCheck:   yumBashInstalledCheck,
 	}
 
 	suseSetup = &inventoryTestSetup{
 		packageType: []string{"zypper"},
 		startup:     compute.BuildInstanceMetadataItem("startup-script", utils.InstallOSConfigSUSE()),
-		machineType: "e2-standard-2",
+		machineType: "e2-medium",
 		timeout:     15 * time.Minute,
+		itemCheck: func(items map[string]*osconfigpb.Inventory_Item) error {
+			for _, item := range items {
+				if item.GetInstalledPackage().GetZypperPackage().GetPackageName() == "bash" {
+					return nil
+				}
+			}
+			return errors.New("did not find 'bash' in installed packages")
+		},
 	}
 
 	cosSetup = &inventoryTestSetup{
 		startup:     compute.BuildInstanceMetadataItem("startup-script", utils.CosSetup),
-		machineType: "e2-standard-2",
+		machineType: "e2-medium",
 		timeout:     5 * time.Minute,
+		itemCheck: func(items map[string]*osconfigpb.Inventory_Item) error {
+			for _, item := range items {
+				if item.GetInstalledPackage().GetCosPackage().GetPackageName() == "app-shells/bash" {
+					return nil
+				}
+			}
+			return errors.New("did not find 'app-shells/bash' in installed packages")
+		},
 	}
 )
 

--- a/e2e_tests/test_suites/ospolicies/ospolicies.go
+++ b/e2e_tests/test_suites/ospolicies/ospolicies.go
@@ -229,6 +229,17 @@ func testCase(ctx context.Context, testSetup *osPolicyTestSetup, tests chan *jun
 	} else {
 		logger.Printf("Running TestCase %q", tc.Name)
 		runTest(ctx, tc, testSetup, logger)
+		if tc.Failure != nil {
+			rerunTC := junitxml.NewTestCase(testSuiteName, tc.Name)
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				logger.Printf("Rerunning TestCase %q", rerunTC.Name)
+				runTest(ctx, rerunTC, testSetup, logger)
+				rerunTC.Finish(tests)
+				logger.Printf("TestCase %q finished in %fs", rerunTC.Name, rerunTC.Time)
+			}()
+		}
 		tc.Finish(tests)
 		logger.Printf("TestCase %q finished in %fs", tc.Name, tc.Time)
 	}

--- a/e2e_tests/test_suites/patch/test_setup.go
+++ b/e2e_tests/test_suites/patch/test_setup.go
@@ -100,7 +100,7 @@ chmod +x ./linux_local_pre_patch_script.sh
 			enableOsconfig,
 			disableFeatures,
 		},
-		machineType: "e2-standard-2",
+		machineType: "e2-medium",
 	}
 	el6Setup = &patchTestSetup{
 		assertTimeout: 15 * time.Minute,
@@ -109,7 +109,7 @@ chmod +x ./linux_local_pre_patch_script.sh
 			enableOsconfig,
 			disableFeatures,
 		},
-		machineType: "e2-standard-2",
+		machineType: "e2-medium",
 	}
 	el7Setup = &patchTestSetup{
 		assertTimeout: 15 * time.Minute,
@@ -118,7 +118,7 @@ chmod +x ./linux_local_pre_patch_script.sh
 			enableOsconfig,
 			disableFeatures,
 		},
-		machineType: "e2-standard-2",
+		machineType: "e2-medium",
 	}
 	el8Setup = &patchTestSetup{
 		assertTimeout: 15 * time.Minute,
@@ -127,7 +127,7 @@ chmod +x ./linux_local_pre_patch_script.sh
 			enableOsconfig,
 			disableFeatures,
 		},
-		machineType: "e2-standard-2",
+		machineType: "e2-medium",
 	}
 	suseSetup = &patchTestSetup{
 		assertTimeout: 15 * time.Minute,
@@ -136,7 +136,7 @@ chmod +x ./linux_local_pre_patch_script.sh
 			enableOsconfig,
 			disableFeatures,
 		},
-		machineType: "e2-standard-2",
+		machineType: "e2-medium",
 	}
 )
 

--- a/e2e_tests/utils/utils.go
+++ b/e2e_tests/utils/utils.go
@@ -380,7 +380,7 @@ func CreateComputeInstance(metadataitems []*api.MetadataItems, client daisyCompu
 				Boot:       true,
 				InitializeParams: &api.AttachedDiskInitializeParams{
 					SourceImage: image,
-					DiskType:    fmt.Sprintf("projects/%s/zones/%s/diskTypes/pd-ssd", projectID, zone),
+					DiskType:    fmt.Sprintf("projects/%s/zones/%s/diskTypes/pd-balanced", projectID, zone),
 				},
 			},
 		},


### PR DESCRIPTION
Move all linux tests to use e2-medium
Move all windows tests (other than patch) to e2-standard-2
Move all instances to use pd-balanced disks
Check inventory items for InventoryReporting tests
Rerun failed tests once to try to reduce flakes for a single test run
 - inventory tests are not rerun as that setup was difficult to rerun simply, but they don't fail often
 - both test cases will report on testgrid, if we don't like how that shows up we can instead not record the first failing test