### PR TITLE
Added patch report logging for Zypper.

### DIFF
--- a/ospatch/apt_upgrade.go
+++ b/ospatch/apt_upgrade.go
@@ -98,12 +98,16 @@ func RunAptGetUpgrade(ctx context.Context, opts ...AptGetUpgradeOption) error {
 		return nil
 	}
 
-	logPackages(ctx, fPkgs)
+	ops := opsToReport{
+		packages: fPkgs,
+	}
+	logOps(ctx, ops)
+
 	err = packages.InstallAptPackages(ctx, pkgNames)
 	if err == nil {
-		logSuccess(ctx, fPkgs)
+		logSuccess(ctx, ops)
 	} else {
-		logFailure(ctx, fPkgs, err)
+		logFailure(ctx, ops, err)
 	}
 
 	return err

--- a/ospatch/googet_update.go
+++ b/ospatch/googet_update.go
@@ -84,7 +84,16 @@ func RunGooGetUpdate(ctx context.Context, opts ...GooGetUpdateOption) error {
 		clog.Infof(ctx, "Running in dryrun mode, not updating %s", msg)
 		return nil
 	}
-	clog.Infof(ctx, "Updating %s", msg)
+	ops := opsToReport{
+		packages: fPkgs,
+	}
+	logOps(ctx, ops)
 
-	return packages.InstallGooGetPackages(ctx, pkgNames)
+	err = packages.InstallGooGetPackages(ctx, pkgNames)
+	if err == nil {
+		logSuccess(ctx, ops)
+	} else {
+		logFailure(ctx, ops, err)
+	}
+	return err
 }

--- a/ospatch/report.go
+++ b/ospatch/report.go
@@ -17,6 +17,7 @@ package ospatch
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	"github.com/GoogleCloudPlatform/osconfig/clog"
 	"github.com/GoogleCloudPlatform/osconfig/packages"
