### PR TITLE
Use exec.CommandContext so that canceling the context also kills any running processes

### DIFF
--- a/config/exec_resource.go
+++ b/config/exec_resource.go
@@ -155,7 +155,7 @@ func (e *execResource) run(ctx context.Context, name string, execR *agentendpoin
 	}
 	args = append(args, execR.GetArgs()...)
 
-	stdout, stderr, err := runner.Run(ctx, exec.Command(cmd, args...))
+	stdout, stderr, err := runner.Run(ctx, exec.CommandContext(ctx, cmd, args...))
 	code := 0
 	if err != nil {
 		code = -1

--- a/config/package_resource_test.go
+++ b/config/package_resource_test.go
@@ -142,7 +142,7 @@ func TestPackageResourceValidate(t *testing.T) {
 				PackageResource: &agentendpointpb.OSPolicy_Resource_PackageResource_Deb{
 					Source: &agentendpointpb.OSPolicy_Resource_File{
 						Type: &agentendpointpb.OSPolicy_Resource_File_LocalPath{LocalPath: tmpFile}}}}},
-			exec.Command("/usr/bin/dpkg-deb", "-I", tmpFile),
+			exec.CommandContext(context.Background(), "/usr/bin/dpkg-deb", "-I", tmpFile),
 			[]byte("Package: foo\nVersion: 1:1dummy-g1\nArchitecture: amd64"),
 		},
 		{
@@ -237,7 +237,7 @@ func TestPackageResourceValidate(t *testing.T) {
 				PackageResource: &agentendpointpb.OSPolicy_Resource_PackageResource_RPM{
 					Source: &agentendpointpb.OSPolicy_Resource_File{
 						Type: &agentendpointpb.OSPolicy_Resource_File_LocalPath{LocalPath: tmpFile}}}}},
-			exec.Command("/usr/bin/rpmquery", "--queryformat", "%{NAME} %{ARCH} %|EPOCH?{%{EPOCH}:}:{}|%{VERSION}-%{RELEASE}\n", "-p", tmpFile),
+			exec.CommandContext(context.Background(), "/usr/bin/rpmquery", "--queryformat", "%{NAME} %{ARCH} %|EPOCH?{%{EPOCH}:}:{}|%{VERSION}-%{RELEASE}\n", "-p", tmpFile),
 			[]byte("foo x86_64 1.2.3-4"),
 		},
 	}
