### PR TITLE
ReportInventory: Fix bug in deb/rpm inventory, reduce calls to append

### DIFF
--- a/agentconfig/agentconfig.go
+++ b/agentconfig/agentconfig.go
@@ -72,7 +72,7 @@ const (
 	cacheDirLinux     = "/var/lib/google_osconfig_agent"
 
 	taskStateFileWindows  = cacheDirWindows + `\osconfig_task.state`
-	taskStateFileLinux    = cacheDirWindows + "/osconfig_task.state"
+	taskStateFileLinux    = cacheDirLinux + "/osconfig_task.state"
 	oldTaskStateFileLinux = oldConfigDirLinux + "/osconfig_task.state"
 
 	configCacheFileWindows = cacheDirLinux + `\osconfig_task.state`

--- a/agentconfig/agentconfig.go
+++ b/agentconfig/agentconfig.go
@@ -75,8 +75,8 @@ const (
 	taskStateFileLinux    = cacheDirLinux + "/osconfig_task.state"
 	oldTaskStateFileLinux = oldConfigDirLinux + "/osconfig_task.state"
 
-	configCacheFileWindows = cacheDirLinux + `\osconfig_task.state`
-	configCacheFileLinux   = cacheDirLinux + "/osconfig_task.state"
+	configCacheFileWindows = cacheDirWindows + `\osconfig_config.cache`
+	configCacheFileLinux   = cacheDirLinux + "/osconfig_config.cache"
 
 	restartFileWindows  = cacheDirWindows + `\osconfig_agent_restart_required`
 	restartFileLinux    = cacheDirLinux + "/osconfig_agent_restart_required"

--- a/agentendpoint/inventory.go
+++ b/agentendpoint/inventory.go
@@ -146,7 +146,7 @@ func formatPackages(ctx context.Context, pkgs *packages.Packages, shortName stri
 		softwarePackages = append(softwarePackages, temp...)
 	}
 	if pkgs.Zypper != nil {
-		temp := make([]*agentendpointpb.Inventory_SoftwarePackage, len(pkgs.Yum))
+		temp := make([]*agentendpointpb.Inventory_SoftwarePackage, len(pkgs.Zypper))
 		for i, pkg := range pkgs.Zypper {
 			temp[i] = &agentendpointpb.Inventory_SoftwarePackage{
 				Details: formatZypperPackage(pkg),

--- a/agentendpoint/inventory.go
+++ b/agentendpoint/inventory.go
@@ -104,88 +104,117 @@ func formatInventory(ctx context.Context, state *inventory.InstanceInventory) *a
 	return &agentendpointpb.Inventory{OsInfo: osInfo, InstalledPackages: installedPackages, AvailablePackages: availablePackages}
 }
 
-func formatPackages(ctx context.Context, packages *packages.Packages, shortName string) []*agentendpointpb.Inventory_SoftwarePackage {
+func formatPackages(ctx context.Context, pkgs *packages.Packages, shortName string) []*agentendpointpb.Inventory_SoftwarePackage {
 	var softwarePackages []*agentendpointpb.Inventory_SoftwarePackage
-	if packages == nil {
+	if pkgs == nil {
 		return softwarePackages
 	}
-	if packages.Apt != nil {
-		for _, pkg := range packages.Apt {
-			softwarePackages = append(softwarePackages, &agentendpointpb.Inventory_SoftwarePackage{
+	if pkgs.Apt != nil {
+		temp := make([]*agentendpointpb.Inventory_SoftwarePackage, len(pkgs.Apt))
+		for i, pkg := range pkgs.Apt {
+			temp[i] = &agentendpointpb.Inventory_SoftwarePackage{
 				Details: formatAptPackage(pkg),
-			})
+			}
 		}
-		for _, pkg := range packages.Deb {
-			softwarePackages = append(softwarePackages, &agentendpointpb.Inventory_SoftwarePackage{
-				Details: formatAptPackage(pkg),
-			})
-		}
+		softwarePackages = append(softwarePackages, temp...)
 	}
-	if packages.GooGet != nil {
-		for _, pkg := range packages.GooGet {
-			softwarePackages = append(softwarePackages, &agentendpointpb.Inventory_SoftwarePackage{
+	if pkgs.Deb != nil {
+		temp := make([]*agentendpointpb.Inventory_SoftwarePackage, len(pkgs.Deb))
+		for i, pkg := range pkgs.Deb {
+			temp[i] = &agentendpointpb.Inventory_SoftwarePackage{
+				Details: formatAptPackage(pkg),
+			}
+		}
+		softwarePackages = append(softwarePackages, temp...)
+	}
+	if pkgs.GooGet != nil {
+		temp := make([]*agentendpointpb.Inventory_SoftwarePackage, len(pkgs.GooGet))
+		for i, pkg := range pkgs.GooGet {
+			temp[i] = &agentendpointpb.Inventory_SoftwarePackage{
 				Details: formatGooGetPackage(pkg),
-			})
+			}
 		}
+		softwarePackages = append(softwarePackages, temp...)
 	}
-	if packages.Yum != nil {
-		for _, pkg := range packages.Yum {
-			softwarePackages = append(softwarePackages, &agentendpointpb.Inventory_SoftwarePackage{
+	if pkgs.Yum != nil {
+		temp := make([]*agentendpointpb.Inventory_SoftwarePackage, len(pkgs.Yum))
+		for i, pkg := range pkgs.Yum {
+			temp[i] = &agentendpointpb.Inventory_SoftwarePackage{
 				Details: formatYumPackage(pkg),
-			})
+			}
 		}
-		for _, pkg := range packages.Rpm {
-			softwarePackages = append(softwarePackages, &agentendpointpb.Inventory_SoftwarePackage{
-				Details: formatYumPackage(pkg),
-			})
-		}
+		softwarePackages = append(softwarePackages, temp...)
 	}
-	if packages.Zypper != nil {
-		for _, pkg := range packages.Zypper {
-			softwarePackages = append(softwarePackages, &agentendpointpb.Inventory_SoftwarePackage{
+	if pkgs.Zypper != nil {
+		temp := make([]*agentendpointpb.Inventory_SoftwarePackage, len(pkgs.Yum))
+		for i, pkg := range pkgs.Zypper {
+			temp[i] = &agentendpointpb.Inventory_SoftwarePackage{
 				Details: formatZypperPackage(pkg),
-			})
+			}
 		}
-		for _, pkg := range packages.Rpm {
-			softwarePackages = append(softwarePackages, &agentendpointpb.Inventory_SoftwarePackage{
-				Details: formatZypperPackage(pkg),
-			})
-		}
+		softwarePackages = append(softwarePackages, temp...)
 	}
-	if packages.ZypperPatches != nil {
-		for _, pkg := range packages.ZypperPatches {
-			softwarePackages = append(softwarePackages, &agentendpointpb.Inventory_SoftwarePackage{
+	if pkgs.Rpm != nil {
+		temp := make([]*agentendpointpb.Inventory_SoftwarePackage, len(pkgs.Rpm))
+		if packages.YumExists {
+			for i, pkg := range pkgs.Rpm {
+				temp[i] = &agentendpointpb.Inventory_SoftwarePackage{
+					Details: formatYumPackage(pkg),
+				}
+			}
+		} else if packages.ZypperExists {
+			for i, pkg := range pkgs.Rpm {
+				temp[i] = &agentendpointpb.Inventory_SoftwarePackage{
+					Details: formatZypperPackage(pkg),
+				}
+			}
+		}
+		softwarePackages = append(softwarePackages, temp...)
+	}
+	if pkgs.ZypperPatches != nil {
+		temp := make([]*agentendpointpb.Inventory_SoftwarePackage, len(pkgs.ZypperPatches))
+		for i, pkg := range pkgs.ZypperPatches {
+			temp[i] = &agentendpointpb.Inventory_SoftwarePackage{
 				Details: formatZypperPatch(pkg),
-			})
+			}
 		}
+		softwarePackages = append(softwarePackages, temp...)
 	}
-	if packages.WUA != nil {
-		for _, pkg := range packages.WUA {
-			softwarePackages = append(softwarePackages, &agentendpointpb.Inventory_SoftwarePackage{
+	if pkgs.WUA != nil {
+		temp := make([]*agentendpointpb.Inventory_SoftwarePackage, len(pkgs.WUA))
+		for i, pkg := range pkgs.WUA {
+			temp[i] = &agentendpointpb.Inventory_SoftwarePackage{
 				Details: formatWUAPackage(pkg),
-			})
+			}
 		}
+		softwarePackages = append(softwarePackages, temp...)
 	}
-	if packages.QFE != nil {
-		for _, pkg := range packages.QFE {
-			softwarePackages = append(softwarePackages, &agentendpointpb.Inventory_SoftwarePackage{
+	if pkgs.QFE != nil {
+		temp := make([]*agentendpointpb.Inventory_SoftwarePackage, len(pkgs.QFE))
+		for i, pkg := range pkgs.QFE {
+			temp[i] = &agentendpointpb.Inventory_SoftwarePackage{
 				Details: formatQFEPackage(ctx, pkg),
-			})
+			}
 		}
+		softwarePackages = append(softwarePackages, temp...)
 	}
-	if packages.COS != nil {
-		for _, pkg := range packages.COS {
-			softwarePackages = append(softwarePackages, &agentendpointpb.Inventory_SoftwarePackage{
+	if pkgs.COS != nil {
+		temp := make([]*agentendpointpb.Inventory_SoftwarePackage, len(pkgs.COS))
+		for i, pkg := range pkgs.COS {
+			temp[i] = &agentendpointpb.Inventory_SoftwarePackage{
 				Details: formatCOSPackage(pkg),
-			})
+			}
 		}
+		softwarePackages = append(softwarePackages, temp...)
 	}
-	if packages.WindowsApplication != nil {
-		for _, pkg := range packages.WindowsApplication {
-			softwarePackages = append(softwarePackages, &agentendpointpb.Inventory_SoftwarePackage{
+	if pkgs.WindowsApplication != nil {
+		temp := make([]*agentendpointpb.Inventory_SoftwarePackage, len(pkgs.WindowsApplication))
+		for i, pkg := range pkgs.WindowsApplication {
+			temp[i] = &agentendpointpb.Inventory_SoftwarePackage{
 				Details: formatWindowsApplication(pkg),
-			})
+			}
 		}
+		softwarePackages = append(softwarePackages, temp...)
 	}
 	// Ignore Pip and Gem packages.
 

--- a/agentendpoint/inventory_test.go
+++ b/agentendpoint/inventory_test.go
@@ -168,20 +168,14 @@ func generateInventory() *agentendpointpb.Inventory {
 						Architecture: "Arch",
 						Version:      "Version"}}},
 			{
-				Details: &agentendpointpb.Inventory_SoftwarePackage_YumPackage{
-					YumPackage: &agentendpointpb.Inventory_VersionedPackage{
-						PackageName:  "RpmInstalledPkg",
-						Architecture: "Arch",
-						Version:      "Version"}}},
-			{
 				Details: &agentendpointpb.Inventory_SoftwarePackage_ZypperPackage{
 					ZypperPackage: &agentendpointpb.Inventory_VersionedPackage{
 						PackageName:  "ZypperInstalledPkg",
 						Architecture: "Arch",
 						Version:      "Version"}}},
 			{
-				Details: &agentendpointpb.Inventory_SoftwarePackage_ZypperPackage{
-					ZypperPackage: &agentendpointpb.Inventory_VersionedPackage{
+				Details: &agentendpointpb.Inventory_SoftwarePackage_YumPackage{
+					YumPackage: &agentendpointpb.Inventory_VersionedPackage{
 						PackageName:  "RpmInstalledPkg",
 						Architecture: "Arch",
 						Version:      "Version"}}},
@@ -402,6 +396,7 @@ func TestWrite(t *testing.T) {
 
 func TestReport(t *testing.T) {
 	ctx := context.Background()
+	packages.YumExists = true
 	srv := &agentEndpointServiceInventoryTestServer{}
 	tc, err := newTestClient(ctx, srv)
 	if err != nil {
@@ -425,7 +420,7 @@ func TestReport(t *testing.T) {
 
 			tc.client.report(ctx, tt.inventoryState)
 
-			if diff := cmp.Diff(tt.wantInventory, srv.lastReportInventoryRequest.Inventory, protocmp.Transform()); diff != "" {
+			if diff := cmp.Diff(srv.lastReportInventoryRequest.Inventory, tt.wantInventory, protocmp.Transform()); diff != "" {
 				t.Fatalf("ReportInventoryRequest.Inventory mismatch (-want +got):\n%s", diff)
 			}
 		})


### PR DESCRIPTION
Because we are appending a known number of packages we can preallocate a temporary slice which we then pass to append. This avoids the constant growing of the slice because of multiple append calls.