### PR TITLE
e2e_tests: deflake tests

### DIFF
--- a/e2e_tests/test_suites/inventory/inventory.go
+++ b/e2e_tests/test_suites/inventory/inventory.go
@@ -279,6 +279,13 @@ func inventoryTestCase(ctx context.Context, testSetup *inventoryTestSetup, tests
 	gatherInventoryTest.Finish(tests)
 	logger.Printf("TestCase %q finished", gatherInventoryTest.Name)
 	if !ok {
+		rerunTC := junitxml.NewTestCase(testSuiteName, strings.TrimPrefix(gatherInventoryTest.Name, fmt.Sprintf("[%s] ", testSuiteName)))
+		logger.Printf("Rerunning TestCase %q", rerunTC.Name)
+		ga, ok = runGatherInventoryTest(ctx, testSetup, rerunTC, &logwg)
+		rerunTC.Finish(tests)
+		logger.Printf("TestCase %q finished in %fs", rerunTC.Name, rerunTC.Time)
+	}
+	if !ok {
 		hostnameTest.WriteFailure("Setup Failure")
 		hostnameTest.Finish(tests)
 		shortNameTest.WriteFailure("Setup Failure")

--- a/e2e_tests/utils/utils.go
+++ b/e2e_tests/utils/utils.go
@@ -298,12 +298,12 @@ var HeadWindowsImages = map[string]string{
 
 // OldWindowsImages is a map of names to image paths for old Windows images.
 var OldWindowsImages = map[string]string{
-	"old/windows-2012-r2":      "projects/windows-cloud/global/images/windows-server-2012-r2-dc-v20191008",
-	"old/windows-2012-r2-core": "projects/windows-cloud/global/images/windows-server-2012-r2-dc-core-v20191008",
-	"old/windows-2016":         "projects/windows-cloud/global/images/windows-server-2016-dc-v20191008",
-	"old/windows-2016-core":    "projects/windows-cloud/global/images/windows-server-2016-dc-core-v20191008",
-	"old/windows-2019":         "projects/windows-cloud/global/images/windows-server-2019-dc-v20191008",
-	"old/windows-2019-core":    "projects/windows-cloud/global/images/windows-server-2019-dc-core-v20191008",
+	"old/windows-2012-r2":      "projects/windows-cloud/global/images/windows-server-2012-r2-dc-v20210309",
+	"old/windows-2012-r2-core": "projects/windows-cloud/global/images/windows-server-2012-r2-dc-core-v20210309",
+	"old/windows-2016":         "projects/windows-cloud/global/images/windows-server-2016-dc-v20210309",
+	"old/windows-2016-core":    "projects/windows-cloud/global/images/windows-server-2016-dc-core-v20210309",
+	"old/windows-2019":         "projects/windows-cloud/global/images/windows-server-2019-dc-v20210309",
+	"old/windows-2019-core":    "projects/windows-cloud/global/images/windows-server-2019-dc-core-v20210309",
 }
 
 // HeadCOSImages is a map of names to image paths for public COS image families.


### PR DESCRIPTION
Update windows "old" images for patch tests since the really old images are very flaky when running updates (can take a long time)
Rerun "gather inventory" test case on failure