### PR TITLE
Add Terraform scripts for multi-project deployments

### DIFF
--- a/examples/Terraform/README.md
+++ b/examples/Terraform/README.md
@@ -1,0 +1,6 @@
+# Terraform Examples
+
+This directory contains examples illustrating the use of Terraform for creating
+OSConfig related resources.
+
+

--- a/examples/Terraform/multi-project-deployments/README.md
+++ b/examples/Terraform/multi-project-deployments/README.md
@@ -1,0 +1,110 @@
+# Prototype to deploy OSConfig Guest Policies in Multiple GCP Projects
+
+This guide describes how to use [Terraform](https://www.terraform.io/) to deploy an OSConfig Guest Policy in multiple GCP Projects.
+
+It proceeds through the following stages:
+
+*  Determine the list of GCP Projects
+*  For each one of them
+   *  Create OSConfig Guest Policies that will execute a basic command (as an illustrative example)
+
+# How to use
+
+From the [Cloud Shell](https://cloud.google.com/shell)
+
+## Clone the repository
+
+Clone the Git repository with the command
+
+```
+git clone ssh://username@gmail.com@source.developers.google.com:2022/p/scip-deployment-manager-dev/r/terraform-multi-project-osconfig-guest-policy
+```
+
+change directory, into the repository
+
+```
+cd terraform-multi-project-osconfig-guest-policy
+```
+
+## Configure Authorization
+
+A service account ought to be authorized to perform operations in Google Cloud
+infrastructure.
+
+### Create Custom IAM Roles
+
+In order to assign all the necessary permissions to the service account,
+[create an IAM custom 
+role](https://cloud.google.com/sdk/gcloud/reference/beta/iam/roles/create)
+using the following commands in the script:
+
+```
+preparation_scripts/create_terraform_custom_role.sh
+enable_services_in_admin_project.sh
+```
+
+Where the `TerraformDeployer.yaml` file in this repository already specifies all the permissions needed.
+
+### Create Service Account and assign Custom IAM Role
+
+Use the commands in the script:
+
+```
+preparation_scripts/create_terraform_service_account.sh
+```
+
+in order to:
+
+*  Create a dedicated service account
+*  Assign to it the Custom IAM Role
+*  Download the service account key
+
+which follows the GCP documentation for
+
+*  [Creating service accounts](https://cloud.google.com/sdk/gcloud/reference/iam/service-accounts/create).
+*  [Binding IAM policies](https://cloud.google.com/sdk/gcloud/reference/projects/add-iam-policy-binding).
+*  [Creating service account keys](https://cloud.google.com/sdk/gcloud/reference/iam/service-accounts/keys/create).
+
+
+### Enable required services
+
+Use the command in the script
+
+```
+preparation_scripts/enable_services_in_admin_project.sh
+```
+
+to enable the API services required for this tutorial.
+
+
+### Set up environment variables
+
+As a helper example, use the file
+
+```
+preparation_scripts/setup_env.sh
+```
+
+Edit the file to introduce the appropriate values in the environment variables.
+
+Then use the command
+
+```
+source preparation_scripts/setup_env.sh
+```
+
+### Create Resources in order
+
+You can now proceed to create the cloud resouces by using the following modules in order:
+
+```
+create_projects
+enable_projects_for_vmmanager
+create_guest_policies
+create_patch_deployments
+create_vm_instances
+```
+
+Note that the last one `create_vm_instance` could be done either before or after `create_guest_policies` and `create_path_deployments`.
+
+

--- a/examples/Terraform/multi-project-deployments/auth/README.md
+++ b/examples/Terraform/multi-project-deployments/auth/README.md
@@ -1,0 +1,10 @@
+This directory is a placeholder for authorization-related files.
+
+For example, the Service Account key file.
+
+
+Use the files below to create IAM Custom Roles:
+
+* TerraformDeployer.yaml:   for creating Folders, Projects and VMs
+* VM_Manager_Deployer.yaml: for creating OS Config Guest Policies and Patch Deployments
+

--- a/examples/Terraform/multi-project-deployments/auth/TerraformDeployer.yaml
+++ b/examples/Terraform/multi-project-deployments/auth/TerraformDeployer.yaml
@@ -1,0 +1,33 @@
+title: Terraform Deployer can create GCP resources
+description: Custom Role for service account that deploys Terraform plans.
+stage: ALPHA
+includedPermissions:
+- compute.addresses.create
+- compute.addresses.delete
+- compute.addresses.get
+- compute.addresses.use
+- compute.disks.create
+- compute.firewalls.create
+- compute.firewalls.delete
+- compute.firewalls.get
+- compute.instanceTemplates.create
+- compute.instanceTemplates.delete
+- compute.instanceTemplates.get
+- compute.instanceTemplates.useReadOnly
+- compute.instances.create
+- compute.instances.delete
+- compute.instances.get
+- compute.instances.setLabels
+- compute.instances.setMetadata
+- compute.instances.setServiceAccount
+- compute.networks.get
+- compute.networks.updatePolicy
+- compute.subnetworks.use
+- compute.subnetworks.useExternalIp
+- compute.zones.get
+- compute.zones.list
+- billing.resourceAssociations.create
+- resourcemanager.organizations.get
+- resourcemanager.folders.create
+- resourcemanager.projects.create
+- resourcemanager.projects.createBillingAssignment

--- a/examples/Terraform/multi-project-deployments/auth/VM_Manager_Deployer.yaml
+++ b/examples/Terraform/multi-project-deployments/auth/VM_Manager_Deployer.yaml
@@ -1,0 +1,8 @@
+title: VM Manager Deployer
+description: Custom Role for creating  Guest Policies and Patch Jobs
+stage: ALPHA
+includedPermissions:
+- osconfig.guestPolicies.update
+- resourcemanager.organizations.get
+- resourcemanager.projects.create
+- resourcemanager.projects.createBillingAssignment

--- a/examples/Terraform/multi-project-deployments/create_guest_policies/README.md
+++ b/examples/Terraform/multi-project-deployments/create_guest_policies/README.md
@@ -1,0 +1,48 @@
+# OSConfig Guest Policies
+
+This module is used to create an OSConfig Guest Policy that will trigger
+an installation in the VM instances belonging to this project.
+
+# Usage
+
+## Configure the Variables
+
+*  Define the folder name in the environment variable: `TF_VAR_folder_name`.
+*  Define the organization ID in the environment variable: `TF_VAR_organization_id`.
+
+For example:
+
+```
+export TF_VAR_folder_name="production-department-x-folder"
+export TF_VAR_organization_id="0123456789"
+```
+
+## Launching the Module
+
+Use the standard commands
+
+```
+terraform init
+```
+
+```
+terraform validate
+```
+
+```
+terraform plan -out=plan.out
+```
+
+Inspect the output, and if you are satisfied, run
+
+```
+terraform apply plan.out
+```
+
+## Destroying the Resources
+
+Once you no longer have use for the OSConfig Guest Policies, you can destroy them with the command
+
+```
+terraform destroy
+```

--- a/examples/Terraform/multi-project-deployments/create_guest_policies/guest_policy_bash_script.txt
+++ b/examples/Terraform/multi-project-deployments/create_guest_policies/guest_policy_bash_script.txt
@@ -1,0 +1,13 @@
+date >> /tmp/osconfig-terraform-multi-project-test.txt
+echo "Execution PASSED!" >> date >> /tmp/osconfig-terraform-multi-project-test.txt
+
+INSTANCE_NAME=$(curl http://metadata.google.internal/computeMetadata/v1/instance/name -H Metadata-Flavor:Google)
+INSTANCE_ZONE=$(curl http://metadata.google.internal/computeMetadata/v1/instance/zone -H Metadata-Flavor:Google | cut -d'/' -f4)
+
+echo "INSTANCE_NAME=${INSTANCE_NAME}" >> /tmp/osconfig-terraform-multi-project-test.txt
+echo "INSTANCE_ZONE=${INSTANCE_ZONE}" >> /tmp/osconfig-terraform-multi-project-test.txt
+
+gcloud compute instances add-metadata \
+  "${INSTANCE_NAME}" \
+  --zone="${INSTANCE_ZONE}" \
+  --metadata='osconfig-terraform-multi-project-test=PASSED'

--- a/examples/Terraform/multi-project-deployments/create_guest_policies/main.tf
+++ b/examples/Terraform/multi-project-deployments/create_guest_policies/main.tf
@@ -1,0 +1,61 @@
+locals {
+  guest_policy_linux = file("${path.module}/guest_policy_bash_script.txt")
+}
+
+data "google_active_folder" "terraform_osconfig" {
+  display_name = var.folder_name
+  parent       = "organizations/${var.organization_id}"
+}
+
+locals {
+  folder_id = split("/",data.google_active_folder.terraform_osconfig.id)[1]
+}
+
+data "google_projects" "in_folder" {
+  filter = "parent.id:${local.folder_id}"
+}
+
+data "google_project" "listed_in_folder" {
+  count = length(data.google_projects.in_folder.projects)
+
+  project_id = data.google_projects.in_folder.projects[count.index].project_id
+}
+
+locals {
+  projects = compact(data.google_project.listed_in_folder.*.number)
+}
+
+resource "google_os_config_guest_policies" "guest_policies" {
+  provider = google-beta
+
+  count = length(data.google_projects.in_folder.projects)
+
+  guest_policy_id = "tf-test-guest-policy"
+  description     = "Test OSConfig Guest Policy in Linux VM instances."
+
+  project = data.google_projects.in_folder.projects[count.index].project_id
+
+  assignment {
+    group_labels {
+      labels = var.labels
+    }
+    os_types {
+      os_short_name = "DEBIAN"
+      os_version    = "9*"
+    }
+    os_types {
+      os_short_name = "UBUNTU"
+    }
+  }
+
+  recipes {
+    name          = "tf-test-recipe-linux"
+    desired_state = "INSTALLED"
+    install_steps {
+      script_run {
+        interpreter = "SHELL"
+        script      = local.guest_policy_linux
+      }
+    }
+  }
+}

--- a/examples/Terraform/multi-project-deployments/create_guest_policies/outputs.tf
+++ b/examples/Terraform/multi-project-deployments/create_guest_policies/outputs.tf
@@ -1,0 +1,14 @@
+output "folder_id" {
+  description = "ID of the folder containing projects of interest."
+  value       = local.folder_id
+}
+
+output "google_projects" {
+  description = "List of projects inside a given folder"
+  value       = local.projects
+}
+
+output "guest_policies_self_links" {
+  description = "List of self-links for OSConfig Guest Policies."
+  value       = google_os_config_guest_policies.guest_policies
+}

--- a/examples/Terraform/multi-project-deployments/create_guest_policies/terraform.example.tfvars
+++ b/examples/Terraform/multi-project-deployments/create_guest_policies/terraform.example.tfvars
@@ -1,0 +1,3 @@
+labels = {
+  key = "value"
+}

--- a/examples/Terraform/multi-project-deployments/create_guest_policies/terraform.tfvars
+++ b/examples/Terraform/multi-project-deployments/create_guest_policies/terraform.tfvars
@@ -1,0 +1,3 @@
+labels = {
+  pizza_topping = "pepperoni"
+}

--- a/examples/Terraform/multi-project-deployments/create_guest_policies/variables.tf
+++ b/examples/Terraform/multi-project-deployments/create_guest_policies/variables.tf
@@ -1,0 +1,14 @@
+variable "organization_id" {
+  description = "Cloud Organization where to create Projects."
+  type        = string
+}
+
+variable "folder_name" {
+  description = "Folder from where to list projects."
+  type        = string
+}
+
+variable "labels" {
+  description = "Labels, provided as a map"
+  type        = map(string)
+}

--- a/examples/Terraform/multi-project-deployments/create_guest_policies/versions.tf
+++ b/examples/Terraform/multi-project-deployments/create_guest_policies/versions.tf
@@ -1,0 +1,12 @@
+terraform {
+  required_version = ">=0.13.0"
+  required_providers {
+    google  = ">= 3.43, <4.0"
+    archive = "~> 1.0"
+    random  = "~> 2.0"
+    null    = "~> 2.1"
+  }
+  provider_meta "google" {
+    module_name = "blueprints/terraform/terraform-google-vm:compute_instance/v6.1.0"
+  }
+}

--- a/examples/Terraform/multi-project-deployments/create_patch_deployments/README.md
+++ b/examples/Terraform/multi-project-deployments/create_patch_deployments/README.md
@@ -1,0 +1,49 @@
+# OSConfig Patch Deployments
+
+This module is used to create an OSConfig Patch Deployment that will trigger
+the application of a patch in VMs on multiple projects.
+
+# Usage
+
+## Configure the Variables
+
+*  Define the folder name in the environment variable: `TF_VAR_folder_name`.
+*  Define the organization ID in the environment variable: `TF_VAR_organization_id`.
+
+For example:
+
+```
+export TF_VAR_folder_name="production-department-x-folder"
+export TF_VAR_organization_id="0123456789"
+```
+
+
+## Launching the Module
+
+Use the standard commands
+
+```
+terraform init
+```
+
+```
+terraform validate
+```
+
+```
+terraform plan -out=plan.out
+```
+
+Inspect the output, and if you are satisfied, run
+
+```
+terraform apply plan.out
+```
+
+## Destroying the Resources
+
+Once you no longer have use for the OSConfig Patch Deployments, you can destroy them with the command
+
+```
+terraform destroy
+```

--- a/examples/Terraform/multi-project-deployments/create_patch_deployments/main.tf
+++ b/examples/Terraform/multi-project-deployments/create_patch_deployments/main.tf
@@ -1,0 +1,41 @@
+data "google_active_folder" "terraform_osconfig" {
+  display_name = var.folder_name
+  parent       = "organizations/${var.organization_id}"
+}
+
+locals {
+  folder_id = split("/",data.google_active_folder.terraform_osconfig.id)[1]
+}
+
+data "google_projects" "in_folder" {
+  filter = "parent.id:${local.folder_id}"
+}
+
+data "google_project" "list_in_folder" {
+  count = length(data.google_projects.in_folder.projects)
+
+  project_id = data.google_projects.in_folder.projects[count.index].project_id
+}
+
+locals {
+  projects = compact(data.google_project.list_in_folder.*.number)
+}
+
+resource "google_os_config_patch_deployment" "patch_deployments" {
+  patch_deployment_id = "patch-deploy-inst"
+
+  count = length(data.google_projects.in_folder.projects)
+
+  project = data.google_projects.in_folder.projects[count.index].project_id
+
+  instance_filter {
+    group_labels {
+      labels = var.labels
+      }
+    }
+
+  one_time_schedule {
+    # Execute 2 minutes from now
+    execute_time = timeadd(timestamp(), var.patch_deployment_execute_time)
+  }
+}

--- a/examples/Terraform/multi-project-deployments/create_patch_deployments/outputs.tf
+++ b/examples/Terraform/multi-project-deployments/create_patch_deployments/outputs.tf
@@ -1,0 +1,14 @@
+output "folder_id" {
+  description = "ID of the folder containing projects of interest."
+  value       = local.folder_id
+}
+
+output "google_projects" {
+  description = "List of projects inside a given folder"
+  value       = local.projects
+}
+
+output "patch_deployments_self_links" {
+  description = "List of self-links for OSConfig Patch Deployments."
+  value       = google_os_config_patch_deployment.patch_deployments
+}

--- a/examples/Terraform/multi-project-deployments/create_patch_deployments/terraform.example.tfvars
+++ b/examples/Terraform/multi-project-deployments/create_patch_deployments/terraform.example.tfvars
@@ -1,0 +1,3 @@
+labels = {
+  key = "value"
+}

--- a/examples/Terraform/multi-project-deployments/create_patch_deployments/terraform.tfvars
+++ b/examples/Terraform/multi-project-deployments/create_patch_deployments/terraform.tfvars
@@ -1,0 +1,3 @@
+labels = {
+  pizza_topping = "pepperoni"
+}

--- a/examples/Terraform/multi-project-deployments/create_patch_deployments/variables.tf
+++ b/examples/Terraform/multi-project-deployments/create_patch_deployments/variables.tf
@@ -1,0 +1,19 @@
+variable "organization_id" {
+  description = "Cloud Organization where to create Projects."
+  type        = string
+}
+
+variable "folder_name" {
+  description = "Folder from where to list projects."
+  type        = string
+}
+
+variable "labels" {
+  description = "Labels, provided as a map"
+  type        = map(string)
+}
+
+variable "patch_deployment_execute_time" {
+  description = "Time to wait before deploying the patch jobs."
+  type        = string
+}

--- a/examples/Terraform/multi-project-deployments/create_patch_deployments/versions.tf
+++ b/examples/Terraform/multi-project-deployments/create_patch_deployments/versions.tf
@@ -1,0 +1,12 @@
+terraform {
+  required_version = ">=0.13.0"
+  required_providers {
+    google  = ">= 3.43, <4.0"
+    archive = "~> 1.0"
+    random  = "~> 2.0"
+    null    = "~> 2.1"
+  }
+  provider_meta "google" {
+    module_name = "blueprints/terraform/terraform-google-vm:compute_instance/v6.1.0"
+  }
+}

--- a/examples/Terraform/multi-project-deployments/create_projects/README.md
+++ b/examples/Terraform/multi-project-deployments/create_projects/README.md
@@ -1,0 +1,45 @@
+# Create GCP Project in a Folder
+
+This module is used to create a set of GCP projects in a Folder.
+
+# Usage
+
+## Configure the Variables
+
+The variables required by this module are defined in the `variables.tf` file.
+
+You can provide the specific values desired for your case by defining the environment variables
+
+*   `TF_VAR_organization_id`
+*   `TF_VAR_folder_name`
+*   `TF_VAR_billing_account`
+
+## Launching the Module
+
+Use the standard commands
+
+```
+terraform init
+```
+
+```
+terraform validate
+```
+
+```
+terraform plan -out=plan.out
+```
+
+Inspect the output, and if you are satisfied, run
+
+```
+terraform apply plan.out
+```
+
+## Destroying the Resources
+
+Once you no longer have use for the projects, you can destroy them with the command
+
+```
+terraform destroy
+```

--- a/examples/Terraform/multi-project-deployments/create_projects/main.tf
+++ b/examples/Terraform/multi-project-deployments/create_projects/main.tf
@@ -1,0 +1,16 @@
+resource "google_folder" "tf_osconfig_folder" {
+  display_name = var.folder_name
+  parent       = "organizations/${var.organization_id}"
+}
+
+module "project-tf" {
+  source = "terraform-google-modules/project-factory/google"
+
+  count = 3
+
+  name              = "tf-osconfig-test-${count.index}"
+  random_project_id = "true"
+  org_id            = var.organization_id
+  billing_account   = var.billing_account
+  folder_id         = google_folder.tf_osconfig_folder.id
+}

--- a/examples/Terraform/multi-project-deployments/create_projects/outputs.tf
+++ b/examples/Terraform/multi-project-deployments/create_projects/outputs.tf
@@ -1,0 +1,10 @@
+output "folder" {
+  description = "The ID of the new folder"
+  value       = google_folder.tf_osconfig_folder.id
+}
+
+output "projects_self_links" {
+  description = "List of self-links to created projects"
+  value       = ["${module.project-tf.*}"]
+}
+

--- a/examples/Terraform/multi-project-deployments/create_projects/variables.tf
+++ b/examples/Terraform/multi-project-deployments/create_projects/variables.tf
@@ -1,0 +1,14 @@
+variable "organization_id" {
+  description = "Cloud Organization where to create Projects."
+  type        = string
+}
+
+variable "folder_name" {
+  description = "New folder in which to create Projects."
+  type        = string
+}
+
+variable "billing_account" {
+  description = "Billing Account to which charge the Projects."
+  type        = string
+}

--- a/examples/Terraform/multi-project-deployments/create_projects/versions.tf
+++ b/examples/Terraform/multi-project-deployments/create_projects/versions.tf
@@ -1,0 +1,12 @@
+terraform {
+  required_version = ">=0.13.0"
+  required_providers {
+    google  = ">= 3.43, <4.0"
+    archive = "~> 1.0"
+    random  = "~> 2.0"
+    null    = "~> 2.1"
+  }
+  provider_meta "google" {
+    module_name = "blueprints/terraform/terraform-google-vm:compute_instance/v6.1.0"
+  }
+}

--- a/examples/Terraform/multi-project-deployments/create_vm_instances/README.md
+++ b/examples/Terraform/multi-project-deployments/create_vm_instances/README.md
@@ -1,0 +1,48 @@
+# VM Instances
+
+This module is used to create multple VM instances for the purpose of testing
+the execution of the OSConfig Guest Policy.
+
+# Usage
+
+## Configure the Variables
+
+*  Define the folder name in the environment variable: `TF_VAR_folder_name`.
+*  Define the organization ID in the environment variable: `TF_VAR_organization_id`.
+
+For example:
+
+```
+export TF_VAR_folder_name="production-department-x-folder"
+export TF_VAR_organization_id="0123456789"
+```
+
+## Launching the Module
+
+Use the standard commands
+
+```
+terraform init
+```
+
+```
+terraform validate
+```
+
+```
+terraform plan -out=plan.out
+```
+
+Inspect the output, and if you are satisfied, run
+
+```
+terraform apply plan.out
+```
+
+## Destroying the Resources
+
+Once you no longer have use for the VM instances, you can destroy them with the command
+
+```
+terraform destroy
+```

--- a/examples/Terraform/multi-project-deployments/create_vm_instances/main.tf
+++ b/examples/Terraform/multi-project-deployments/create_vm_instances/main.tf
@@ -1,0 +1,143 @@
+data "google_active_folder" "terraform_osconfig" {
+  display_name = var.folder_name
+  parent       = "organizations/${var.organization_id}"
+}
+
+locals {
+  folder_id = split("/",data.google_active_folder.terraform_osconfig.id)[1]
+}
+
+data "google_projects" "in_folder" {
+  filter = "parent.id:${local.folder_id}"
+}
+
+data "google_project" "list_in_folder" {
+  count = length(data.google_projects.in_folder.projects)
+
+  project_id = data.google_projects.in_folder.projects[count.index].project_id
+}
+
+locals {
+  projects = compact(data.google_project.list_in_folder.*.number)
+}
+
+
+locals {
+  scopes = [
+    #
+    #  Required by OS Config
+    #
+    "https://www.googleapis.com/auth/cloud-platform",
+    #
+    # Default scopes
+    #   https://cloud.google.com/sdk/gcloud/reference/alpha/compute/instances/set-scopes#--scopes
+    "https://www.googleapis.com/auth/devstorage.read_only",
+    "https://www.googleapis.com/auth/logging.write",
+    "https://www.googleapis.com/auth/monitoring.write",
+    "https://www.googleapis.com/auth/pubsub",
+    "https://www.googleapis.com/auth/service.management.readonly",
+    "https://www.googleapis.com/auth/servicecontrol",
+    "https://www.googleapis.com/auth/trace.append",
+  ]
+}
+
+
+resource "google_compute_network" "vpc_network" {
+  name    = "vpc-network"
+  count   = length(data.google_projects.in_folder.projects)
+  project = data.google_projects.in_folder.projects[count.index].project_id
+}
+
+resource "google_compute_firewall" "default" {
+  name    = "ssh-firewall-rule"
+  count   = length(data.google_projects.in_folder.projects)
+  project = data.google_projects.in_folder.projects[count.index].project_id
+  network = google_compute_network.vpc_network[count.index].name
+  allow {
+    protocol = "tcp"
+    ports    = ["22"]
+  }
+}
+
+resource "google_compute_address" "external_ip" {
+  name    = "external-ip"
+  region  = "us-central1"
+  count   = length(data.google_projects.in_folder.projects)
+  project = data.google_projects.in_folder.projects[count.index].project_id
+}
+
+resource "google_service_account" "default" {
+  account_id   = "tf-osconfig-vm"
+  display_name = "TF OSConfig VM Service Account"
+  count        = length(data.google_projects.in_folder.projects)
+  project      = data.google_projects.in_folder.projects[count.index].project_id
+}
+
+#
+#  The following roles are needed for the service account to be able to write instance metadata.
+#
+resource "google_project_iam_binding" "log_writer" {
+  count   = length(data.google_projects.in_folder.projects)
+  project = data.google_projects.in_folder.projects[count.index].project_id
+  role    = "roles/logging.logWriter"
+  members = [
+    "serviceAccount:${google_service_account.default[count.index].email}"
+  ]
+}
+
+resource "google_project_iam_binding" "compute_viewer" {
+  count   = length(data.google_projects.in_folder.projects)
+  project = data.google_projects.in_folder.projects[count.index].project_id
+  role    = "roles/compute.viewer"
+  members = [
+    "serviceAccount:${google_service_account.default[count.index].email}"
+  ]
+}
+
+resource "google_project_iam_binding" "compute_instance_admin_v1" {
+  count   = length(data.google_projects.in_folder.projects)
+  project = data.google_projects.in_folder.projects[count.index].project_id
+  role    = "roles/compute.instanceAdmin.v1"
+  members = [
+    "serviceAccount:${google_service_account.default[count.index].email}"
+  ]
+}
+
+resource "google_project_iam_binding" "iam_service_account_user" {
+  count   = length(data.google_projects.in_folder.projects)
+  project = data.google_projects.in_folder.projects[count.index].project_id
+  role    = "roles/iam.serviceAccountUser"
+  members = [
+    "serviceAccount:${google_service_account.default[count.index].email}"
+  ]
+}
+
+resource "google_compute_instance" "default" {
+  name = "tf-osconfig-vm"
+
+  count = length(data.google_projects.in_folder.projects)
+
+  project = data.google_projects.in_folder.projects[count.index].project_id
+
+  machine_type = "n1-standard-1"
+  zone         = "us-central1-a"
+
+  boot_disk {
+    initialize_params {
+      image = "debian-cloud/debian-9"
+    }
+  }
+
+  network_interface {
+    network = google_compute_network.vpc_network[count.index].name
+    access_config {
+      nat_ip = google_compute_address.external_ip[count.index].address
+    }
+  }
+
+  service_account {
+    email  = google_service_account.default[count.index].email
+    scopes = local.scopes
+  }
+  labels = var.labels
+}

--- a/examples/Terraform/multi-project-deployments/create_vm_instances/outputs.tf
+++ b/examples/Terraform/multi-project-deployments/create_vm_instances/outputs.tf
@@ -1,0 +1,20 @@
+output "folder_id" {
+  description = "ID of the folder containing projects of interest."
+  value       = local.folder_id
+}
+
+output "google_projects" {
+  description = "List of projects inside a given folder"
+  value       = local.projects
+}
+
+output "google_compute_instance_self_links" {
+  description = "List of self-links for VM instances."
+  value       = google_compute_instance.default
+  sensitive   = true
+}
+
+output "google_compute_instance_ip" {
+  description = "External IP addresses of VM instances."
+  value       = google_compute_address.external_ip
+}

--- a/examples/Terraform/multi-project-deployments/create_vm_instances/terraform.example.tfvars
+++ b/examples/Terraform/multi-project-deployments/create_vm_instances/terraform.example.tfvars
@@ -1,0 +1,3 @@
+labels = {
+  key = "value"
+}

--- a/examples/Terraform/multi-project-deployments/create_vm_instances/terraform.tfvars
+++ b/examples/Terraform/multi-project-deployments/create_vm_instances/terraform.tfvars
@@ -1,0 +1,3 @@
+labels = {
+  pizza_topping = "pepperoni"
+}

--- a/examples/Terraform/multi-project-deployments/create_vm_instances/variables.tf
+++ b/examples/Terraform/multi-project-deployments/create_vm_instances/variables.tf
@@ -1,0 +1,14 @@
+variable "organization_id" {
+  description = "Cloud Organization where to create Projects."
+  type        = string
+}
+
+variable "folder_name" {
+  description = "Folder from where to list projects."
+  type        = string
+}
+
+variable "labels" {
+  type        = map(string)
+  description = "Labels, provided as a map"
+}

--- a/examples/Terraform/multi-project-deployments/create_vm_instances/versions.tf
+++ b/examples/Terraform/multi-project-deployments/create_vm_instances/versions.tf
@@ -1,0 +1,9 @@
+terraform {
+  required_version = ">=0.13.0"
+  required_providers {
+    google = ">= 3.43, <4.0"
+  }
+  provider_meta "google" {
+    module_name = "blueprints/terraform/terraform-google-vm:compute_instance/v6.1.0"
+  }
+}

--- a/examples/Terraform/multi-project-deployments/enable_projects_for_vmmanager/README.md
+++ b/examples/Terraform/multi-project-deployments/enable_projects_for_vmmanager/README.md
@@ -1,0 +1,50 @@
+#  Enable Projects to use VMManager
+
+This module is used to enable projects to use the VMManager functionalities.
+
+This includes
+
+*   Enabling required APIs
+*   Defining METADATA at project level
+
+# Usage
+
+## Configure the Variables
+
+Define the folder name in the environment variable: `TF_VAR_folder_name`.
+
+For example:
+
+```
+export TF_VAR_folder_name="production-department-x-folder"
+```
+
+## Launching the Module
+
+Use the standard commands
+
+```
+terraform init
+```
+
+```
+terraform validate
+```
+
+```
+terraform plan -out=plan.out
+```
+
+Inspect the output, and if you are satisfied, run
+
+```
+terraform apply plan.out
+```
+
+## Destroying the Resources
+
+The resources created by this module can be destroyed with the command:
+
+```
+terraform destroy
+```

--- a/examples/Terraform/multi-project-deployments/enable_projects_for_vmmanager/main.tf
+++ b/examples/Terraform/multi-project-deployments/enable_projects_for_vmmanager/main.tf
@@ -1,0 +1,84 @@
+data "google_active_folder" "terraform_osconfig" {
+  display_name = var.folder_name
+  parent       = "organizations/${var.organization_id}"
+}
+
+locals {
+  folder_id = split("/",data.google_active_folder.terraform_osconfig.id)[1]
+}
+
+data "google_projects" "in_folder" {
+  filter = "parent.id:${local.folder_id}"
+}
+
+data "google_project" "listed_in_folder" {
+  count = length(data.google_projects.in_folder.projects)
+
+  project_id = data.google_projects.in_folder.projects[count.index].project_id
+}
+
+locals {
+  projects  = compact(data.google_project.listed_in_folder.*.number)
+}
+
+module "project-services" {
+  source  = "terraform-google-modules/project-factory/google//modules/project_services"
+
+  count = length(data.google_projects.in_folder.projects)
+
+  project_id = data.google_projects.in_folder.projects[count.index].project_id
+
+  enable_apis = true
+  activate_apis = [
+    "iam.googleapis.com",
+    "logging.googleapis.com",
+    "osconfig.googleapis.com",
+    "containeranalysis.googleapis.com",
+  ]
+}
+
+
+resource "google_project_service" "compute_api" {
+  count = length(data.google_projects.in_folder.projects)
+
+  project = data.google_projects.in_folder.projects[count.index].project_id
+
+  service = "compute.googleapis.com"
+  # Wait for some time after the API has been enabled before continuing, as the
+  # call returns before the API has actually finished initializing.
+  provisioner "local-exec" {
+    command ="sleep 60"
+  }
+}
+
+
+resource "google_compute_project_metadata_item" "osconfig_enable_meta" {
+  count = length(data.google_projects.in_folder.projects)
+
+  project = data.google_projects.in_folder.projects[count.index].project_id
+
+  key     = "enable-osconfig"
+  value   = "TRUE"
+  depends_on = [ google_project_service.compute_api ]
+}
+
+resource "google_compute_project_metadata_item" "osconfig_log_level_meta" {
+  count = length(data.google_projects.in_folder.projects)
+
+  project = data.google_projects.in_folder.projects[count.index].project_id
+
+  key     = "osconfig-log-level"
+  value   = "debug"
+  depends_on = [ google_project_service.compute_api ]
+}
+
+resource "google_compute_project_metadata_item" "enable_guest_attributes_meta" {
+  count = length(data.google_projects.in_folder.projects)
+
+  project = data.google_projects.in_folder.projects[count.index].project_id
+
+  key     = "enable-guest-attributes"
+  value   = "TRUE"
+  depends_on = [ google_project_service.compute_api ]
+}
+

--- a/examples/Terraform/multi-project-deployments/enable_projects_for_vmmanager/outputs.tf
+++ b/examples/Terraform/multi-project-deployments/enable_projects_for_vmmanager/outputs.tf
@@ -1,0 +1,14 @@
+output "google_projects" {
+  description = "List of projects inside a given folder"
+  value       = local.projects
+}
+
+output "folder_name" {
+  description = "Folder Name"
+  value       = data.google_active_folder.terraform_osconfig.display_name
+}
+
+output "folder_id" {
+  description = "Folder ID"
+  value       = local.folder_id
+}

--- a/examples/Terraform/multi-project-deployments/enable_projects_for_vmmanager/variables.tf
+++ b/examples/Terraform/multi-project-deployments/enable_projects_for_vmmanager/variables.tf
@@ -1,0 +1,9 @@
+variable "organization_id" {
+  description = "Cloud Organization from where to list Projects."
+  type        = string
+}
+
+variable "folder_name" {
+  description = "Folder from where to list projects."
+  type        = string
+}

--- a/examples/Terraform/multi-project-deployments/enable_projects_for_vmmanager/versions.tf
+++ b/examples/Terraform/multi-project-deployments/enable_projects_for_vmmanager/versions.tf
@@ -1,0 +1,12 @@
+terraform {
+  required_version = ">=0.13.0"
+  required_providers {
+    google  = ">= 3.43, <4.0"
+    archive = "~> 1.0"
+    random  = "~> 2.0"
+    null    = "~> 2.1"
+  }
+  provider_meta "google" {
+    module_name = "blueprints/terraform/terraform-google-vm:compute_instance/v6.1.0"
+  }
+}

--- a/examples/Terraform/multi-project-deployments/preparation_scripts/create_terraform_custom_role.sh
+++ b/examples/Terraform/multi-project-deployments/preparation_scripts/create_terraform_custom_role.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+#
+#   Create IAM Custom role to use Terraform to create infrastructure
+#   such as Folders, Projects, VM instances, networks and firewalls.
+#
+
+gcloud iam roles create TerraformDeployer5 \
+--organization=${TF_VAR_organization_id} \
+--file=../auth/TerraformDeployer.yaml
+

--- a/examples/Terraform/multi-project-deployments/preparation_scripts/create_terraform_service_account.sh
+++ b/examples/Terraform/multi-project-deployments/preparation_scripts/create_terraform_service_account.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+#
+#   Create a service account dedicated to managing infrastructure
+#   via Terraform commands.
+#
+#
+
+
+SERVICE_ACCOUNT_NAME="terraform-infra"
+
+gcloud iam service-accounts create "${SERVICE_ACCOUNT_NAME}"
+
+
+#
+#  Grant the IAM Custom Role for Terraform to the service account
+#
+gcloud organizations add-iam-policy-binding ${TF_VAR_organization_id} \
+--member="serviceAccount:${SERVICE_ACCOUNT_NAME}@${TF_ADMIN_PROJECT}.iam.gserviceaccount.com" \
+--role=organizations/${TF_VAR_organization_id}/roles/TerraformDeployer5
+
+
+#
+#  Create and download keys from the service account
+#
+gcloud iam service-accounts keys create \
+../auth/terraform_deployer.json \
+--key-file-type=json \
+--iam-account=${SERVICE_ACCOUNT_NAME}@${TF_ADMIN_PROJECT}.iam.gserviceaccount.com
+
+
+export GOOGLE_APPLICATION_CREDENTIALS=../auth/terraform_deployer.json

--- a/examples/Terraform/multi-project-deployments/preparation_scripts/enable_services_in_admin_project.sh
+++ b/examples/Terraform/multi-project-deployments/preparation_scripts/enable_services_in_admin_project.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+#
+#  APIs to enable in the admin project
+#
+
+gcloud config set project "${TF_ADMIN_PROJECT}"
+
+gcloud services enable cloudbilling.googleapis.com
+gcloud services enable cloudresourcemanager.googleapis.com
+gcloud services enable compute.googleapis.com
+gcloud services enable iam.googleapis.com
+gcloud services enable serviceusage.googleapis.com
+gcloud services enable sourcerepo.googleapis.com

--- a/examples/Terraform/multi-project-deployments/preparation_scripts/setup_env.sh
+++ b/examples/Terraform/multi-project-deployments/preparation_scripts/setup_env.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+export TF_VAR_organization_id=""
+export TF_VAR_folder_name=""
+export TF_VAR_billing_account=""
+export TF_VAR_patch_deployment_execute_time=""
+export TF_ADMIN_PROJECT="terraform-admin-${USER}"
+export GOOGLE_APPLICATION_CREDENTIALS="${HOME}/service_account_key.json"


### PR DESCRIPTION
This Pull Requests contains the Terraform scripts that will accompany the Tutorial on how to use Terraform for creating Guest Policies and Patch Deployments in multiple GCP projects inside an organization.