### PR TITLE
e2e_tests: Don't retry failed OSPolicy tests, fix msi test

### DIFF
--- a/e2e_tests/test_suites/ospolicies/ospolicies.go
+++ b/e2e_tests/test_suites/ospolicies/ospolicies.go
@@ -240,17 +240,19 @@ func testCase(ctx context.Context, testSetup *osPolicyTestSetup, tests chan *jun
 	} else {
 		logger.Printf("Running TestCase %q", tc.Name)
 		runTest(ctx, tc, testSetup, logger)
-		if tc.Failure != nil {
-			rerunTC := junitxml.NewTestCase(testSuiteName, strings.TrimPrefix(tc.Name, fmt.Sprintf("[%s] ", testSuiteName)))
-			wg.Add(1)
-			go func() {
-				defer wg.Done()
-				logger.Printf("Rerunning TestCase %q", rerunTC.Name)
-				runTest(ctx, rerunTC, testSetup, logger)
-				rerunTC.Finish(tests)
-				logger.Printf("TestCase %q finished in %fs", rerunTC.Name, rerunTC.Time)
-			}()
-		}
+		/*
+			if tc.Failure != nil {
+				rerunTC := junitxml.NewTestCase(testSuiteName, strings.TrimPrefix(tc.Name, fmt.Sprintf("[%s] ", testSuiteName)))
+				wg.Add(1)
+				go func() {
+					defer wg.Done()
+					logger.Printf("Rerunning TestCase %q", rerunTC.Name)
+					runTest(ctx, rerunTC, testSetup, logger)
+					rerunTC.Finish(tests)
+					logger.Printf("TestCase %q finished in %fs", rerunTC.Name, rerunTC.Time)
+				}()
+			}
+		*/
 		tc.Finish(tests)
 		logger.Printf("TestCase %q finished in %fs", tc.Name, tc.Time)
 	}

--- a/e2e_tests/test_suites/ospolicies/ospolicies_test_data.go
+++ b/e2e_tests/test_suites/ospolicies/ospolicies_test_data.go
@@ -651,9 +651,32 @@ func buildMsiTestSetup(name, image, key string) *osPolicyTestSetup {
 	}
 	wantCompliances := []*osconfigpb.InstanceOSPoliciesCompliance_OSPolicyCompliance{
 		{
-			OsPolicyId:                  testName,
-			State:                       osconfigpb.OSPolicyComplianceState_COMPLIANT,
-			OsPolicyResourceCompliances: wantLocalPackageCompliances,
+			OsPolicyId: testName,
+			State:      osconfigpb.OSPolicyComplianceState_COMPLIANT,
+			OsPolicyResourceCompliances: []*osconfigpb.OSPolicyResourceCompliance{
+				{
+					OsPolicyResourceId: "install-package",
+					ConfigSteps: []*osconfigpb.OSPolicyResourceConfigStep{
+						{
+							Type:    osconfigpb.OSPolicyResourceConfigStep_VALIDATION,
+							Outcome: osconfigpb.OSPolicyResourceConfigStep_SUCCEEDED,
+						},
+						{
+							Type:    osconfigpb.OSPolicyResourceConfigStep_DESIRED_STATE_CHECK,
+							Outcome: osconfigpb.OSPolicyResourceConfigStep_SUCCEEDED,
+						},
+						{
+							Type:    osconfigpb.OSPolicyResourceConfigStep_DESIRED_STATE_ENFORCEMENT,
+							Outcome: osconfigpb.OSPolicyResourceConfigStep_SUCCEEDED,
+						},
+						{
+							Type:    osconfigpb.OSPolicyResourceConfigStep_DESIRED_STATE_CHECK_POST_ENFORCEMENT,
+							Outcome: osconfigpb.OSPolicyResourceConfigStep_SUCCEEDED,
+						},
+					},
+					State: osconfigpb.OSPolicyComplianceState_COMPLIANT,
+				},
+			},
 		},
 	}
 	ss := getStartupScriptPackage(name, "msi")


### PR DESCRIPTION
Tests are not particularly flaky so retries right now aren't very helpful and they are causing test run timeouts.