### PR TITLE
Update Zypper patch info parsing

### DIFF
--- a/packages/zypper.go
+++ b/packages/zypper.go
@@ -348,13 +348,13 @@ func parseZypperPatchInfo(out []byte) (map[string][]string, error) {
 			//python-solv.x86_64 < 0.6.36-2.27.19.8
 			//zypper.src < 1.13.54-18.40.2
 			//zypper.x86_64 < 1.13.54-18.40.2
-			//zypper-log.noarch < 1.13.54-18.40.2
+			//zypper-log < 1.13.54-18.40.2
 			parts := strings.Split(string(lines[ctr]), "<")
 			if len(parts) != 2 {
 				return nil, fmt.Errorf("invalid package info")
 			}
 			nameArch := strings.Split(parts[0], ".")
-			if len(nameArch) != 2 {
+			if len(nameArch) < 1 || len(nameArch) > 2 {
 				return nil, fmt.Errorf("invalid package info")
 			}
 

--- a/packages/zypper_test.go
+++ b/packages/zypper_test.go
@@ -290,6 +290,11 @@ Conflicts   : [32]
     python3-six.noarch < 1.11.0-9.21.2
     common-package.src < 1.1.0-9.3.1
     common-package.x86_64 < 1.1.0-9.3.1
+    zypper.src < 1.14.46-13.1
+    zypper.noarch < 1.14.46-13.1
+    zypper.x86_64 < 1.14.46-13.1
+    zypper-log < 1.14.46-13.1
+    zypper-needs-restarting < 1.14.46-13.1
 
 `
 	ppMap, err := parseZypperPatchInfo([]byte(patchInfo))


### PR DESCRIPTION
In the zypper info conflict section, the package names used to contain the architecture details as well. It has recently changed in SLES 15, which breaks the current parsing logic.

sample conflict section
`
Conflicts   : [10]
    libzypp.src < 17.27.0-12.1
    libzypp.noarch < 17.27.0-12.1
    libzypp.x86_64 < 17.27.0-12.1
    libzypp-devel.x86_64 < 17.27.0-12.1
    libzypp-devel.noarch < 17.27.0-12.1
    zypper.src < 1.14.46-13.1
    zypper.noarch < 1.14.46-13.1
    zypper.x86_64 < 1.14.46-13.1
    zypper-log < 1.14.46-13.1
    zypper-needs-restarting < 1.14.46-13.1
`

Tested with unit tests