### PR TITLE
Create e2e test that runs apt-get in a state that makes it downgrade a package

### DIFF
--- a/e2e_tests/test_suites/patch/patch.go
+++ b/e2e_tests/test_suites/patch/patch.go
@@ -41,7 +41,8 @@ import (
 )
 
 const (
-	testSuiteName = "OSPatch"
+	testSuiteName              = "OSPatch"
+	AptDowngradeScriptLocation = "./set_apt_downgrade.sh"
 )
 
 var (
@@ -446,7 +447,7 @@ func patchConfigWithPrePostSteps() *osconfigpb.PatchConfig {
 }
 
 func patchConfigWithPreStepsForcingDowngrade() *osconfigpb.PatchConfig {
-	linuxPreStepConfig := &osconfigpb.ExecStepConfig{Executable: &osconfigpb.ExecStepConfig_LocalPath{LocalPath: "./set_apt_downgrade.sh"}, Interpreter: osconfigpb.ExecStepConfig_SHELL}
+	linuxPreStepConfig := &osconfigpb.ExecStepConfig{Executable: &osconfigpb.ExecStepConfig_LocalPath{LocalPath: AptDowngradeScriptLocation}, Interpreter: osconfigpb.ExecStepConfig_SHELL}
 
 	preStep := &osconfigpb.ExecStep{LinuxExecStepConfig: linuxPreStepConfig}
 

--- a/e2e_tests/test_suites/patch/patch.go
+++ b/e2e_tests/test_suites/patch/patch.go
@@ -42,7 +42,7 @@ import (
 
 const (
 	testSuiteName              = "OSPatch"
-	AptDowngradeScriptLocation = "./set_apt_downgrade.sh"
+	aptDowngradeScriptLocation = "./set_apt_downgrade.sh"
 )
 
 var (
@@ -447,7 +447,7 @@ func patchConfigWithPrePostSteps() *osconfigpb.PatchConfig {
 }
 
 func patchConfigWithPreStepsForcingDowngrade() *osconfigpb.PatchConfig {
-	linuxPreStepConfig := &osconfigpb.ExecStepConfig{Executable: &osconfigpb.ExecStepConfig_LocalPath{LocalPath: AptDowngradeScriptLocation}, Interpreter: osconfigpb.ExecStepConfig_SHELL}
+	linuxPreStepConfig := &osconfigpb.ExecStepConfig{Executable: &osconfigpb.ExecStepConfig_LocalPath{LocalPath: aptDowngradeScriptLocation}, Interpreter: osconfigpb.ExecStepConfig_SHELL}
 
 	preStep := &osconfigpb.ExecStep{LinuxExecStepConfig: linuxPreStepConfig}
 

--- a/e2e_tests/test_suites/patch/patch.go
+++ b/e2e_tests/test_suites/patch/patch.go
@@ -132,7 +132,7 @@ func TestSuite(ctx context.Context, tswg *sync.WaitGroup, testSuites chan *junit
 	for _, setup := range aptDownradeImageTestSetup() {
 		wg.Add(1)
 		s := setup
-		tc := junitxml.NewTestCase(testSuiteName, fmt.Sprintf("[PatchJob runs pre-step and post-step] [%s]", s.testName))
+		tc := junitxml.NewTestCase(testSuiteName, fmt.Sprintf("[PatchJob apt-get doesn't fail on downgrades] [%s]", s.testName))
 		pc := patchConfigWithPreStepsForcingDowngrade()
 		f := func() { runExecutePatchJobTest(ctx, tc, s, pc) }
 		go runTestCase(tc, f, tests, &wg, logger, testCaseRegex)

--- a/e2e_tests/test_suites/patch/patch.go
+++ b/e2e_tests/test_suites/patch/patch.go
@@ -129,7 +129,7 @@ func TestSuite(ctx context.Context, tswg *sync.WaitGroup, testSuites chan *junit
 		go runTestCase(tc, f, tests, &wg, logger, testCaseRegex)
 	}
 	// Test that apt-get patch works even when a package needs to be downgraded
-	for _, setup := range aptDownradeImageTestSetup() {
+	for _, setup := range aptDowngradeImageTestSetup() {
 		wg.Add(1)
 		s := setup
 		tc := junitxml.NewTestCase(testSuiteName, fmt.Sprintf("[PatchJob apt-get doesn't fail on downgrades] [%s]", s.testName))

--- a/e2e_tests/test_suites/patch/test_setup.go
+++ b/e2e_tests/test_suites/patch/test_setup.go
@@ -81,10 +81,10 @@ chmod +x ./linux_local_pre_patch_script.sh
 `
 
 	setUpDowngradeScript = `
-echo 'echo \'deb [trusted=yes check-valid-until=no] http://snapshot.debian.org/archive/debian/20190801T025637Z/ buster main\' >> /etc/apt/sources.list' >> ./set_apt_downgrade.sh
-echo 'echo \'Package: sudo\' >> /etc/apt/preferences' >> ./set_apt_downgrade.sh
-echo 'echo \'Pin: version 1.8.27-1\' >> /etc/apt/preferences' >> ./set_apt_downgrade.sh
-echo 'echo \'Pin-priority: 9999\' >> /etc/apt/preferences' >> ./set_apt_downgrade.sh
+echo 'echo \'deb [trusted=yes check-valid-until=no] http://snapshot.debian.org/archive/debian/20190801T025637Z/ buster main\' >> /etc/apt/sources.list' >> ` + AptDowngradeScriptLocation + `
+echo 'echo \'Package: sudo\' >> /etc/apt/preferences' >> ` + AptDowngradeScriptLocation + `
+echo 'echo \'Pin: version 1.8.27-1\' >> /etc/apt/preferences' >> ` + AptDowngradeScriptLocation + `
+echo 'echo \'Pin-priority: 9999\' >> /etc/apt/preferences' >> ` + AptDowngradeScriptLocation + `
 `
 
 	enableOsconfig  = compute.BuildInstanceMetadataItem("enable-osconfig", "true")

--- a/e2e_tests/test_suites/patch/test_setup.go
+++ b/e2e_tests/test_suites/patch/test_setup.go
@@ -205,7 +205,7 @@ func aptHeadImageTestSetup() []*patchTestSetup {
 	return imageTestSetup(mapping)
 }
 
-func aptDownradeImageTestSetup() []*patchTestSetup {
+func aptDowngradeImageTestSetup() []*patchTestSetup {
 	// This maps a specific patchTestSetup to test setup names and associated images.
 	mapping := map[*patchTestSetup]map[string]string{
 		aptDowngradeSetup: utils.DowngradeAptImages,

--- a/e2e_tests/test_suites/patch/test_setup.go
+++ b/e2e_tests/test_suites/patch/test_setup.go
@@ -80,11 +80,11 @@ echo 'curl -X PUT --data "1" http://metadata.google.internal/computeMetadata/v1/
 chmod +x ./linux_local_pre_patch_script.sh
 `
 
-	setUpDowngradeScript = `
-echo 'echo \'deb [trusted=yes check-valid-until=no] http://snapshot.debian.org/archive/debian/20190801T025637Z/ buster main\' >> /etc/apt/sources.list' >> ` + aptDowngradeScriptLocation + `
-echo 'echo \'Package: sudo\' >> /etc/apt/preferences' >> ` + aptDowngradeScriptLocation + `
-echo 'echo \'Pin: version 1.8.27-1\' >> /etc/apt/preferences' >> ` + aptDowngradeScriptLocation + `
-echo 'echo \'Pin-priority: 9999\' >> /etc/apt/preferences' >> ` + aptDowngradeScriptLocation + `
+	setUpDowngradeState = `
+echo 'deb [trusted=yes check-valid-until=no] http://snapshot.debian.org/archive/debian/20190801T025637Z/ buster main' >> /etc/apt/sources.list
+echo 'Package: sudo' >> /etc/apt/preferences
+echo 'Pin: version 1.8.27-1' >> /etc/apt/preferences
+echo 'Pin-priority: 9999' >> /etc/apt/preferences
 `
 
 	enableOsconfig  = compute.BuildInstanceMetadataItem("enable-osconfig", "true")
@@ -112,7 +112,7 @@ echo 'echo \'Pin-priority: 9999\' >> /etc/apt/preferences' >> ` + aptDowngradeSc
 	aptDowngradeSetup = &patchTestSetup{
 		assertTimeout: 10 * time.Minute,
 		metadata: []*computeApi.MetadataItems{
-			compute.BuildInstanceMetadataItem("startup-script", linuxRecordBoot+utils.InstallOSConfigDeb()+linuxLocalPrePatchScript+setUpDowngradeScript),
+			compute.BuildInstanceMetadataItem("startup-script", linuxRecordBoot+utils.InstallOSConfigDeb()+linuxLocalPrePatchScript+setUpDowngradeState),
 			enableOsconfig,
 			disableFeatures,
 		},

--- a/e2e_tests/test_suites/patch/test_setup.go
+++ b/e2e_tests/test_suites/patch/test_setup.go
@@ -80,6 +80,13 @@ echo 'curl -X PUT --data "1" http://metadata.google.internal/computeMetadata/v1/
 chmod +x ./linux_local_pre_patch_script.sh
 `
 
+	setUpDowngradeScript = `
+echo 'echo \'deb [trusted=yes check-valid-until=no] http://snapshot.debian.org/archive/debian/20190801T025637Z/ buster main\' >> /etc/apt/sources.list' >> ./set_apt_downgrade.sh
+echo 'echo \'Package: sudo\' >> /etc/apt/preferences' >> ./set_apt_downgrade.sh
+echo 'echo \'Pin: version 1.8.27-1\' >> /etc/apt/preferences' >> ./set_apt_downgrade.sh
+echo 'echo \'Pin-priority: 9999\' >> /etc/apt/preferences' >> ./set_apt_downgrade.sh
+`
+
 	enableOsconfig  = compute.BuildInstanceMetadataItem("enable-osconfig", "true")
 	disableFeatures = compute.BuildInstanceMetadataItem("osconfig-disabled-features", "guestpolicies,osinventory")
 
@@ -97,6 +104,15 @@ chmod +x ./linux_local_pre_patch_script.sh
 		assertTimeout: 10 * time.Minute,
 		metadata: []*computeApi.MetadataItems{
 			compute.BuildInstanceMetadataItem("startup-script", linuxRecordBoot+utils.InstallOSConfigDeb()+linuxLocalPrePatchScript),
+			enableOsconfig,
+			disableFeatures,
+		},
+		machineType: "e2-medium",
+	}
+	aptDowngradeSetup = &patchTestSetup{
+		assertTimeout: 10 * time.Minute,
+		metadata: []*computeApi.MetadataItems{
+			compute.BuildInstanceMetadataItem("startup-script", linuxRecordBoot+utils.InstallOSConfigDeb()+linuxLocalPrePatchScript+setUpDowngradeScript),
 			enableOsconfig,
 			disableFeatures,
 		},
@@ -184,6 +200,15 @@ func aptHeadImageTestSetup() []*patchTestSetup {
 	// This maps a specific patchTestSetup to test setup names and associated images.
 	mapping := map[*patchTestSetup]map[string]string{
 		aptSetup: utils.HeadAptImages,
+	}
+
+	return imageTestSetup(mapping)
+}
+
+func aptDownradeImageTestSetup() []*patchTestSetup {
+	// This maps a specific patchTestSetup to test setup names and associated images.
+	mapping := map[*patchTestSetup]map[string]string{
+		aptDowngradeSetup: utils.DowngradeAptImages,
 	}
 
 	return imageTestSetup(mapping)

--- a/e2e_tests/test_suites/patch/test_setup.go
+++ b/e2e_tests/test_suites/patch/test_setup.go
@@ -81,10 +81,10 @@ chmod +x ./linux_local_pre_patch_script.sh
 `
 
 	setUpDowngradeScript = `
-echo 'echo \'deb [trusted=yes check-valid-until=no] http://snapshot.debian.org/archive/debian/20190801T025637Z/ buster main\' >> /etc/apt/sources.list' >> ` + AptDowngradeScriptLocation + `
-echo 'echo \'Package: sudo\' >> /etc/apt/preferences' >> ` + AptDowngradeScriptLocation + `
-echo 'echo \'Pin: version 1.8.27-1\' >> /etc/apt/preferences' >> ` + AptDowngradeScriptLocation + `
-echo 'echo \'Pin-priority: 9999\' >> /etc/apt/preferences' >> ` + AptDowngradeScriptLocation + `
+echo 'echo \'deb [trusted=yes check-valid-until=no] http://snapshot.debian.org/archive/debian/20190801T025637Z/ buster main\' >> /etc/apt/sources.list' >> ` + aptDowngradeScriptLocation + `
+echo 'echo \'Package: sudo\' >> /etc/apt/preferences' >> ` + aptDowngradeScriptLocation + `
+echo 'echo \'Pin: version 1.8.27-1\' >> /etc/apt/preferences' >> ` + aptDowngradeScriptLocation + `
+echo 'echo \'Pin-priority: 9999\' >> /etc/apt/preferences' >> ` + aptDowngradeScriptLocation + `
 `
 
 	enableOsconfig  = compute.BuildInstanceMetadataItem("enable-osconfig", "true")

--- a/e2e_tests/utils/utils.go
+++ b/e2e_tests/utils/utils.go
@@ -206,6 +206,7 @@ func InstallOSConfigEL(image string) string {
 	return ""
 }
 
+// DowngradeAptImages is a single image that are used for testing downgrade case with apt-get
 var DowngradeAptImages = map[string]string{
 	"debian-cloud/debian-10": "projects/debian-cloud/global/images/family/debian-10",
 }

--- a/e2e_tests/utils/utils.go
+++ b/e2e_tests/utils/utils.go
@@ -206,6 +206,10 @@ func InstallOSConfigEL(image string) string {
 	return ""
 }
 
+var DowngradeAptImages = map[string]string{
+	"debian-cloud/debian-10": "projects/debian-cloud/global/images/family/debian-10",
+}
+
 // HeadAptImages is a map of names to image paths for public image families that use APT.
 var HeadAptImages = map[string]string{
 	// Debian images.


### PR DESCRIPTION
Apt-get to downgrade a package when using -y flag needs and additional --allow-downgrades flag

This new test should fail in the current state of the code and https://github.com/GoogleCloudPlatform/osconfig/pull/418 should fix that