@@ -285,7 +285,7 @@ func TestPopulateInstalledCache(t *testing.T) {
 
 	mockCommandRunner := utilmocks.NewMockCommandRunner(mockCtrl)
 	packages.SetCommandRunner(mockCommandRunner)
-	mockCommandRunner.EXPECT().Run(ctx, exec.Command("googet.exe", "installed")).Return([]byte("Installed Packages:\nfoo.x86_64 1.2.3@4\nbar.noarch 1.2.3@4"), nil, nil).Times(1)
+	mockCommandRunner.EXPECT().Run(ctx, exec.CommandContext(context.Background(), "googet.exe", "installed")).Return([]byte("Installed Packages:\nfoo.x86_64 1.2.3@4\nbar.noarch 1.2.3@4"), nil, nil).Times(1)
 
 	if err := populateInstalledCache(ctx, ManagedPackage{GooGet: &GooGetPackage{}}); err != nil {
 		t.Fatalf("Unexpected error from populateInstalledCache: %v", err)
@@ -407,8 +407,8 @@ func TestPackageResourceEnforceState(t *testing.T) {
 			aptInstalledPR,
 			aptInstalled,
 			func() []*exec.Cmd {
-				cmd1 := exec.Command("/usr/bin/apt-get", "update")
-				cmd2 := exec.Command("/usr/bin/apt-get", "install", "-y", "foo")
+				cmd1 := exec.CommandContext(context.Background(), "/usr/bin/apt-get", "update")
+				cmd2 := exec.CommandContext(context.Background(), "/usr/bin/apt-get", "install", "-y", "foo")
 				cmd2.Env = append(os.Environ(),
 					"DEBIAN_FRONTEND=noninteractive",
 				)
@@ -420,7 +420,7 @@ func TestPackageResourceEnforceState(t *testing.T) {
 			aptRemovedPR,
 			aptInstalled,
 			func() []*exec.Cmd {
-				cmd1 := exec.Command("/usr/bin/apt-get", "remove", "-y", "foo")
+				cmd1 := exec.CommandContext(context.Background(), "/usr/bin/apt-get", "remove", "-y", "foo")
 				cmd1.Env = append(os.Environ(),
 					"DEBIAN_FRONTEND=noninteractive",
 				)
@@ -431,37 +431,37 @@ func TestPackageResourceEnforceState(t *testing.T) {
 			"GooGetInstalled",
 			googetInstalledPR,
 			gooInstalled,
-			[]*exec.Cmd{exec.Command("googet.exe", "-noconfirm", "install", "foo")},
+			[]*exec.Cmd{exec.CommandContext(context.Background(), "googet.exe", "-noconfirm", "install", "foo")},
 		},
 		{
 			"GooGetRemoved",
 			googetRemovedPR,
 			gooInstalled,
-			[]*exec.Cmd{exec.Command("googet.exe", "-noconfirm", "remove", "foo")},
+			[]*exec.Cmd{exec.CommandContext(context.Background(), "googet.exe", "-noconfirm", "remove", "foo")},
 		},
 		{
 			"YumInstalled",
 			yumInstalledPR,
 			yumInstalled,
-			[]*exec.Cmd{exec.Command("/usr/bin/yum", "install", "--assumeyes", "foo")},
+			[]*exec.Cmd{exec.CommandContext(context.Background(), "/usr/bin/yum", "install", "--assumeyes", "foo")},
 		},
 		{
 			"YumRemoved",
 			yumRemovedPR,
 			yumInstalled,
-			[]*exec.Cmd{exec.Command("/usr/bin/yum", "remove", "--assumeyes", "foo")},
+			[]*exec.Cmd{exec.CommandContext(context.Background(), "/usr/bin/yum", "remove", "--assumeyes", "foo")},
 		},
 		{
 			"ZypperInstalled",
 			zypperInstalledPR,
 			zypperInstalled,
-			[]*exec.Cmd{exec.Command("/usr/bin/zypper", "--gpg-auto-import-keys", "--non-interactive", "install", "--auto-agree-with-licenses", "foo")},
+			[]*exec.Cmd{exec.CommandContext(context.Background(), "/usr/bin/zypper", "--gpg-auto-import-keys", "--non-interactive", "install", "--auto-agree-with-licenses", "foo")},
 		},
 		{
 			"ZypperRemoved",
 			zypperRemovedPR,
 			zypperInstalled,
-			[]*exec.Cmd{exec.Command("/usr/bin/zypper", "--non-interactive", "remove", "foo")},
+			[]*exec.Cmd{exec.CommandContext(context.Background(), "/usr/bin/zypper", "--non-interactive", "remove", "foo")},
 		},
 	}
 

--- a/ospatch/yum_update_test.go
+++ b/ospatch/yum_update_test.go
@@ -40,7 +40,7 @@ func TestRunYumUpdateWithSecurity(t *testing.T) {
 		os.Exit(100)
 	}
 
-	cmd := exec.Command(os.Args[0], "-test.run=TestRunYumUpdateWithSecurity")
+	cmd := exec.CommandContext(context.Background(), os.Args[0], "-test.run=TestRunYumUpdateWithSecurity")
 	cmd.Env = append(os.Environ(), "EXIT100=1")
 	err := cmd.Run()
 
@@ -49,12 +49,12 @@ func TestRunYumUpdateWithSecurity(t *testing.T) {
 
 	mockCommandRunner := utilmocks.NewMockCommandRunner(mockCtrl)
 	packages.SetCommandRunner(mockCommandRunner)
-	checkUpdateCall := mockCommandRunner.EXPECT().Run(ctx, exec.Command("/usr/bin/yum", []string{"check-update", "--assumeyes"}...)).Return([]byte("stdout"), []byte("stderr"), err).Times(1)
+	checkUpdateCall := mockCommandRunner.EXPECT().Run(ctx, exec.CommandContext(context.Background(), "/usr/bin/yum", []string{"check-update", "--assumeyes"}...)).Return([]byte("stdout"), []byte("stderr"), err).Times(1)
 	// yum install call to install package
-	mockCommandRunner.EXPECT().Run(ctx, exec.Command("/usr/bin/yum", []string{"install", "--assumeyes", "foo"}...)).After(checkUpdateCall).Return([]byte("stdout"), []byte("stderr"), nil).Times(1)
+	mockCommandRunner.EXPECT().Run(ctx, exec.CommandContext(context.Background(), "/usr/bin/yum", []string{"install", "--assumeyes", "foo"}...)).After(checkUpdateCall).Return([]byte("stdout"), []byte("stderr"), nil).Times(1)
 
 	packages.SetPtyCommandRunner(mockCommandRunner)
-	mockCommandRunner.EXPECT().Run(ctx, exec.Command("/usr/bin/yum", []string{"update", "--assumeno", "--cacheonly", "--color=never", "--security"}...)).Return(data, []byte("stderr"), nil).Times(1)
+	mockCommandRunner.EXPECT().Run(ctx, exec.CommandContext(context.Background(), "/usr/bin/yum", []string{"update", "--assumeno", "--cacheonly", "--color=never", "--security"}...)).Return(data, []byte("stderr"), nil).Times(1)
 
 	err = RunYumUpdate(ctx, YumUpdateMinimal(false), YumUpdateSecurity(true))
 	if err != nil {
@@ -82,7 +82,7 @@ func TestRunYumUpdateWithSecurityWithExclusives(t *testing.T) {
 		os.Exit(100)
 	}
 
-	cmd := exec.Command(os.Args[0], "-test.run=TestRunYumUpdateWithSecurityWithExclusives")
+	cmd := exec.CommandContext(context.Background(), os.Args[0], "-test.run=TestRunYumUpdateWithSecurityWithExclusives")
 	cmd.Env = append(os.Environ(), "EXIT100=1")
 	err := cmd.Run()
 
@@ -91,12 +91,12 @@ func TestRunYumUpdateWithSecurityWithExclusives(t *testing.T) {
 
 	mockCommandRunner := utilmocks.NewMockCommandRunner(mockCtrl)
 	packages.SetCommandRunner(mockCommandRunner)
-	checkUpdateCall := mockCommandRunner.EXPECT().Run(ctx, exec.Command("/usr/bin/yum", []string{"check-update", "--assumeyes"}...)).Return([]byte("stdout"), []byte("stderr"), err).Times(1)
+	checkUpdateCall := mockCommandRunner.EXPECT().Run(ctx, exec.CommandContext(context.Background(), "/usr/bin/yum", []string{"check-update", "--assumeyes"}...)).Return([]byte("stdout"), []byte("stderr"), err).Times(1)
 	// yum install call to install package, make sure only 2 packages are installed.
-	mockCommandRunner.EXPECT().Run(ctx, exec.Command("/usr/bin/yum", []string{"install", "--assumeyes", "foo", "bar"}...)).After(checkUpdateCall).Return([]byte("stdout"), []byte("stderr"), nil).Times(1)
+	mockCommandRunner.EXPECT().Run(ctx, exec.CommandContext(context.Background(), "/usr/bin/yum", []string{"install", "--assumeyes", "foo", "bar"}...)).After(checkUpdateCall).Return([]byte("stdout"), []byte("stderr"), nil).Times(1)
 
 	packages.SetPtyCommandRunner(mockCommandRunner)
-	mockCommandRunner.EXPECT().Run(ctx, exec.Command("/usr/bin/yum", []string{"update", "--assumeno", "--cacheonly", "--color=never", "--security"}...)).Return(data, []byte("stderr"), nil).Times(1)
+	mockCommandRunner.EXPECT().Run(ctx, exec.CommandContext(context.Background(), "/usr/bin/yum", []string{"update", "--assumeno", "--cacheonly", "--color=never", "--security"}...)).Return(data, []byte("stderr"), nil).Times(1)
 
 	err = RunYumUpdate(ctx, YumUpdateMinimal(false), YumUpdateSecurity(true), YumExclusivePackages(exclusivePackages))
 	if err != nil {

--- a/packages/apt_deb.go
+++ b/packages/apt_deb.go
@@ -181,7 +181,7 @@ func DebPkgInfo(ctx context.Context, path string) (*PkgInfo, error) {
 // InstallAptPackages installs apt packages.
 func InstallAptPackages(ctx context.Context, pkgs []string) error {
 	args := append(aptGetInstallArgs, pkgs...)
-	install := exec.Command(aptGet, args...)
+	install := exec.CommandContext(ctx, aptGet, args...)
 	install.Env = append(os.Environ(),
 		"DEBIAN_FRONTEND=noninteractive",
 	)
@@ -200,7 +200,7 @@ func InstallAptPackages(ctx context.Context, pkgs []string) error {
 // RemoveAptPackages removes apt packages.
 func RemoveAptPackages(ctx context.Context, pkgs []string) error {
 	args := append(aptGetRemoveArgs, pkgs...)
-	remove := exec.Command(aptGet, args...)
+	remove := exec.CommandContext(ctx, aptGet, args...)
 	remove.Env = append(os.Environ(),
 		"DEBIAN_FRONTEND=noninteractive",
 	)

--- a/packages/apt_deb_test.go
+++ b/packages/apt_deb_test.go
@@ -15,6 +15,7 @@
 package packages
 
 import (
+	"context"
 	"errors"
 	"os"
 	"os/exec"
@@ -32,7 +33,7 @@ func TestInstallAptPackages(t *testing.T) {
 	mockCommandRunner := utilmocks.NewMockCommandRunner(mockCtrl)
 	runner = mockCommandRunner
 
-	expectedCmd := exec.Command(aptGet, append(aptGetInstallArgs, pkgs...)...)
+	expectedCmd := exec.CommandContext(context.Background(), aptGet, append(aptGetInstallArgs, pkgs...)...)
 	expectedCmd.Env = append(os.Environ(),
 		"DEBIAN_FRONTEND=noninteractive",
 	)
@@ -43,7 +44,7 @@ func TestInstallAptPackages(t *testing.T) {
 	}
 
 	first := mockCommandRunner.EXPECT().Run(testCtx, expectedCmd).Return([]byte("stdout"), dpkgErr, errors.New("error")).Times(1)
-	repair := mockCommandRunner.EXPECT().Run(testCtx, exec.Command(dpkg, dpkgRepairArgs...)).After(first).Return([]byte("stdout"), []byte("stderr"), nil).Times(1)
+	repair := mockCommandRunner.EXPECT().Run(testCtx, exec.CommandContext(context.Background(), dpkg, dpkgRepairArgs...)).After(first).Return([]byte("stdout"), []byte("stderr"), nil).Times(1)
 	mockCommandRunner.EXPECT().Run(testCtx, expectedCmd).After(repair).Return([]byte("stdout"), []byte("stderr"), errors.New("error")).Times(1)
 	if err := InstallAptPackages(testCtx, pkgs); err == nil {
 		t.Errorf("did not get expected error")
@@ -56,7 +57,7 @@ func TestRemoveAptPackages(t *testing.T) {
 
 	mockCommandRunner := utilmocks.NewMockCommandRunner(mockCtrl)
 	runner = mockCommandRunner
-	expectedCmd := exec.Command(aptGet, append(aptGetRemoveArgs, pkgs...)...)
+	expectedCmd := exec.CommandContext(context.Background(), aptGet, append(aptGetRemoveArgs, pkgs...)...)
 	expectedCmd.Env = append(os.Environ(),
 		"DEBIAN_FRONTEND=noninteractive",
 	)
@@ -67,7 +68,7 @@ func TestRemoveAptPackages(t *testing.T) {
 	}
 
 	first := mockCommandRunner.EXPECT().Run(testCtx, expectedCmd).Return([]byte("stdout"), dpkgErr, errors.New("error")).Times(1)
-	repair := mockCommandRunner.EXPECT().Run(testCtx, exec.Command(dpkg, dpkgRepairArgs...)).After(first).Return([]byte("stdout"), []byte("stderr"), nil).Times(1)
+	repair := mockCommandRunner.EXPECT().Run(testCtx, exec.CommandContext(context.Background(), dpkg, dpkgRepairArgs...)).After(first).Return([]byte("stdout"), []byte("stderr"), nil).Times(1)
 	mockCommandRunner.EXPECT().Run(testCtx, expectedCmd).After(repair).Return([]byte("stdout"), []byte("stderr"), errors.New("error")).Times(1)
 	if err := RemoveAptPackages(testCtx, pkgs); err == nil {
 		t.Errorf("did not get expected error")
@@ -80,7 +81,7 @@ func TestInstalledDebPackages(t *testing.T) {
 
 	mockCommandRunner := utilmocks.NewMockCommandRunner(mockCtrl)
 	runner = mockCommandRunner
-	expectedCmd := exec.Command(dpkgQuery, dpkgQueryArgs...)
+	expectedCmd := exec.CommandContext(context.Background(), dpkgQuery, dpkgQueryArgs...)
 	data := []byte("foo amd64 1.2.3-4 installed")
 
 	mockCommandRunner.EXPECT().Run(testCtx, expectedCmd).Return(data, []byte("stderr"), nil).Times(1)
@@ -155,8 +156,8 @@ func TestAptUpdates(t *testing.T) {
 
 	mockCommandRunner := utilmocks.NewMockCommandRunner(mockCtrl)
 	runner = mockCommandRunner
-	updateCmd := exec.Command(aptGet, aptGetUpdateArgs...)
-	expectedCmd := exec.Command(aptGet, append(aptGetUpgradableArgs, aptGetUpgradeCmd)...)
+	updateCmd := exec.CommandContext(context.Background(), aptGet, aptGetUpdateArgs...)
+	expectedCmd := exec.CommandContext(context.Background(), aptGet, append(aptGetUpgradableArgs, aptGetUpgradeCmd)...)
 	data := []byte("Inst google-cloud-sdk [245.0.0-0] (246.0.0-0 cloud-sdk-stretch:cloud-sdk-stretch [amd64])")
 
 	first := mockCommandRunner.EXPECT().Run(testCtx, updateCmd).Return(data, []byte("stderr"), nil).Times(1)
@@ -185,7 +186,7 @@ func TestDebPkgInfo(t *testing.T) {
 	mockCommandRunner := utilmocks.NewMockCommandRunner(mockCtrl)
 	runner = mockCommandRunner
 	testPkg := "test.deb"
-	expectedCmd := exec.Command(dpkgDeb, "-I", testPkg)
+	expectedCmd := exec.CommandContext(context.Background(), dpkgDeb, "-I", testPkg)
 	out := []byte(`new Debian package, version 2.0.
 	size 6731954 bytes: control archive=2138 bytes.
 		498 bytes,    12 lines      control

--- a/packages/gem.go
+++ b/packages/gem.go
@@ -40,7 +40,7 @@ func init() {
 
 // GemUpdates queries for all available gem updates.
 func GemUpdates(ctx context.Context) ([]*PkgInfo, error) {
-	stdout, _, err := runner.Run(ctx, exec.Command(gem, gemOutdatedArgs...))
+	stdout, _, err := runner.Run(ctx, exec.CommandContext(ctx, gem, gemOutdatedArgs...))
 	if err != nil {
 		return nil, err
 	}
@@ -70,7 +70,7 @@ func GemUpdates(ctx context.Context) ([]*PkgInfo, error) {
 
 // InstalledGemPackages queries for all installed gem packages.
 func InstalledGemPackages(ctx context.Context) ([]*PkgInfo, error) {
-	stdout, _, err := runner.Run(ctx, exec.Command(gem, gemListArgs...))
+	stdout, _, err := runner.Run(ctx, exec.CommandContext(ctx, gem, gemListArgs...))
 	if err != nil {
 		return nil, err
 	}

--- a/packages/googet_test.go
+++ b/packages/googet_test.go
@@ -15,6 +15,7 @@
 package packages
 
 import (
+	"context"
 	"errors"
 	"os/exec"
 	"reflect"
@@ -30,7 +31,7 @@ func TestInstallGooGetPackages(t *testing.T) {
 
 	mockCommandRunner := utilmocks.NewMockCommandRunner(mockCtrl)
 	runner = mockCommandRunner
-	expectedCmd := exec.Command(googet, append(googetInstallArgs, pkgs...)...)
+	expectedCmd := exec.CommandContext(context.Background(), googet, append(googetInstallArgs, pkgs...)...)
 
 	mockCommandRunner.EXPECT().Run(testCtx, expectedCmd).Return([]byte("stdout"), []byte("stderr"), nil).Times(1)
 	if err := InstallGooGetPackages(testCtx, pkgs); err != nil {
@@ -49,7 +50,7 @@ func TestRemoveGooGet(t *testing.T) {
 
 	mockCommandRunner := utilmocks.NewMockCommandRunner(mockCtrl)
 	runner = mockCommandRunner
-	expectedCmd := exec.Command(googet, append(googetRemoveArgs, pkgs...)...)
+	expectedCmd := exec.CommandContext(context.Background(), googet, append(googetRemoveArgs, pkgs...)...)
 
 	mockCommandRunner.EXPECT().Run(testCtx, expectedCmd).Return([]byte("stdout"), []byte("stderr"), nil).Times(1)
 	if err := RemoveGooGetPackages(testCtx, pkgs); err != nil {
@@ -88,7 +89,7 @@ func TestInstalledGooGetPackages(t *testing.T) {
 
 	mockCommandRunner := utilmocks.NewMockCommandRunner(mockCtrl)
 	runner = mockCommandRunner
-	expectedCmd := exec.Command(googet, googetInstalledQueryArgs...)
+	expectedCmd := exec.CommandContext(context.Background(), googet, googetInstalledQueryArgs...)
 
 	mockCommandRunner.EXPECT().Run(testCtx, expectedCmd).Return([]byte("foo.x86_64 1.2.3@4"), []byte("stderr"), nil).Times(1)
 	ret, err := InstalledGooGetPackages(testCtx)
@@ -133,7 +134,7 @@ func TestGooGetUpdates(t *testing.T) {
 
 	mockCommandRunner := utilmocks.NewMockCommandRunner(mockCtrl)
 	runner = mockCommandRunner
-	expectedCmd := exec.Command(googet, googetUpdateQueryArgs...)
+	expectedCmd := exec.CommandContext(context.Background(), googet, googetUpdateQueryArgs...)
 
 	mockCommandRunner.EXPECT().Run(testCtx, expectedCmd).Return([]byte("foo.noarch, 3.5.4@1 --> 3.6.7@1 from repo"), []byte("stderr"), nil).Times(1)
 	ret, err := GooGetUpdates(testCtx)

--- a/packages/packages.go
+++ b/packages/packages.go
@@ -106,7 +106,7 @@ type QFEPackage struct {
 }
 
 func run(ctx context.Context, cmd string, args []string) ([]byte, error) {
-	stdout, stderr, err := runner.Run(ctx, exec.Command(cmd, args...))
+	stdout, stderr, err := runner.Run(ctx, exec.CommandContext(ctx, cmd, args...))
 	if err != nil {
 		return nil, fmt.Errorf("error running %s with args %q: %v, stdout: %q, stderr: %q", cmd, args, err, stdout, stderr)
 	}

--- a/packages/qfe_windows.go
+++ b/packages/qfe_windows.go
@@ -28,8 +28,8 @@ type win32QuickFixEngineering struct {
 // QuickFixEngineering queries the wmi object win32_QuickFixEngineering for a list of installed updates.
 func QuickFixEngineering(ctx context.Context) ([]*QFEPackage, error) {
 	var updts []win32QuickFixEngineering
-	clog.Debugf(ctx, "Querying WMI for installed QuickFixEngineering updates.")
 	query := "SELECT Caption, Description, HotFixID, InstalledOn FROM Win32_QuickFixEngineering"
+	clog.Debugf(ctx, "Querying WMI for installed QuickFixEngineering updates, query=%q.", query)
 	if err := wmi.Query(query, &updts); err != nil {
 		return nil, fmt.Errorf("wmi.Query(%q) error: %v", query, err)
 	}

--- a/packages/rpm_test.go
+++ b/packages/rpm_test.go
@@ -15,6 +15,7 @@
 package packages
 
 import (
+	"context"
 	"errors"
 	"os/exec"
 	"reflect"
@@ -51,7 +52,7 @@ func TestInstalledRPMPackages(t *testing.T) {
 
 	mockCommandRunner := utilmocks.NewMockCommandRunner(mockCtrl)
 	runner = mockCommandRunner
-	expectedCmd := exec.Command(rpmquery, rpmqueryInstalledArgs...)
+	expectedCmd := exec.CommandContext(context.Background(), rpmquery, rpmqueryInstalledArgs...)
 
 	mockCommandRunner.EXPECT().Run(testCtx, expectedCmd).Return([]byte("foo x86_64 1.2.3-4"), []byte("stderr"), nil).Times(1)
 	ret, err := InstalledRPMPackages(testCtx)
@@ -77,7 +78,7 @@ func TestRPMPkgInfo(t *testing.T) {
 	mockCommandRunner := utilmocks.NewMockCommandRunner(mockCtrl)
 	runner = mockCommandRunner
 	testPkg := "test.rpm"
-	expectedCmd := exec.Command(rpmquery, append(rpmqueryRPMArgs, testPkg)...)
+	expectedCmd := exec.CommandContext(context.Background(), rpmquery, append(rpmqueryRPMArgs, testPkg)...)
 
 	mockCommandRunner.EXPECT().Run(testCtx, expectedCmd).Return([]byte("foo x86_64 1.2.3-4"), []byte("stderr"), nil).Times(1)
 	ret, err := RPMPkgInfo(testCtx, testPkg)

--- a/packages/yum.go
+++ b/packages/yum.go
@@ -144,7 +144,7 @@ func parseYumUpdates(data []byte) []*PkgInfo {
 func YumUpdates(ctx context.Context, opts ...YumUpdateOption) ([]*PkgInfo, error) {
 	// We just use check-update to ensure all repo keys are synced as we run
 	// update with --assumeno.
-	stdout, stderr, err := runner.Run(ctx, exec.Command(yum, yumCheckUpdateArgs...))
+	stdout, stderr, err := runner.Run(ctx, exec.CommandContext(ctx, yum, yumCheckUpdateArgs...))
 	// Exit code 0 means no updates, 100 means there are updates.
 	if err == nil {
 		return nil, nil
@@ -187,7 +187,7 @@ func listAndParseYumPackages(ctx context.Context, opts ...YumUpdateOption) ([]*P
 		}
 	}
 
-	stdout, stderr, err := ptyrunner.Run(ctx, exec.Command(yum, args...))
+	stdout, stderr, err := ptyrunner.Run(ctx, exec.CommandContext(ctx, yum, args...))
 	if err != nil {
 		return nil, fmt.Errorf("error running %s with args %q: %v, stdout: %q, stderr: %q", yum, args, err, stdout, stderr)
 	}

--- a/packages/yum_test.go
+++ b/packages/yum_test.go
@@ -32,7 +32,7 @@ func TestInstallYumPackages(t *testing.T) {
 
 	mockCommandRunner := utilmocks.NewMockCommandRunner(mockCtrl)
 	runner = mockCommandRunner
-	expectedCmd := exec.Command(yum, append(yumInstallArgs, pkgs...)...)
+	expectedCmd := exec.CommandContext(context.Background(), yum, append(yumInstallArgs, pkgs...)...)
 
 	mockCommandRunner.EXPECT().Run(testCtx, expectedCmd).Return([]byte("stdout"), []byte("stderr"), nil).Times(1)
 	if err := InstallYumPackages(testCtx, pkgs); err != nil {
@@ -52,7 +52,7 @@ func TestRemoveYum(t *testing.T) {
 
 	mockCommandRunner := utilmocks.NewMockCommandRunner(mockCtrl)
 	runner = mockCommandRunner
-	expectedCmd := exec.Command(yum, append(yumRemoveArgs, pkgs...)...)
+	expectedCmd := exec.CommandContext(context.Background(), yum, append(yumRemoveArgs, pkgs...)...)
 
 	mockCommandRunner.EXPECT().Run(ctx, expectedCmd).Return([]byte("stdout"), []byte("stderr"), nil).Times(1)
 	if err := RemoveYumPackages(ctx, pkgs); err != nil {
@@ -84,7 +84,7 @@ func TestYumUpdates(t *testing.T) {
 		os.Exit(100)
 	}
 
-	cmd := exec.Command(os.Args[0], "-test.run=TestYumUpdates")
+	cmd := exec.CommandContext(context.Background(), os.Args[0], "-test.run=TestYumUpdates")
 	cmd.Env = append(os.Environ(), "EXIT100=1")
 	errExit100 := cmd.Run()
 
@@ -94,7 +94,7 @@ func TestYumUpdates(t *testing.T) {
 	mockCommandRunner := utilmocks.NewMockCommandRunner(mockCtrl)
 	runner = mockCommandRunner
 	ptyrunner = mockCommandRunner
-	expectedCheckUpdate := exec.Command(yum, yumCheckUpdateArgs...)
+	expectedCheckUpdate := exec.CommandContext(context.Background(), yum, yumCheckUpdateArgs...)
 
 	// Test Error
 	t.Run("Error", func(t *testing.T) {
@@ -118,7 +118,7 @@ func TestYumUpdates(t *testing.T) {
 
 	// Test no options
 	t.Run("NoOptions", func(t *testing.T) {
-		expectedCmd := exec.Command(yum, yumListUpdatesArgs...)
+		expectedCmd := exec.CommandContext(context.Background(), yum, yumListUpdatesArgs...)
 
 		first := mockCommandRunner.EXPECT().Run(testCtx, expectedCheckUpdate).Return(data, []byte("stderr"), errExit100).Times(1)
 		mockCommandRunner.EXPECT().Run(testCtx, expectedCmd).After(first).Return(data, []byte("stderr"), nil).Times(1)
@@ -137,7 +137,7 @@ func TestYumUpdates(t *testing.T) {
 
 	// Test MinimalWithSecurity
 	t.Run("MinimalWithSecurity", func(t *testing.T) {
-		expectedCmd := exec.Command(yum, append(yumListUpdateMinimalArgs, "--security")...)
+		expectedCmd := exec.CommandContext(context.Background(), yum, append(yumListUpdateMinimalArgs, "--security")...)
 
 		first := mockCommandRunner.EXPECT().Run(testCtx, expectedCheckUpdate).Return(data, []byte("stderr"), errExit100).Times(1)
 		mockCommandRunner.EXPECT().Run(testCtx, expectedCmd).After(first).Return(data, []byte("stderr"), nil).Times(1)
@@ -161,7 +161,7 @@ func TestYumUpdates(t *testing.T) {
 		// when customer specifies excluded packages, we set the --exclude flag
 		// in the yum command.
 		excludedPackages := []string{"ex-pkg1", "ex-pkg2"}
-		expectedCmd := exec.Command(yum, append(yumListUpdatesArgs, "--security", "--exclude", excludedPackages[0], "--exclude", excludedPackages[1])...)
+		expectedCmd := exec.CommandContext(context.Background(), yum, append(yumListUpdatesArgs, "--security", "--exclude", excludedPackages[0], "--exclude", excludedPackages[1])...)
 
 		first := mockCommandRunner.EXPECT().Run(testCtx, expectedCheckUpdate).Return(data, []byte("stderr"), errExit100).Times(1)
 		mockCommandRunner.EXPECT().Run(testCtx, expectedCmd).After(first).Return(data, []byte("stderr"), nil).Times(1)

--- a/packages/zypper.go
+++ b/packages/zypper.go
@@ -103,7 +103,7 @@ func ZypperInstall(ctx context.Context, patches []*ZypperPatch, pkgs []*PkgInfo)
 		args = append(args, "package:"+pkg.Name)
 	}
 
-	stdout, stderr, err := runner.Run(ctx, exec.Command(zypper, args...))
+	stdout, stderr, err := runner.Run(ctx, exec.CommandContext(ctx, zypper, args...))
 	// https://en.opensuse.org/SDB:Zypper_manual#EXIT_CODES
 	if err != nil {
 		if exitErr, ok := err.(*exec.ExitError); ok {

--- a/packages/zypper_test.go
+++ b/packages/zypper_test.go
@@ -15,6 +15,7 @@
 package packages
 
 import (
+	"context"
 	"errors"
 	"os/exec"
 	"reflect"
@@ -31,7 +32,7 @@ func TestZypperInstalls(t *testing.T) {
 
 	mockCommandRunner := utilmocks.NewMockCommandRunner(mockCtrl)
 	runner = mockCommandRunner
-	expectedCmd := exec.Command(zypper, append(zypperInstallArgs, pkgs...)...)
+	expectedCmd := exec.CommandContext(context.Background(), zypper, append(zypperInstallArgs, pkgs...)...)
 
 	mockCommandRunner.EXPECT().Run(testCtx, expectedCmd).Return([]byte("stdout"), []byte("stderr"), nil).Times(1)
 	if err := InstallZypperPackages(testCtx, pkgs); err != nil {
@@ -50,7 +51,7 @@ func TestRemoveZypper(t *testing.T) {
 
 	mockCommandRunner := utilmocks.NewMockCommandRunner(mockCtrl)
 	runner = mockCommandRunner
-	expectedCmd := exec.Command(zypper, append(zypperRemoveArgs, pkgs...)...)
+	expectedCmd := exec.CommandContext(context.Background(), zypper, append(zypperRemoveArgs, pkgs...)...)
 
 	mockCommandRunner.EXPECT().Run(testCtx, expectedCmd).Return([]byte("stdout"), []byte("stderr"), nil).Times(1)
 	if err := RemoveZypperPackages(testCtx, pkgs); err != nil {
@@ -94,7 +95,7 @@ func TestZypperUpdates(t *testing.T) {
 
 	mockCommandRunner := utilmocks.NewMockCommandRunner(mockCtrl)
 	runner = mockCommandRunner
-	expectedCmd := exec.Command(zypper, zypperListUpdatesArgs...)
+	expectedCmd := exec.CommandContext(context.Background(), zypper, zypperListUpdatesArgs...)
 
 	data := []byte("v | SLES12-SP3-Updates  | at                     | 3.1.14-7.3      | 3.1.14-8.3.1      | x86_64")
 	mockCommandRunner.EXPECT().Run(testCtx, expectedCmd).Return(data, []byte("stderr"), nil).Times(1)
@@ -157,7 +158,7 @@ func TestZypperPatches(t *testing.T) {
 
 	mockCommandRunner := utilmocks.NewMockCommandRunner(mockCtrl)
 	runner = mockCommandRunner
-	expectedCmd := exec.Command(zypper, append(zypperListPatchesArgs, "--all")...)
+	expectedCmd := exec.CommandContext(context.Background(), zypper, append(zypperListPatchesArgs, "--all")...)
 
 	data := []byte("SLE-Module-Basesystem15-SP1-Updates | SUSE-SLE-Module-Basesystem-15-SP1-2019-1258 | recommended | moderate  | ---         | needed     | Recommended update for postfix")
 	mockCommandRunner.EXPECT().Run(testCtx, expectedCmd).Return(data, []byte("stderr"), nil).Times(1)
@@ -183,7 +184,7 @@ func TestZypperInstalledPatches(t *testing.T) {
 
 	mockCommandRunner := utilmocks.NewMockCommandRunner(mockCtrl)
 	runner = mockCommandRunner
-	expectedCmd := exec.Command(zypper, append(zypperListPatchesArgs, "--all")...)
+	expectedCmd := exec.CommandContext(context.Background(), zypper, append(zypperListPatchesArgs, "--all")...)
 
 	data := []byte("SLE-Module-Basesystem15-SP1-Updates | SUSE-SLE-Module-Basesystem-15-SP1-2019-1258 | recommended | moderate  | ---         | applied     | Recommended update for postfix")
 	mockCommandRunner.EXPECT().Run(testCtx, expectedCmd).Return(data, []byte("stderr"), nil).Times(1)

--- a/util/util.go
+++ b/util/util.go
@@ -129,7 +129,22 @@ func (r *DefaultRunner) Run(ctx context.Context, cmd *exec.Cmd) ([]byte, []byte,
 	cmd.Stdout = &stdout
 	cmd.Stderr = &stderr
 	err := cmd.Run()
-	clog.Debugf(ctx, "%s %q exit code: %d, output:\n%s", cmd.Path, cmd.Args[1:], cmd.ProcessState.ExitCode(), strings.ReplaceAll(stdout.String(), "\n", "\n "))
+	clog.DebugStructured(
+		ctx,
+		struct {
+			Command  string
+			Args     []string
+			ExitCode interface{}
+			Stdout   string
+			Stderr   string
+		}{
+			Command:  cmd.Path,
+			Args:     cmd.Args[1:],
+			ExitCode: cmd.ProcessState.ExitCode(),
+			Stdout:   stdout.String(),
+			Stderr:   stderr.String(),
+		},
+		"%s %q exit code: %d, output:\n%s", cmd.Path, cmd.Args[1:], cmd.ProcessState.ExitCode(), strings.ReplaceAll(stdout.String(), "\n", "\n "))
 	return stdout.Bytes(), stderr.Bytes(), err
 }
 


### PR DESCRIPTION
Add better debug logging to DefaultRunner.Run()