### PR TITLE
Add retry logic for RegisterAgent

### DIFF
--- a/agentendpoint/agentendpoint.go
+++ b/agentendpoint/agentendpoint.go
@@ -124,7 +124,11 @@ func (c *Client) RegisterAgent(ctx context.Context) error {
 	clog.DebugRPC(ctx, "RegisterAgent", req, nil)
 	req.InstanceIdToken = token
 
-	resp, err := c.raw.RegisterAgent(ctx, req)
+	var resp *agentendpointpb.RegisterAgentResponse
+	err = retryutil.RetryAPICall(ctx, apiRetrySec*time.Second, "RegisterAgent", func() error {
+		resp, err = c.raw.RegisterAgent(ctx, req)
+		return err
+	})
 	clog.DebugRPC(ctx, "RegisterAgent", nil, resp)
 
 	return err

--- a/main.go
+++ b/main.go
@@ -82,17 +82,12 @@ var deferredFuncs []func()
 // 5 minutes and try again.
 func registerAgent(ctx context.Context) {
 	for {
-		// Only call register agent if the agent is enabled.
-		if agentconfig.TaskNotificationEnabled() || agentconfig.GuestPoliciesEnabled() {
-			if client, err := agentendpoint.NewClient(ctx); err != nil {
-				logger.Errorf(err.Error())
-			} else if err := client.RegisterAgent(ctx); err != nil {
-				logger.Errorf(err.Error())
-			} else {
-				// RegisterAgent completed successfully.
-				return
-			}
+		if client, err := agentendpoint.NewClient(ctx); err != nil {
+			logger.Errorf(err.Error())
+		} else if err := client.RegisterAgent(ctx); err != nil {
+			logger.Errorf(err.Error())
 		} else {
+			// RegisterAgent completed successfully.
 			return
 		}
 		time.Sleep(5 * time.Minute)
@@ -158,7 +153,9 @@ func run(ctx context.Context) {
 	go func() {
 		c := time.Tick(24 * time.Hour)
 		for range c {
-			registerAgent(ctx)
+			if agentconfig.TaskNotificationEnabled() || agentconfig.GuestPoliciesEnabled() {
+				registerAgent(ctx)
+			}
 		}
 	}()
 


### PR DESCRIPTION
We will retry RegisterAgent forever now, this will block other functions on first start but this is WAI as we can not do anything else until RegisterAgent has completed anyway