### PR TITLE
Add regex support to package exclusion in OS Patch

### DIFF
--- a/agentendpoint/patch_linux.go
+++ b/agentendpoint/patch_linux.go
@@ -17,6 +17,7 @@ package agentendpoint
 import (
 	"context"
 	"errors"
+	"regexp"
 	"strings"
 	"time"
 
@@ -33,9 +34,13 @@ func (r *patchTask) runUpdates(ctx context.Context) error {
 	const retryPeriod = 3 * time.Minute
 	// Check for both apt-get and dpkg-query to give us a clean signal.
 	if packages.AptExists && packages.DpkgQueryExists {
+		excludes, err := convertInputToExcludes(r.Task.GetPatchConfig().GetApt().GetExcludes())
+		if err != nil {
+			return err
+		}
 		opts := []ospatch.AptGetUpgradeOption{
 			ospatch.AptGetDryRun(r.Task.GetDryRun()),
-			ospatch.AptGetExcludes(r.Task.GetPatchConfig().GetApt().GetExcludes()),
+			ospatch.AptGetExcludes(excludes),
 			ospatch.AptGetExclusivePackages(r.Task.GetPatchConfig().GetApt().GetExclusivePackages()),
 		}
 		switch r.Task.GetPatchConfig().GetApt().GetType() {
@@ -48,10 +53,14 @@ func (r *patchTask) runUpdates(ctx context.Context) error {
 		}
 	}
 	if packages.YumExists && packages.RPMQueryExists {
+		excludes, err := convertInputToExcludes(r.Task.GetPatchConfig().GetYum().GetExcludes())
+		if err != nil {
+			return err
+		}
 		opts := []ospatch.YumUpdateOption{
 			ospatch.YumUpdateSecurity(r.Task.GetPatchConfig().GetYum().GetSecurity()),
 			ospatch.YumUpdateMinimal(r.Task.GetPatchConfig().GetYum().GetMinimal()),
-			ospatch.YumUpdateExcludes(r.Task.GetPatchConfig().GetYum().GetExcludes()),
+			ospatch.YumUpdateExcludes(excludes),
 			ospatch.YumExclusivePackages(r.Task.GetPatchConfig().GetYum().GetExclusivePackages()),
 			ospatch.YumDryRun(r.Task.GetDryRun()),
 		}
@@ -61,12 +70,16 @@ func (r *patchTask) runUpdates(ctx context.Context) error {
 		}
 	}
 	if packages.ZypperExists && packages.RPMQueryExists {
+		excludes, err := convertInputToExcludes(r.Task.GetPatchConfig().GetZypper().GetExcludes())
+		if err != nil {
+			return err
+		}
 		opts := []ospatch.ZypperPatchOption{
 			ospatch.ZypperPatchCategories(r.Task.GetPatchConfig().GetZypper().GetCategories()),
 			ospatch.ZypperPatchSeverities(r.Task.GetPatchConfig().GetZypper().GetSeverities()),
 			ospatch.ZypperUpdateWithUpdate(r.Task.GetPatchConfig().GetZypper().GetWithUpdate()),
 			ospatch.ZypperUpdateWithOptional(r.Task.GetPatchConfig().GetZypper().GetWithOptional()),
-			ospatch.ZypperUpdateWithExcludes(r.Task.GetPatchConfig().GetZypper().GetExcludes()),
+			ospatch.ZypperUpdateWithExcludes(excludes),
 			ospatch.ZypperUpdateWithExclusivePatches(r.Task.GetPatchConfig().GetZypper().GetExclusivePatches()),
 			ospatch.ZypperUpdateDryrun(r.Task.GetDryRun()),
 		}
@@ -79,4 +92,38 @@ func (r *patchTask) runUpdates(ctx context.Context) error {
 		return nil
 	}
 	return errors.New(strings.Join(errs, ",\n"))
+}
+
+func convertInputToExcludes(input []string) ([]*ospatch.Exclude, error) {
+	var output []*ospatch.Exclude
+	for _, s := range input {
+		if len(s) >= 2 && (s)[0] == '/' && s[len(s)-1] == '/' {
+			exclude, err := regexExcludeFromString(s[1 : len(s)-1])
+			if err != nil {
+				return nil, err
+			}
+			output = append(output, exclude)
+		} else {
+			output = append(output, strictExcludeFromString(s))
+		}
+	}
+	return output, nil
+}
+
+func strictExcludeFromString(s string) *ospatch.Exclude {
+	return &ospatch.Exclude{
+		IsRegexp:     false,
+		StrictString: &s,
+	}
+}
+
+func regexExcludeFromString(s string) (*ospatch.Exclude, error) {
+	compile, err := regexp.Compile(s)
+	if err != nil {
+		return nil, err
+	}
+	return &ospatch.Exclude{
+		IsRegexp: true,
+		Regex:    compile,
+	}, nil
 }

--- a/agentendpoint/patch_linux.go
+++ b/agentendpoint/patch_linux.go
@@ -104,17 +104,10 @@ func convertInputToExcludes(input []string) ([]*ospatch.Exclude, error) {
 			}
 			output = append(output, exclude)
 		} else {
-			output = append(output, strictExcludeFromString(s))
+			output = append(output, ospatch.CreateStringExclude(&s))
 		}
 	}
 	return output, nil
-}
-
-func strictExcludeFromString(s string) *ospatch.Exclude {
-	return &ospatch.Exclude{
-		IsRegexp:     false,
-		StrictString: &s,
-	}
 }
 
 func regexExcludeFromString(s string) (*ospatch.Exclude, error) {
@@ -122,8 +115,5 @@ func regexExcludeFromString(s string) (*ospatch.Exclude, error) {
 	if err != nil {
 		return nil, err
 	}
-	return &ospatch.Exclude{
-		IsRegexp: true,
-		Regex:    compile,
-	}, nil
+	return ospatch.CreateRegexExclude(compile), nil
 }

--- a/agentendpoint/patch_linux_test.go
+++ b/agentendpoint/patch_linux_test.go
@@ -24,26 +24,21 @@ import (
 
 func TestExcludeConversion(t *testing.T) {
 	strictString := "PackageName"
-	excludeStrictString := ospatch.Exclude{IsRegexp: false, StrictString: &strictString}
 	regex, _ := regexp.Compile("PackageName")
-	excludeRegex := ospatch.Exclude{IsRegexp: true, Regex: regex}
 	emptyRegex, _ := regexp.Compile("")
-	emptyExcludeRegex := ospatch.Exclude{IsRegexp: true, Regex: emptyRegex}
 	slashString := "/"
-	slashExcludeStrictString := ospatch.Exclude{IsRegexp: false, StrictString: &slashString}
 	emptyString := ""
-	emptyExcludeStrictString := ospatch.Exclude{IsRegexp: false, StrictString: &emptyString}
 
 	tests := []struct {
 		name  string
 		input []string
 		want  []*ospatch.Exclude
 	}{
-		{name: "StrictStringConversion", input: []string{"PackageName"}, want: []*ospatch.Exclude{&excludeStrictString}},
-		{name: "RegexConversion", input: []string{"/PackageName/"}, want: []*ospatch.Exclude{&excludeRegex}},
-		{name: "CornerCaseRegex", input: []string{"//"}, want: []*ospatch.Exclude{&emptyExcludeRegex}},
-		{name: "CornerCaseStrictString", input: []string{"/"}, want: []*ospatch.Exclude{&slashExcludeStrictString}},
-		{name: "CornerCaseEmptyString", input: []string{""}, want: []*ospatch.Exclude{&emptyExcludeStrictString}},
+		{name: "StrictStringConversion", input: []string{"PackageName"}, want: []*ospatch.Exclude{ospatch.CreateStringExclude(&strictString)}},
+		{name: "RegexConversion", input: []string{"/PackageName/"}, want: []*ospatch.Exclude{ospatch.CreateRegexExclude(regex)}},
+		{name: "CornerCaseRegex", input: []string{"//"}, want: []*ospatch.Exclude{ospatch.CreateRegexExclude(emptyRegex)}},
+		{name: "CornerCaseStrictString", input: []string{"/"}, want: []*ospatch.Exclude{ospatch.CreateStringExclude(&slashString)}},
+		{name: "CornerCaseEmptyString", input: []string{""}, want: []*ospatch.Exclude{ospatch.CreateStringExclude(&emptyString)}},
 	}
 
 	for _, tt := range tests {

--- a/agentendpoint/patch_linux_test.go
+++ b/agentendpoint/patch_linux_test.go
@@ -1,0 +1,60 @@
+//  Copyright 2022 Google Inc. All Rights Reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
+package agentendpoint
+
+import (
+	"reflect"
+	"regexp"
+	"testing"
+
+	"github.com/GoogleCloudPlatform/osconfig/ospatch"
+)
+
+func TestExcludeConversion(t *testing.T) {
+	strictString := "PackageName"
+	excludeStrictString := ospatch.Exclude{IsRegexp: false, StrictString: &strictString}
+	regex, _ := regexp.Compile("PackageName")
+	excludeRegex := ospatch.Exclude{IsRegexp: true, Regex: regex}
+	emptyRegex, _ := regexp.Compile("")
+	emptyExcludeRegex := ospatch.Exclude{IsRegexp: true, Regex: emptyRegex}
+	slashString := "/"
+	slashExcludeStrictString := ospatch.Exclude{IsRegexp: false, StrictString: &slashString}
+	emptyString := ""
+	emptyExcludeStrictString := ospatch.Exclude{IsRegexp: false, StrictString: &emptyString}
+
+	tests := []struct {
+		name  string
+		input []string
+		want  []*ospatch.Exclude
+	}{
+		{name: "StrictStringConversion", input: []string{"PackageName"}, want: []*ospatch.Exclude{&excludeStrictString}},
+		{name: "RegexConversion", input: []string{"/PackageName/"}, want: []*ospatch.Exclude{&excludeRegex}},
+		{name: "CornerCaseRegex", input: []string{"//"}, want: []*ospatch.Exclude{&emptyExcludeRegex}},
+		{name: "CornerCaseStrictString", input: []string{"/"}, want: []*ospatch.Exclude{&slashExcludeStrictString}},
+		{name: "CornerCaseEmptyString", input: []string{""}, want: []*ospatch.Exclude{&emptyExcludeStrictString}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			excludes, err := convertInputToExcludes(tt.input)
+			if err != nil {
+				t.Errorf("err = %v, want %v", err, nil)
+			}
+			if !reflect.DeepEqual(excludes, tt.want) {
+				t.Errorf("convertInputToExcludes() = %v, want = %v", excludes, tt.want)
+			}
+		})
+	}
+}

--- a/e2e_tests/test_suites/patch/patch.go
+++ b/e2e_tests/test_suites/patch/patch.go
@@ -114,7 +114,7 @@ func TestSuite(ctx context.Context, tswg *sync.WaitGroup, testSuites chan *junit
 		s := setup
 		tc := junitxml.NewTestCase(testSuiteName, fmt.Sprintf("[APT dist-upgrade, excludes] [%s]", s.testName))
 		f := func() {
-			runExecutePatchJobTest(ctx, tc, s, &osconfigpb.PatchConfig{Apt: &osconfigpb.AptSettings{Type: osconfigpb.AptSettings_DIST, Excludes: []string{"pkg1"}}})
+			runExecutePatchJobTest(ctx, tc, s, &osconfigpb.PatchConfig{Apt: &osconfigpb.AptSettings{Type: osconfigpb.AptSettings_DIST, Excludes: []string{"pkg1", "/pkg2/"}}})
 		}
 		go runTestCase(tc, f, tests, &wg, logger, testCaseRegex)
 	}
@@ -134,7 +134,7 @@ func TestSuite(ctx context.Context, tswg *sync.WaitGroup, testSuites chan *junit
 		s := setup
 		tc := junitxml.NewTestCase(testSuiteName, fmt.Sprintf("[YUM security, minimal and excludes] [%s]", s.testName))
 		f := func() {
-			runExecutePatchJobTest(ctx, tc, s, &osconfigpb.PatchConfig{Yum: &osconfigpb.YumSettings{Security: true, Minimal: true, Excludes: []string{"pkg1", "pkg2"}}})
+			runExecutePatchJobTest(ctx, tc, s, &osconfigpb.PatchConfig{Yum: &osconfigpb.YumSettings{Security: true, Minimal: true, Excludes: []string{"pkg1", "pkg2", "/pkg3/"}}})
 		}
 		go runTestCase(tc, f, tests, &wg, logger, testCaseRegex)
 	}
@@ -155,7 +155,7 @@ func TestSuite(ctx context.Context, tswg *sync.WaitGroup, testSuites chan *junit
 		tc := junitxml.NewTestCase(testSuiteName, fmt.Sprintf("[Zypper excludes, WithOptional, WithUpdate, Categories and Severities] [%s]", s.testName))
 		f := func() {
 			runExecutePatchJobTest(ctx, tc, s, &osconfigpb.PatchConfig{
-				Zypper: &osconfigpb.ZypperSettings{Excludes: []string{"patch-1"}, WithOptional: true, WithUpdate: true, Categories: []string{"security", "recommended", "feature"}, Severities: []string{"critical", "important", "moderate", "low"}}})
+				Zypper: &osconfigpb.ZypperSettings{Excludes: []string{"patch-1", "/patch-2/"}, WithOptional: true, WithUpdate: true, Categories: []string{"security", "recommended", "feature"}, Severities: []string{"critical", "important", "moderate", "low"}}})
 		}
 		go runTestCase(tc, f, tests, &wg, logger, testCaseRegex)
 	}

--- a/ospatch/apt_upgrade.go
+++ b/ospatch/apt_upgrade.go
@@ -24,7 +24,7 @@ import (
 
 type aptGetUpgradeOpts struct {
 	exclusivePackages []string
-	excludes          []string
+	excludes          []*Exclude
 	upgradeType       packages.AptUpgradeType
 	dryrun            bool
 }
@@ -40,7 +40,7 @@ func AptGetUpgradeType(upgradeType packages.AptUpgradeType) AptGetUpgradeOption 
 }
 
 // AptGetExcludes excludes these packages from upgrade.
-func AptGetExcludes(excludes []string) AptGetUpgradeOption {
+func AptGetExcludes(excludes []*Exclude) AptGetUpgradeOption {
 	return func(args *aptGetUpgradeOpts) {
 		args.excludes = excludes
 	}

--- a/ospatch/exclude.go
+++ b/ospatch/exclude.go
@@ -18,6 +18,7 @@ import (
 	"regexp"
 )
 
+// Exclude represents package exclude entry by a user
 type Exclude struct {
 	IsRegexp     bool
 	Regex        *regexp.Regexp

--- a/ospatch/exclude.go
+++ b/ospatch/exclude.go
@@ -1,0 +1,25 @@
+//  Copyright 2022 Google Inc. All Rights Reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
+package ospatch
+
+import (
+	"regexp"
+)
+
+type Exclude struct {
+	IsRegexp     bool
+	Regex        *regexp.Regexp
+	StrictString *string
+}

--- a/ospatch/exclude.go
+++ b/ospatch/exclude.go
@@ -20,7 +20,28 @@ import (
 
 // Exclude represents package exclude entry by a user
 type Exclude struct {
-	IsRegexp     bool
-	Regex        *regexp.Regexp
-	StrictString *string
+	isRegexp     bool
+	regex        *regexp.Regexp
+	strictString *string
+}
+
+func CreateRegexExclude(regex *regexp.Regexp) *Exclude {
+	return &Exclude{
+		isRegexp: true,
+		regex:    regex,
+	}
+}
+
+func CreateStringExclude(strictString *string) *Exclude {
+	return &Exclude{
+		isRegexp:     false,
+		strictString: strictString,
+	}
+}
+
+func (exclude *Exclude) MatchesName(name *string) bool {
+	if exclude.isRegexp {
+		return exclude.regex.MatchString(*name)
+	}
+	return *exclude.strictString == *name
 }

--- a/ospatch/exclude.go
+++ b/ospatch/exclude.go
@@ -25,6 +25,7 @@ type Exclude struct {
 	strictString *string
 }
 
+// CreateRegexExclude returns new Exclude struct that represents exclusion with regex
 func CreateRegexExclude(regex *regexp.Regexp) *Exclude {
 	return &Exclude{
 		isRegexp: true,
@@ -32,6 +33,7 @@ func CreateRegexExclude(regex *regexp.Regexp) *Exclude {
 	}
 }
 
+// CreateStringExclude returns new Exclude struct that represents exclusion with string
 func CreateStringExclude(strictString *string) *Exclude {
 	return &Exclude{
 		isRegexp:     false,
@@ -39,6 +41,7 @@ func CreateStringExclude(strictString *string) *Exclude {
 	}
 }
 
+// MatchesName returns if a package with a certain name matches Exclude struct and should be excluded
 func (exclude *Exclude) MatchesName(name *string) bool {
 	if exclude.isRegexp {
 		return exclude.regex.MatchString(*name)

--- a/ospatch/googet_update.go
+++ b/ospatch/googet_update.go
@@ -24,7 +24,7 @@ import (
 
 type googetUpdateOpts struct {
 	exclusivePackages []string
-	excludes          []string
+	excludes          []*Exclude
 	dryrun            bool
 }
 
@@ -32,7 +32,7 @@ type googetUpdateOpts struct {
 type GooGetUpdateOption func(*googetUpdateOpts)
 
 // GooGetExcludes excludes these packages from upgrade.
-func GooGetExcludes(excludes []string) GooGetUpdateOption {
+func GooGetExcludes(excludes []*Exclude) GooGetUpdateOption {
 	return func(args *googetUpdateOpts) {
 		args.excludes = excludes
 	}

--- a/ospatch/updates.go
+++ b/ospatch/updates.go
@@ -113,18 +113,11 @@ func rpmReboot() (bool, error) {
 
 func shouldPackageBeExcluded(excludes []*Exclude, packageName *string) bool {
 	for _, exclude := range excludes {
-		if excludeMatchesPackageName(exclude, packageName) {
+		if exclude.MatchesName(packageName) {
 			return true
 		}
 	}
 	return false
-}
-
-func excludeMatchesPackageName(exclude *Exclude, packageName *string) bool {
-	if exclude.IsRegexp {
-		return exclude.Regex.MatchString(*packageName)
-	}
-	return *exclude.StrictString == *packageName
 }
 
 func containsString(ss []string, c string) bool {

--- a/ospatch/updates_test.go
+++ b/ospatch/updates_test.go
@@ -100,9 +100,9 @@ func TestFilterPackages(t *testing.T) {
 		exludes []*Exclude
 		want    []*packages.PkgInfo
 	}{
-		{name: "StrictStringFiltering", pkgs: []*packages.PkgInfo{&pkg}, exludes: []*Exclude{{IsRegexp: false, StrictString: &strictString}}, want: []*packages.PkgInfo{}},
-		{name: "RegexpFiltering", pkgs: []*packages.PkgInfo{&pkg}, exludes: []*Exclude{{IsRegexp: true, Regex: regex}}, want: []*packages.PkgInfo{}},
-		{name: "MissedFilter", pkgs: []*packages.PkgInfo{&pkg}, exludes: []*Exclude{{IsRegexp: true, Regex: missingRegex}}, want: []*packages.PkgInfo{&pkg}},
+		{name: "StrictStringFiltering", pkgs: []*packages.PkgInfo{&pkg}, exludes: []*Exclude{CreateStringExclude(&strictString)}, want: []*packages.PkgInfo{}},
+		{name: "RegexpFiltering", pkgs: []*packages.PkgInfo{&pkg}, exludes: []*Exclude{CreateRegexExclude(regex)}, want: []*packages.PkgInfo{}},
+		{name: "MissedFilter", pkgs: []*packages.PkgInfo{&pkg}, exludes: []*Exclude{CreateRegexExclude(missingRegex)}, want: []*packages.PkgInfo{&pkg}},
 	}
 
 	for _, tt := range tests {

--- a/ospatch/updates_test.go
+++ b/ospatch/updates_test.go
@@ -17,7 +17,11 @@ package ospatch
 import (
 	"io/ioutil"
 	"os"
+	"reflect"
+	"regexp"
 	"testing"
+
+	"github.com/GoogleCloudPlatform/osconfig/packages"
 )
 
 func TestGetBtime(t *testing.T) {
@@ -80,6 +84,35 @@ func TestRpmRebootRequired(t *testing.T) {
 			got := rpmRebootRequired(tt.args.pkgs, tt.args.btime)
 			if got != tt.want {
 				t.Errorf("rpmRebootRequired() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestFilterPackages(t *testing.T) {
+	pkg := packages.PkgInfo{Name: "NameOfThePackage"}
+	strictString := "NameOfThePackage"
+	regex, _ := regexp.Compile("^NameO[e-g]ThePackage$")
+	missingRegex, _ := regexp.Compile("^NameO[e-g]ThePackag$")
+	tests := []struct {
+		name    string
+		pkgs    []*packages.PkgInfo
+		exludes []*Exclude
+		want    []*packages.PkgInfo
+	}{
+		{name: "StrictStringFiltering", pkgs: []*packages.PkgInfo{&pkg}, exludes: []*Exclude{{IsRegexp: false, StrictString: &strictString}}, want: []*packages.PkgInfo{}},
+		{name: "RegexpFiltering", pkgs: []*packages.PkgInfo{&pkg}, exludes: []*Exclude{{IsRegexp: true, Regex: regex}}, want: []*packages.PkgInfo{}},
+		{name: "MissedFilter", pkgs: []*packages.PkgInfo{&pkg}, exludes: []*Exclude{{IsRegexp: true, Regex: missingRegex}}, want: []*packages.PkgInfo{&pkg}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := filterPackages(tt.pkgs, nil, tt.exludes)
+			if err != nil {
+				t.Errorf("err = %v, want %v", err, nil)
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("filterPackages() = %v, want %v", got, tt.want)
 			}
 		})
 	}

--- a/ospatch/yum_update.go
+++ b/ospatch/yum_update.go
@@ -31,7 +31,7 @@ var (
 
 type yumUpdateOpts struct {
 	exclusivePackages []string
-	excludes          []string
+	excludes          []*Exclude
 	security          bool
 	minimal           bool
 	dryrun            bool
@@ -58,7 +58,7 @@ func YumUpdateMinimal(minimal bool) YumUpdateOption {
 
 // YumUpdateExcludes returns a YumUpdateOption that specifies what packages to add to
 // the --exclude flag.
-func YumUpdateExcludes(excludes []string) YumUpdateOption {
+func YumUpdateExcludes(excludes []*Exclude) YumUpdateOption {
 	return func(args *yumUpdateOpts) {
 		args.excludes = excludes
 	}
@@ -90,14 +90,14 @@ func RunYumUpdate(ctx context.Context, opts ...YumUpdateOption) error {
 		opt(yumOpts)
 	}
 
-	pkgs, err := packages.YumUpdates(ctx, packages.YumUpdateMinimal(yumOpts.minimal), packages.YumUpdateSecurity(yumOpts.security), packages.YumExcludes(yumOpts.excludes))
+	pkgs, err := packages.YumUpdates(ctx, packages.YumUpdateMinimal(yumOpts.minimal), packages.YumUpdateSecurity(yumOpts.security))
 	if err != nil {
 		return err
 	}
 
 	// Yum excludes are already excluded while listing yumUpdates, so we send
 	// and empty list.
-	fPkgs, err := filterPackages(pkgs, yumOpts.exclusivePackages, []string{})
+	fPkgs, err := filterPackages(pkgs, yumOpts.exclusivePackages, yumOpts.excludes)
 	if err != nil {
 		return err
 	}

--- a/ospatch/zypper_patch_test.go
+++ b/ospatch/zypper_patch_test.go
@@ -14,7 +14,7 @@ func TestRunFilter(t *testing.T) {
 		pkgUpdates        []*packages.PkgInfo
 		pkgToPatchesMap   map[string][]string
 		exclusiveIncludes []string
-		excludes          []string
+		excludes          []*Exclude
 		withUpdate        bool
 	}
 	type expect struct {
@@ -23,30 +23,32 @@ func TestRunFilter(t *testing.T) {
 		err        error
 	}
 
+	var patch3String = "patch-3"
+
 	tests := []struct {
 		name   string
 		input  input
 		expect expect
 	}{
 		{name: "runfilterwithexclusivepatches",
-			input:  input{patches: patches, pkgUpdates: pkgUpdates, pkgToPatchesMap: pkgToPatchesMap, exclusiveIncludes: []string{"patch-3"}, excludes: []string{}, withUpdate: false},
+			input:  input{patches: patches, pkgUpdates: pkgUpdates, pkgToPatchesMap: pkgToPatchesMap, exclusiveIncludes: []string{"patch-3"}, excludes: []*Exclude{}, withUpdate: false},
 			expect: expect{patches: []string{"patch-3"}, pkgUpdates: []string{}, err: nil},
 		},
 		{name: "runFilterwithUpdatewithexcludes",
 			// withupdate, exclude a patch that has
-			input:  input{patches: patches, pkgUpdates: pkgUpdates, pkgToPatchesMap: pkgToPatchesMap, exclusiveIncludes: []string{}, excludes: []string{"patch-3"}, withUpdate: true},
+			input:  input{patches: patches, pkgUpdates: pkgUpdates, pkgToPatchesMap: pkgToPatchesMap, exclusiveIncludes: []string{}, excludes: []*Exclude{{IsRegexp: false, StrictString: &patch3String}}, withUpdate: true},
 			expect: expect{patches: []string{"patch-1", "patch-2"}, pkgUpdates: []string{"pkg6"}, err: nil},
 		},
 		{name: "runFilterwithoutUpdatewithexcludes",
-			input:  input{patches: patches, pkgUpdates: pkgUpdates, pkgToPatchesMap: pkgToPatchesMap, exclusiveIncludes: []string{}, excludes: []string{"patch-3"}, withUpdate: false},
+			input:  input{patches: patches, pkgUpdates: pkgUpdates, pkgToPatchesMap: pkgToPatchesMap, exclusiveIncludes: []string{}, excludes: []*Exclude{{IsRegexp: false, StrictString: &patch3String}}, withUpdate: false},
 			expect: expect{patches: []string{"patch-1", "patch-2"}, pkgUpdates: []string{}, err: nil},
 		},
 		{name: "runFilterwithUpdatewithoutexcludes",
-			input:  input{patches: patches, pkgUpdates: pkgUpdates, pkgToPatchesMap: pkgToPatchesMap, exclusiveIncludes: []string{}, excludes: []string{}, withUpdate: true},
+			input:  input{patches: patches, pkgUpdates: pkgUpdates, pkgToPatchesMap: pkgToPatchesMap, exclusiveIncludes: []string{}, excludes: []*Exclude{}, withUpdate: true},
 			expect: expect{patches: []string{"patch-1", "patch-2", "patch-3"}, pkgUpdates: []string{"pkg6"}, err: nil},
 		},
 		{name: "runFilterwithoutUpdatewithoutexcludes",
-			input:  input{patches: patches, pkgUpdates: pkgUpdates, pkgToPatchesMap: pkgToPatchesMap, exclusiveIncludes: []string{}, excludes: []string{}, withUpdate: false},
+			input:  input{patches: patches, pkgUpdates: pkgUpdates, pkgToPatchesMap: pkgToPatchesMap, exclusiveIncludes: []string{}, excludes: []*Exclude{}, withUpdate: false},
 			expect: expect{patches: []string{"patch-1", "patch-2", "patch-3"}, pkgUpdates: []string{}, err: nil},
 		},
 	}

--- a/ospatch/zypper_patch_test.go
+++ b/ospatch/zypper_patch_test.go
@@ -36,11 +36,11 @@ func TestRunFilter(t *testing.T) {
 		},
 		{name: "runFilterwithUpdatewithexcludes",
 			// withupdate, exclude a patch that has
-			input:  input{patches: patches, pkgUpdates: pkgUpdates, pkgToPatchesMap: pkgToPatchesMap, exclusiveIncludes: []string{}, excludes: []*Exclude{{IsRegexp: false, StrictString: &patch3String}}, withUpdate: true},
+			input:  input{patches: patches, pkgUpdates: pkgUpdates, pkgToPatchesMap: pkgToPatchesMap, exclusiveIncludes: []string{}, excludes: []*Exclude{CreateStringExclude(&patch3String)}, withUpdate: true},
 			expect: expect{patches: []string{"patch-1", "patch-2"}, pkgUpdates: []string{"pkg6"}, err: nil},
 		},
 		{name: "runFilterwithoutUpdatewithexcludes",
-			input:  input{patches: patches, pkgUpdates: pkgUpdates, pkgToPatchesMap: pkgToPatchesMap, exclusiveIncludes: []string{}, excludes: []*Exclude{{IsRegexp: false, StrictString: &patch3String}}, withUpdate: false},
+			input:  input{patches: patches, pkgUpdates: pkgUpdates, pkgToPatchesMap: pkgToPatchesMap, exclusiveIncludes: []string{}, excludes: []*Exclude{CreateStringExclude(&patch3String)}, withUpdate: false},
 			expect: expect{patches: []string{"patch-1", "patch-2"}, pkgUpdates: []string{}, err: nil},
 		},
 		{name: "runFilterwithUpdatewithoutexcludes",

--- a/packages/yum.go
+++ b/packages/yum.go
@@ -43,7 +43,6 @@ func init() {
 }
 
 type yumUpdateOpts struct {
-	excludes []string
 	security bool
 	minimal  bool
 }
@@ -64,14 +63,6 @@ func YumUpdateSecurity(security bool) YumUpdateOption {
 func YumUpdateMinimal(minimal bool) YumUpdateOption {
 	return func(args *yumUpdateOpts) {
 		args.minimal = minimal
-	}
-}
-
-// YumExcludes returns a YumUpdateOption that specifies the excludes
-// command should be used.
-func YumExcludes(excludes []string) YumUpdateOption {
-	return func(args *yumUpdateOpts) {
-		args.excludes = excludes
 	}
 }
 
@@ -167,7 +158,6 @@ func listAndParseYumPackages(ctx context.Context, opts ...YumUpdateOption) ([]*P
 	yumOpts := &yumUpdateOpts{
 		security: false,
 		minimal:  false,
-		excludes: []string{},
 	}
 
 	for _, opt := range opts {
@@ -180,11 +170,6 @@ func listAndParseYumPackages(ctx context.Context, opts ...YumUpdateOption) ([]*P
 	}
 	if yumOpts.security {
 		args = append(args, "--security")
-	}
-	if len(yumOpts.excludes) > 0 {
-		for _, pkg := range yumOpts.excludes {
-			args = append(args, []string{"--exclude", pkg}...)
-		}
 	}
 
 	stdout, stderr, err := ptyrunner.Run(ctx, exec.CommandContext(ctx, yum, args...))

--- a/packages/yum_test.go
+++ b/packages/yum_test.go
@@ -154,29 +154,28 @@ func TestYumUpdates(t *testing.T) {
 		}
 	})
 
-	// Test WithSecurityWithExcludes
-	t.Run("WithSecurityWithExcludes", func(t *testing.T) {
-		// the mock data returned by mockcommandrunner will not include this
-		// package anyways. The purpose of this test is to make sure that
-		// when customer specifies excluded packages, we set the --exclude flag
-		// in the yum command.
-		excludedPackages := []string{"ex-pkg1", "ex-pkg2"}
-		expectedCmd := exec.CommandContext(context.Background(), yum, append(yumListUpdatesArgs, "--security", "--exclude", excludedPackages[0], "--exclude", excludedPackages[1])...)
+	/*	// Test WithSecurityWithExcludes
+		t.Run("WithSecurityWithExcludes", func(t *testing.T) {
+			// the mock data returned by mockcommandrunner will not include this
+			// package anyways. The purpose of this test is to make sure that
+			// when customer specifies excluded packages, we set the --exclude flag
+			// in the yum command.
+			expectedCmd := exec.CommandContext(context.Background(), yum, append(yumListUpdatesArgs, "--security")...)
 
-		first := mockCommandRunner.EXPECT().Run(testCtx, expectedCheckUpdate).Return(data, []byte("stderr"), errExit100).Times(1)
-		mockCommandRunner.EXPECT().Run(testCtx, expectedCmd).After(first).Return(data, []byte("stderr"), nil).Times(1)
-		ret, err := YumUpdates(testCtx, YumUpdateMinimal(false), YumUpdateSecurity(true), YumExcludes(excludedPackages))
-		if err != nil {
-			t.Errorf("did not expect error: %v", err)
-		}
-
-		allPackageNames := []string{"kernel", "foo", "bar"}
-		for _, pkg := range ret {
-			if !contains(allPackageNames, pkg.Name) {
-				t.Errorf("package %s expected to be present.", pkg.Name)
+			first := mockCommandRunner.EXPECT().Run(testCtx, expectedCheckUpdate).Return(data, []byte("stderr"), errExit100).Times(1)
+			mockCommandRunner.EXPECT().Run(testCtx, expectedCmd).After(first).Return(data, []byte("stderr"), nil).Times(1)
+			ret, err := YumUpdates(testCtx, YumUpdateMinimal(false), YumUpdateSecurity(true))
+			if err != nil {
+				t.Errorf("did not expect error: %v", err)
 			}
-		}
-	})
+
+			allPackageNames := []string{"kernel", "foo", "bar"}
+			for _, pkg := range ret {
+				if !contains(allPackageNames, pkg.Name) {
+					t.Errorf("package %s expected to be present.", pkg.Name)
+				}
+			}
+		})*/
 }
 
 func contains(names []string, name string) bool {


### PR DESCRIPTION
Unify filtering of packages - change filtering in yum to not use filt…ering eagerly when listing packages (only yum supports this operation)

Add possibility to use regex to exclude packages, when the exclude value is contained in '/' treat it as a regex, i.e.: "/^abc.*xyz$/", the '/' character cannot be used inside a linux package name (only letters, numbers, .-+_) so we don't have a problem of name collisions between packages and regexes

We don't add regex excluding in windows because KB numbers are pretty arbitrary