### PR TITLE
Add more info logs, actually cleanup unmanaged repos

### DIFF
--- a/agentconfig/agentconfig.go
+++ b/agentconfig/agentconfig.go
@@ -26,6 +26,7 @@ import (
 	"net/http"
 	"net/url"
 	"os"
+	"path/filepath"
 	"runtime"
 	"strconv"
 	"strings"
@@ -514,6 +515,11 @@ func ZypperRepoDir() string {
 	return zypperRepoDir
 }
 
+// ZypperRepoFormat is the format of the zypper repo files.
+func ZypperRepoFormat() string {
+	return filepath.Join(zypperRepoDir, "osconfig_managed_%s.repo")
+}
+
 // ZypperRepoFilePath is the location where the zypper repo file will be created.
 func ZypperRepoFilePath() string {
 	return getAgentConfig().zypperRepoFilePath
@@ -522,6 +528,11 @@ func ZypperRepoFilePath() string {
 // YumRepoDir is the location of the yum repo files.
 func YumRepoDir() string {
 	return yumRepoDir
+}
+
+// YumRepoFormat is the format of the yum repo files.
+func YumRepoFormat() string {
+	return filepath.Join(yumRepoDir, "osconfig_managed_%s.repo")
 }
 
 // YumRepoFilePath is the location where the yum repo file will be created.
@@ -534,6 +545,11 @@ func AptRepoDir() string {
 	return aptRepoDir
 }
 
+// AptRepoFormat is the format of the apt repo files.
+func AptRepoFormat() string {
+	return filepath.Join(aptRepoDir, "osconfig_managed_%s.list")
+}
+
 // AptRepoFilePath is the location where the apt repo file will be created.
 func AptRepoFilePath() string {
 	return getAgentConfig().aptRepoFilePath
@@ -542,6 +558,11 @@ func AptRepoFilePath() string {
 // GooGetRepoDir is the location of the googet repo files.
 func GooGetRepoDir() string {
 	return googetRepoDir
+}
+
+// GooGetRepoFormat is the format of the googet repo files.
+func GooGetRepoFormat() string {
+	return filepath.Join(googetRepoDir, "osconfig_managed_%s.repo")
 }
 
 // GooGetRepoFilePath is the location where the googet repo file will be created.

--- a/agentendpoint/config_task.go
+++ b/agentendpoint/config_task.go
@@ -159,7 +159,7 @@ func validateConfigResource(ctx context.Context, res *resource, policyMR *config
 		if err := detectPolicyConflicts(res.ManagedResources(), policyMR); err != nil {
 			outcome = agentendpointpb.OSPolicyResourceConfigStep_FAILED
 			hasError = true
-			errMessage = fmt.Sprintf("Validate: resource conflict in policy: %v", err)
+			errMessage = truncateMessage(fmt.Sprintf("Validate: resource conflict in policy: %v", err), maxErrorMessage)
 			clog.Errorf(ctx, errMessage)
 		} else {
 			clog.Infof(ctx, "Validate: resource %q validation successful.", configResource.GetId())

--- a/agentendpoint/config_task.go
+++ b/agentendpoint/config_task.go
@@ -336,7 +336,7 @@ func (c *configTask) cleanupRepos(ctx context.Context) {
 			clog.Errorf(ctx, "Error globing directory: %v", err)
 		}
 		for _, match := range matches {
-			if err := removeIfNoMatch(match, managedRepos); err != nil {
+			if err := removeFileIfNoMatch(match, managedRepos); err != nil {
 				clog.Errorf(ctx, "Error cleaning up old repo: %v", err)
 			}
 		}

--- a/agentendpoint/config_task.go
+++ b/agentendpoint/config_task.go
@@ -311,7 +311,7 @@ func (c *configTask) generateBaseResults() {
 	}
 }
 
-func removeIfNoMatch(a string, s []string) error {
+func removeFileIfNoMatch(a string, s []string) error {
 	for _, b := range s {
 		if a == b {
 			return nil

--- a/agentendpoint/patch_windows.go
+++ b/agentendpoint/patch_windows.go
@@ -12,6 +12,7 @@
 //  See the License for the specific language governing permissions and
 //  limitations under the License.
 
+//go:build windows
 // +build windows
 
 package agentendpoint

--- a/agentendpoint/reboot_windows.go
+++ b/agentendpoint/reboot_windows.go
@@ -12,6 +12,7 @@
 //  See the License for the specific language governing permissions and
 //  limitations under the License.
 
+//go:build windows
 // +build windows
 
 package agentendpoint

--- a/config/exec_resource.go
+++ b/config/exec_resource.go
@@ -186,6 +186,7 @@ func (e *execResource) checkState(ctx context.Context) (inDesiredState bool, err
 }
 
 func (e *execResource) enforceState(ctx context.Context) (inDesiredState bool, err error) {
+	clog.Infof(ctx, "Running Enforce for ExecResource.")
 	// For enforce we expect an exit code of 100 for "success" and anything positive code is a failure".
 	// 100 was chosen over 0 because we want an explicit indicator of "sucess" vs errors.
 	// Also Powershell will always exit 0 unless "exit" is explicitly called.

--- a/config/exec_resource.go
+++ b/config/exec_resource.go
@@ -186,7 +186,7 @@ func (e *execResource) checkState(ctx context.Context) (inDesiredState bool, err
 }
 
 func (e *execResource) enforceState(ctx context.Context) (inDesiredState bool, err error) {
-	clog.Infof(ctx, "Running Enforce for ExecResource.")
+	clog.Infof(ctx, `Running "Enforce" for ExecResource.`)
 	// For enforce we expect an exit code of 100 for "success" and anything positive code is a failure".
 	// 100 was chosen over 0 because we want an explicit indicator of "sucess" vs errors.
 	// Also Powershell will always exit 0 unless "exit" is explicitly called.

--- a/config/file_resource.go
+++ b/config/file_resource.go
@@ -24,6 +24,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/GoogleCloudPlatform/osconfig/clog"
 	"github.com/GoogleCloudPlatform/osconfig/util"
 
 	agentendpointpb "google.golang.org/genproto/googleapis/cloud/osconfig/agentendpoint/v1"
@@ -185,6 +186,7 @@ func copyFile(dst, src string, perms os.FileMode) (retErr error) {
 }
 
 func (f *fileResource) enforceState(ctx context.Context) (inDesiredState bool, err error) {
+	clog.Infof(ctx, "Enforcing state %q for file %q.", f.managedFile.State, f.managedFile.Path)
 	switch f.managedFile.State {
 	case agentendpointpb.OSPolicy_Resource_FileResource_ABSENT:
 		if err := os.Remove(f.managedFile.Path); err != nil {

--- a/config/repository_resource.go
+++ b/config/repository_resource.go
@@ -26,6 +26,7 @@ import (
 	"path/filepath"
 
 	"github.com/GoogleCloudPlatform/osconfig/agentconfig"
+	"github.com/GoogleCloudPlatform/osconfig/clog"
 	"github.com/GoogleCloudPlatform/osconfig/packages"
 	"github.com/GoogleCloudPlatform/osconfig/util"
 	"golang.org/x/crypto/openpgp"
@@ -212,7 +213,7 @@ func fetchGPGKey(key string) ([]byte, error) {
 }
 
 func (r *repositoryResource) validate(ctx context.Context) (*ManagedResources, error) {
-	var filePath string
+	var repoFormat string
 	switch r.GetRepository().(type) {
 	case *agentendpointpb.OSPolicy_Resource_RepositoryResource_Apt:
 		if !packages.AptExists {
@@ -221,7 +222,7 @@ func (r *repositoryResource) validate(ctx context.Context) (*ManagedResources, e
 		gpgkey := r.GetApt().GetGpgKey()
 		r.managedRepository.Apt = &AptRepository{RepositoryResource: r.GetApt()}
 		r.managedRepository.RepoFileContents = aptRepoContents(r.GetApt())
-		filePath = filepath.Join(agentconfig.AptRepoDir(), "osconfig_managed_%s.list")
+		repoFormat = agentconfig.AptRepoFormat()
 		if gpgkey != "" {
 			keyContents, err := fetchGPGKey(gpgkey)
 			if err != nil {
@@ -239,7 +240,7 @@ func (r *repositoryResource) validate(ctx context.Context) (*ManagedResources, e
 		}
 		r.managedRepository.GooGet = &GooGetRepository{RepositoryResource: r.GetGoo()}
 		r.managedRepository.RepoFileContents = googetRepoContents(r.GetGoo())
-		filePath = filepath.Join(agentconfig.GooGetRepoDir(), "osconfig_managed_%s.repo")
+		repoFormat = agentconfig.GooGetRepoFormat()
 
 	case *agentendpointpb.OSPolicy_Resource_RepositoryResource_Yum:
 		if !packages.YumExists {
@@ -247,7 +248,7 @@ func (r *repositoryResource) validate(ctx context.Context) (*ManagedResources, e
 		}
 		r.managedRepository.Yum = &YumRepository{RepositoryResource: r.GetYum()}
 		r.managedRepository.RepoFileContents = yumRepoContents(r.GetYum())
-		filePath = filepath.Join(agentconfig.YumRepoDir(), "osconfig_managed_%s.repo")
+		repoFormat = agentconfig.YumRepoFormat()
 
 	case *agentendpointpb.OSPolicy_Resource_RepositoryResource_Zypper:
 		if !packages.ZypperExists {
@@ -255,13 +256,13 @@ func (r *repositoryResource) validate(ctx context.Context) (*ManagedResources, e
 		}
 		r.managedRepository.Zypper = &ZypperRepository{RepositoryResource: r.GetZypper()}
 		r.managedRepository.RepoFileContents = zypperRepoContents(r.GetZypper())
-		filePath = filepath.Join(agentconfig.ZypperRepoDir(), "osconfig_managed_%s.repo")
+		repoFormat = agentconfig.ZypperRepoFormat()
 	default:
 		return nil, fmt.Errorf("Repository field not set or references unknown repository type: %v", r.GetRepository())
 	}
 
 	r.managedRepository.RepoChecksum = checksum(bytes.NewReader(r.managedRepository.RepoFileContents))
-	r.managedRepository.RepoFilePath = fmt.Sprintf(filePath, r.managedRepository.RepoChecksum[:10])
+	r.managedRepository.RepoFilePath = fmt.Sprintf(repoFormat, r.managedRepository.RepoChecksum[:10])
 	return &ManagedResources{Repositories: []ManagedRepository{r.managedRepository}}, nil
 }
 
@@ -294,6 +295,7 @@ func (r *repositoryResource) checkState(ctx context.Context) (inDesiredState boo
 }
 
 func (r *repositoryResource) enforceState(ctx context.Context) (inDesiredState bool, err error) {
+	clog.Infof(ctx, "Enforcing repo %s.", r.managedRepository.RepoFilePath)
 	// Set APT gpg key if applicable.
 	if r.managedRepository.Apt != nil && r.managedRepository.Apt.GpgFileContents != nil {
 		if err := ioutil.WriteFile(r.managedRepository.Apt.GpgFilePath, r.managedRepository.Apt.GpgFileContents, 0644); err != nil {

--- a/ospatch/system_linux.go
+++ b/ospatch/system_linux.go
@@ -12,7 +12,8 @@
 //  See the License for the specific language governing permissions and
 //  limitations under the License.
 
-//+build !test
+//go:build !test
+// +build !test
 
 package ospatch
 

--- a/ospatch/system_test_stub.go
+++ b/ospatch/system_test_stub.go
@@ -12,7 +12,8 @@
 //  See the License for the specific language governing permissions and
 //  limitations under the License.
 
-//+build test
+//go:build test
+// +build test
 
 package ospatch
 

--- a/ospatch/system_windows.go
+++ b/ospatch/system_windows.go
@@ -12,7 +12,8 @@
 //  See the License for the specific language governing permissions and
 //  limitations under the License.
 
-//+build !test
+//go:build !test
+// +build !test
 
 package ospatch
 

--- a/ospatch/updates_linux.go
+++ b/ospatch/updates_linux.go
@@ -12,7 +12,8 @@
 //  See the License for the specific language governing permissions and
 //  limitations under the License.
 
-//+build !test
+//go:build !test
+// +build !test
 
 package ospatch
 

--- a/ospatch/updates_test_stub.go
+++ b/ospatch/updates_test_stub.go
@@ -12,7 +12,8 @@
 //  See the License for the specific language governing permissions and
 //  limitations under the License.
 
-//+build test
+//go:build test
+// +build test
 
 package ospatch
 

--- a/ospatch/updates_windows.go
+++ b/ospatch/updates_windows.go
@@ -12,7 +12,8 @@
 //  See the License for the specific language governing permissions and
 //  limitations under the License.
 
-//+build !test
+//go:build !test
+// +build !test
 
 package ospatch
 

--- a/packages/cos.go
+++ b/packages/cos.go
@@ -14,6 +14,7 @@
 
 // Only build for linux but not on unsupported architectures.
 
+//go:build linux && (386 || amd64)
 // +build linux
 // +build 386 amd64
 

--- a/packages/cos_stub.go
+++ b/packages/cos_stub.go
@@ -14,6 +14,7 @@
 
 // Stub for linux builds.
 
+//go:build linux && !386 && !amd64
 // +build linux,!386,!amd64
 
 package packages

--- a/packages/cos_test.go
+++ b/packages/cos_test.go
@@ -12,6 +12,7 @@
 //  See the License for the specific language governing permissions and
 //  limitations under the License.
 
+//go:build linux && (386 || amd64)
 // +build linux
 // +build 386 amd64
 

--- a/packages/stub_linux.go
+++ b/packages/stub_linux.go
@@ -12,6 +12,7 @@
 //  See the License for the specific language governing permissions and
 //  limitations under the License.
 
+//go:build !windows
 // +build !windows
 
 package packages

--- a/packages/stub_windows.go
+++ b/packages/stub_windows.go
@@ -12,6 +12,7 @@
 //  See the License for the specific language governing permissions and
 //  limitations under the License.
 
+//go:build !linux
 // +build !linux
 
 package packages

--- a/policies/recipes/steps_linux.go
+++ b/policies/recipes/steps_linux.go
@@ -12,6 +12,7 @@
 //  See the License for the specific language governing permissions and
 //  limitations under the License.
 
+//go:build linux
 // +build linux
 
 package recipes

--- a/policies/recipes/steps_windows.go
+++ b/policies/recipes/steps_windows.go
@@ -12,6 +12,7 @@
 //  See the License for the specific language governing permissions and
 //  limitations under the License.
 
+//go:build windows
 // +build windows
 
 package recipes


### PR DESCRIPTION
During a config run there will now be clear info logs when actions are taken or after a check has been completed.
We need to remove repos that config is no longer managing, we do this by clearing out all unmanaged repos that match our naming.
Actually limit error messages to the 512 byte limit.

For the new logging, here is an example of info logs, errors are always logged at any of the satges.
Execution Resource (success case)
- Validation successful
- Check state: resource state is NON_COMPLIANT
- Enforcing desired state for resource
- Desired state enforcement is successful
- Check state post enforcement: resource state is COMPLIANT

Execution Resource (resource is already in desired state)
- Validation successful
- Check state: resource state is COMPLIANT
