### PR TITLE
Made registerAgent cancel-compliant

### DIFF
--- a/main.go
+++ b/main.go
@@ -90,7 +90,11 @@ func registerAgent(ctx context.Context) {
 			// RegisterAgent completed successfully.
 			return
 		}
-		time.Sleep(5 * time.Minute)
+		select {
+		case <-time.After(5 * time.Minute):
+		case <-ctx.Done():
+			return
+		}
 	}
 }
 


### PR DESCRIPTION
Before this change registerAgent ignored the parent context
getting canceled.