### PR TITLE
Config: Add package info caching

### DIFF
--- a/agentconfig/agentconfig.go
+++ b/agentconfig/agentconfig.go
@@ -75,9 +75,6 @@ const (
 	taskStateFileLinux    = cacheDirLinux + "/osconfig_task.state"
 	oldTaskStateFileLinux = oldConfigDirLinux + "/osconfig_task.state"
 
-	configCacheFileWindows = cacheDirWindows + `\osconfig_config.cache`
-	configCacheFileLinux   = cacheDirLinux + "/osconfig_config.cache"
-
 	restartFileWindows  = cacheDirWindows + `\osconfig_agent_restart_required`
 	restartFileLinux    = cacheDirLinux + "/osconfig_agent_restart_required"
 	oldRestartFileLinux = oldConfigDirLinux + "/osconfig_agent_restart_required"
@@ -706,6 +703,15 @@ func RestartFile() string {
 // OldRestartFile is the location of the restart required file.
 func OldRestartFile() string {
 	return oldRestartFileLinux
+}
+
+// CacheDir is the location of the cache directory.
+func CacheDir() string {
+	if runtime.GOOS == "windows" {
+		return cacheDirWindows
+	}
+
+	return cacheDirLinux
 }
 
 // UserAgent for creating http/grpc clients.

--- a/config/package_resource.go
+++ b/config/package_resource.go
@@ -141,7 +141,7 @@ func loadPackageInfoCache(ctx context.Context) {
 	}
 	var cache packageInfoCache
 	if err := json.Unmarshal(data, &cache); err != nil {
-		clog.Debugf(ctx, "Error reading the package info cache: %v", err)
+		clog.Debugf(ctx, "Error unmarshaling the package info cache: %v", err)
 		packageInfoCacheStore = packageInfoCache{}
 		return
 	}
@@ -154,7 +154,7 @@ func getPackageInfoFromCache(ctx context.Context, pkgFile *agentendpointpb.OSPol
 	if err != nil {
 		// Just ignore the error and return early
 		// The error mode here is just always redownload the file.
-		clog.Debugf(ctx, "Error reading the package info cache: %v", err)
+		clog.Debugf(ctx, "Error creating the package info cache key: %v", err)
 		return nil
 	}
 	packageInfo, ok := packageInfoCacheStore[key]

--- a/config/package_resource.go
+++ b/config/package_resource.go
@@ -530,7 +530,7 @@ func (p *packageResouce) enforceState(ctx context.Context) (inDesiredState bool,
 		enforcePackage.name = p.managedPackage.MSI.productName
 		enforcePackage.packageType = "msi"
 		enforcePackage.action = installing
-		enforcePackage.installedCache = &packageCache{} // We have a msi cache but installing an MSI does not invalidate it.
+		enforcePackage.installedCache = &packageCache{} // No package cache for msi.
 		// Check if we have not pulled the package yet.
 		if p.managedPackage.MSI.localPath == "" {
 			localPath, err := p.download(ctx, "pkg.msi", p.GetMsi().GetSource())

--- a/packages/msi_windows.go
+++ b/packages/msi_windows.go
@@ -187,8 +187,8 @@ func msiInstallProductW(szPackagePath string, szCommandLine []string) error {
 	return nil
 }
 
-// MSIInfo returns the ProductName and whether or not a specific msi (based on ProductCode) is installed.
-func MSIInfo(path string) (string, bool, error) {
+// MSIInfo returns the ProductName and ProductCode for an MSI.
+func MSIInfo(path string) (string, string, bool, error) {
 	setUIMode()
 
 	if err := coInitializeEx(); err != nil {
@@ -213,12 +213,24 @@ func MSIInfo(path string) (string, bool, error) {
 		return "", false, fmt.Errorf("error getting ProductName property: %v", err)
 	}
 
+	return productName, productCode, nil
+}
+
+// MSIInstalled returns if the msi ProductCode is installed.
+func MSIInstalled(productCode string) (bool, error) {
+	setUIMode()
+
+	if err := coInitializeEx(); err != nil {
+		return "", false, err
+	}
+	defer ole.CoUninitialize()
+
 	state, err := msiMsiQueryProductStateW(productCode)
 	if err != nil {
 		return "", false, err
 	}
 
-	return productName, state == INSTALLSTATE_DEFAULT, nil
+	return state == INSTALLSTATE_DEFAULT, nil
 }
 
 // InstallMSIPackage installs an msi package.

--- a/packages/msi_windows.go
+++ b/packages/msi_windows.go
@@ -188,29 +188,29 @@ func msiInstallProductW(szPackagePath string, szCommandLine []string) error {
 }
 
 // MSIInfo returns the ProductName and ProductCode for an MSI.
-func MSIInfo(path string) (string, string, bool, error) {
+func MSIInfo(path string) (string, string, error) {
 	setUIMode()
 
 	if err := coInitializeEx(); err != nil {
-		return "", false, err
+		return "", "", err
 	}
 	defer ole.CoUninitialize()
 
 	const MSIOPENPACKAGEFLAGS_IGNOREMACHINESTATE = 1
 	handle, err := msiOpenPackageExW(path, MSIOPENPACKAGEFLAGS_IGNOREMACHINESTATE)
 	if err != nil {
-		return "", false, fmt.Errorf("error opening MSI package %q: %v", path, err)
+		return "", "", fmt.Errorf("error opening MSI package %q: %v", path, err)
 	}
 	defer msiCloseHandle(handle)
 
 	productCode, err := msiGetProductPropertyW(handle, "ProductCode")
 	if err != nil {
-		return "", false, fmt.Errorf("error getting ProductCode property: %v", err)
+		return "", "", fmt.Errorf("error getting ProductCode property: %v", err)
 	}
 
 	productName, err := msiGetProductPropertyW(handle, "ProductName")
 	if err != nil {
-		return "", false, fmt.Errorf("error getting ProductName property: %v", err)
+		return "", "", fmt.Errorf("error getting ProductName property: %v", err)
 	}
 
 	return productName, productCode, nil
@@ -221,13 +221,13 @@ func MSIInstalled(productCode string) (bool, error) {
 	setUIMode()
 
 	if err := coInitializeEx(); err != nil {
-		return "", false, err
+		return false, err
 	}
 	defer ole.CoUninitialize()
 
 	state, err := msiMsiQueryProductStateW(productCode)
 	if err != nil {
-		return "", false, err
+		return false, err
 	}
 
 	return state == INSTALLSTATE_DEFAULT, nil

--- a/packages/stub_linux.go
+++ b/packages/stub_linux.go
@@ -25,6 +25,11 @@ func InstallMSIPackage(_ context.Context, _ string, _ []string) error {
 }
 
 // MSIInfo is a linux stub function.
-func MSIInfo(_ string) (string, bool, error) {
-	return "", false, nil
+func MSIInfo(_ string) (string, string, error) {
+	return "", "", nil
+}
+
+// MSIInstalled is a linux stub function.
+func MSIInstalled(_ string) (bool, error) {
+	return false, nil
 }


### PR DESCRIPTION
Keep a cache of package info for config package resource so we don't need to download the package on every run
This cache is keyed to the source of the resource so multiple resources that use the exact same source will use the same cache item
On every run update the timestamp for each accessed item in the cache so that we can clean up the cache of items that have not been touched for >7 days
Failure modes are very forgiving and we just invalidate the entire cache if necessary which will result in redownloading packages and recreating the cache.