### PR TITLE
Fix previous PR: exec.CommandContext cannot be reused

### DIFF
--- a/packages/apt_deb.go
+++ b/packages/apt_deb.go
@@ -215,10 +215,10 @@ func InstallAptPackages(ctx context.Context, pkgs []string) error {
 			cmd.Env = append(os.Environ(), "DEBIAN_FRONTEND=noninteractive")
 		},
 	}
-	stdout, stderr, err := runAptGetWithDowngradeRetrial(ctx, args, cmdModifiers)
+	stdout, stderr, err := runAptGet(ctx, args, cmdModifiers)
 	if err != nil {
 		if dpkgRepair(ctx, stderr) {
-			stdout, stderr, err = runAptGetWithDowngradeRetrial(ctx, args, cmdModifiers)
+			stdout, stderr, err = runAptGet(ctx, args, cmdModifiers)
 		}
 	}
 	if err != nil {
@@ -235,10 +235,10 @@ func RemoveAptPackages(ctx context.Context, pkgs []string) error {
 			cmd.Env = append(os.Environ(), "DEBIAN_FRONTEND=noninteractive")
 		},
 	}
-	stdout, stderr, err := runAptGetWithDowngradeRetrial(ctx, args, cmdModifiers)
+	stdout, stderr, err := runAptGet(ctx, args, cmdModifiers)
 	if err != nil {
 		if dpkgRepair(ctx, stderr) {
-			stdout, stderr, err = runAptGetWithDowngradeRetrial(ctx, args, cmdModifiers)
+			stdout, stderr, err = runAptGet(ctx, args, cmdModifiers)
 		}
 	}
 	if err != nil {
@@ -329,7 +329,7 @@ func AptUpdates(ctx context.Context, opts ...AptGetUpgradeOption) ([]*PkgInfo, e
 
 // AptUpdate runs apt-get update.
 func AptUpdate(ctx context.Context) ([]byte, error) {
-	stdout, _, err := runAptGetWithDowngradeRetrial(ctx, aptGetUpdateArgs, []cmdModifier{})
+	stdout, _, err := runAptGet(ctx, aptGetUpdateArgs, []cmdModifier{})
 	return stdout, err
 }
 

--- a/packages/apt_deb.go
+++ b/packages/apt_deb.go
@@ -215,10 +215,10 @@ func InstallAptPackages(ctx context.Context, pkgs []string) error {
 			cmd.Env = append(os.Environ(), "DEBIAN_FRONTEND=noninteractive")
 		},
 	}
-	stdout, stderr, err := runAptGet(ctx, args, cmdModifiers)
+	stdout, stderr, err := runAptGetWithDowngradeRetrial(ctx, args, cmdModifiers)
 	if err != nil {
 		if dpkgRepair(ctx, stderr) {
-			stdout, stderr, err = runAptGet(ctx, args, cmdModifiers)
+			stdout, stderr, err = runAptGetWithDowngradeRetrial(ctx, args, cmdModifiers)
 		}
 	}
 	if err != nil {

--- a/packages/apt_deb_test.go
+++ b/packages/apt_deb_test.go
@@ -243,7 +243,7 @@ func TestAllowDowngradesLogic(t *testing.T) {
 	stderrBytes := []byte("stderr")
 	mockCommandRunner.EXPECT().Run(testCtx, cmdWithAllowDowngradesFlag).Return(stdoutBytes, stderrBytes, nil).Times(1)
 
-	stdout, stderr, err := runAptGet(testCtx, []string{}, []cmdModifier{})
+	stdout, stderr, err := runAptGetWithDowngradeRetrial(testCtx, []string{}, []cmdModifier{})
 	if err != nil || !reflect.DeepEqual(stderr, stderrBytes) || !reflect.DeepEqual(stdout, stdoutBytes) {
 		t.Errorf("unexpected output: err - %v, stderr - %v, stdout - %v", err, string(stderr), string(stdout))
 	}


### PR DESCRIPTION
Changed logic to recreate exec.CommandContext when retrying with a new flag