### PR TITLE
Skip getting patch info when no patches are found.

### DIFF
--- a/packages/zypper.go
+++ b/packages/zypper.go
@@ -381,6 +381,9 @@ func parseZypperPatchInfo(out []byte) (map[string][]string, error) {
 
 // ZypperPackagesInPatch returns the list of patches, a package upgrade belongs to
 func ZypperPackagesInPatch(ctx context.Context, patches []*ZypperPatch) (map[string][]string, error) {
+	if len(patches) == 0 {
+		return make(map[string][]string), nil
+	}
 	var patchNames []string
 	for _, patch := range patches {
 		patchNames = append(patchNames, patch.Name)

--- a/packages/zypper_test.go
+++ b/packages/zypper_test.go
@@ -320,8 +320,7 @@ Conflicts   : [32]
 }
 
 func TestZypperPackagesInPatch(t *testing.T) {
-	patches := make([]*ZypperPatch, 0)
-	ppMap, err := ZypperPackagesInPatch(testCtx, patches)
+	ppMap, err := ZypperPackagesInPatch(testCtx, nil)
 	if err != nil {
 		t.Errorf("Unexpected error: %v", err)
 	}

--- a/packages/zypper_test.go
+++ b/packages/zypper_test.go
@@ -317,5 +317,15 @@ Conflicts   : [32]
 			}
 		}
 	}
+}
 
+func TestZypperPackagesInPatch(t *testing.T) {
+	patches := make([]*ZypperPatch, 0)
+	ppMap, err := ZypperPackagesInPatch(testCtx, patches)
+	if err != nil {
+		t.Errorf("Unexpected error: %v", err)
+	}
+	if len(ppMap) > 0 {
+		t.Errorf("Unexpected result: expected no mappings, got = [%+v]", ppMap)
+	}
 }


### PR DESCRIPTION
patch info command requires a patch name to be provided. When there is no such argument provided, the command errors out with exit code 3.