@@ -26,24 +27,67 @@ import (
 // are retrieved
 var repLabels = map[string]string{"package-report": "true"}
 
+// opsToReport represents packages and patches that are to be logged
+// as part of patch reporting
+type opsToReport struct {
+	packages []*packages.PkgInfo
+	patches  []*packages.ZypperPatch
+}
+
+func formatPatches(patches []*packages.ZypperPatch) string {
+	names := []string{}
+	for _, p := range patches {
+		names = append(names, p.Name)
+	}
+	return strings.Join(names, ", ")
+}
+
 // logPackages logs the intent to patch the packages in pkgs
 // for the purpose of patch report.
-func logPackages(ctx context.Context, pkgs []*packages.PkgInfo) {
-	msg := fmt.Sprintf("Updating %d packages: %q", len(pkgs), pkgs)
+func logOps(ctx context.Context, ops opsToReport) {
+	msg := ""
+	sep := ""
+	if len(ops.packages) > 0 {
+		msg = fmt.Sprintf("Updating %d packages: %q", len(ops.packages), ops.packages)
+		sep = "; "
+	}
+	if len(ops.patches) > 0 {
+		msg = msg + fmt.Sprintf("%sInstalling %d patches: %s", sep, len(ops.patches), formatPatches(ops.patches))
+	}
+
 	clog.Infof(clog.WithLabels(ctx, repLabels), msg)
 }
 
 // logSuccess logs the success of patching the packages in pkgs
 // for the purpose of patch report.
-func logSuccess(ctx context.Context, pkgs []*packages.PkgInfo) {
-	msg := fmt.Sprintf("Success. Updated %d packages: %q", len(pkgs), pkgs)
+func logSuccess(ctx context.Context, ops opsToReport) {
+	sep := ""
+	msg := ""
+	pkgs, patches := ops.packages, ops.patches
+	if len(pkgs) > 0 {
+		msg = fmt.Sprintf("Updated %d packages: %q", len(pkgs), pkgs)
+		sep = "; "
+	}
+	if len(patches) > 0 {
+		msg = msg + fmt.Sprintf("%sApplied %d patches: %s", sep, len(patches), formatPatches(patches))
+	}
+	msg = fmt.Sprintf("Success. %s", msg)
 	clog.Infof(clog.WithLabels(ctx, repLabels), msg)
 }
 
 // logFailure logs the failure of patching the packages in pkgs caused by err,
 // for the purpose of patch report.
-func logFailure(ctx context.Context, pkgs []*packages.PkgInfo, err error) {
-	var pkgNames []string
-	msg := fmt.Sprintf("Failure updating %d packages: %q: %v", len(pkgNames), pkgNames, err)
+func logFailure(ctx context.Context, ops opsToReport, err error) {
+	sep := ""
+	msg := ""
+	pkgs, patches := ops.packages, ops.patches
+	if len(pkgs) > 0 {
+		msg = fmt.Sprintf("Tried to update %d packages: %q", len(pkgs), pkgs)
+		sep = "; "
+	}
+	if len(patches) > 0 {
+		msg = msg + fmt.Sprintf("%sTried to apply %d patches: %s", sep, len(patches), formatPatches(patches))
+	}
+	msg = fmt.Sprintf("Failure: %s. Error: %v", msg, err)
 	clog.Infof(clog.WithLabels(ctx, repLabels), msg)
 }

--- a/ospatch/yum_update.go
+++ b/ospatch/yum_update.go
@@ -116,13 +116,17 @@ func RunYumUpdate(ctx context.Context, opts ...YumUpdateOption) error {
 		clog.Infof(ctx, "Running in dryrun mode, not updating %s", msg)
 		return nil
 	}
-	logPackages(ctx, fPkgs)
+	ops := opsToReport{
+		packages: fPkgs,
+	}
+
+	logOps(ctx, ops)
 
 	err = packages.InstallYumPackages(ctx, pkgNames)
 	if err == nil {
-		logSuccess(ctx, fPkgs)
+		logSuccess(ctx, ops)
 	} else {
-		logFailure(ctx, fPkgs, err)
+		logFailure(ctx, ops, err)
 	}
 	return err
 }

--- a/ospatch/zypper_patch.go
+++ b/ospatch/zypper_patch.go
@@ -145,14 +145,16 @@ func RunZypperPatch(ctx context.Context, opts ...ZypperPatchOption) error {
 		return nil
 	}
 
+	var ops opsToReport
+
 	if len(fPatches) == 0 {
 		clog.Infof(ctx, "No patches to install.")
 	} else {
-		msg := fmt.Sprintf("%d patches: %v", len(fPatches), fPatches)
+		msg := fmt.Sprintf("%d patches: %s", len(fPatches), formatPatches(fPatches))
 		if zOpts.dryrun {
 			clog.Infof(ctx, "Running in dryrun mode, not installing %s", msg)
 		} else {
-			clog.Infof(ctx, "Installing %s", msg)
+			ops.patches = fPatches
 		}
 	}
 
@@ -163,18 +165,19 @@ func RunZypperPatch(ctx context.Context, opts ...ZypperPatchOption) error {
 		if zOpts.dryrun {
 			clog.Infof(ctx, "Running in dryrun mode, not Updating %s", msg)
 		} else {
-			logPackages(ctx, fpkgs)
+			ops.packages = fpkgs
 		}
 	}
+	logOps(ctx, ops)
 
 	if zOpts.dryrun {
 		return nil
 	}
 	err = packages.ZypperInstall(ctx, fPatches, fpkgs)
 	if err == nil {
-		logSuccess(ctx, fpkgs)
+		logSuccess(ctx, ops)
 	} else {
-		logFailure(ctx, fpkgs, err)
+		logFailure(ctx, ops, err)
 	}
 	return err
 }


### PR DESCRIPTION
Also fixed the "%v" in patch logging, as it outputs hex pointer values rather than the string representation of objects.
