### PR TITLE
Return lower-case package name

### DIFF
--- a/packages/apt_deb.go
+++ b/packages/apt_deb.go
@@ -153,7 +153,7 @@ func parseDpkgDeb(data []byte) (*PkgInfo, error) {
 			// Some packages do not adhere to the Debian Policy and might have mix-cased names
 			// And dpkg will register the package with lower case anyway so use lower-case package name
 			// This is necessary because the compliance check is done between the .deb file descriptor value
-			// and the internal dpkg db which register a lower-cased package name 
+			// and the internal dpkg db which register a lower-cased package name
 			info.Name = strings.ToLower(string(fields[1]))
 			continue
 		}

--- a/packages/apt_deb.go
+++ b/packages/apt_deb.go
@@ -150,7 +150,11 @@ func parseDpkgDeb(data []byte) (*PkgInfo, error) {
 			continue
 		}
 		if bytes.Contains(fields[0], []byte("Package:")) {
-			info.Name = string(fields[1])
+			// Some packages do not adhere to the Debian Policy and might have mix-cased names
+			// And dpkg will register the package with lower case anyway so use lower-case package name
+			// This is necessary because the compliance check is done between the .deb file descriptor value
+			// and the internal dpkg db which register a lower-cased package name 
+			info.Name = strings.ToLower(string(fields[1]))
 			continue
 		}
 		if bytes.Contains(fields[0], []byte("Version:")) {


### PR DESCRIPTION
Return lower-case package name for better resilience to non-compliant .deb packages as some packages
do not always adhere to the Debian Policy and might have mix-cased names.
Debian package manager  will register the package with lower case anyway so use lower-case package name.
This is necessary because the compliance check is done between the .deb file descriptor value and the internal
package management db which registers a lower-cased name.

fixes #376 