### PR TITLE
Add default timeout for pip and gem list commands

### DIFF
--- a/packages/gem.go
+++ b/packages/gem.go
@@ -19,6 +19,7 @@ import (
 	"os/exec"
 	"runtime"
 	"strings"
+	"time"
 
 	"github.com/GoogleCloudPlatform/osconfig/clog"
 	"github.com/GoogleCloudPlatform/osconfig/util"
@@ -29,6 +30,7 @@ var (
 
 	gemListArgs     = []string{"list", "--local"}
 	gemOutdatedArgs = []string{"outdated", "--local"}
+	gemListTimeout  = 15 * time.Second
 )
 
 func init() {
@@ -70,7 +72,7 @@ func GemUpdates(ctx context.Context) ([]*PkgInfo, error) {
 
 // InstalledGemPackages queries for all installed gem packages.
 func InstalledGemPackages(ctx context.Context) ([]*PkgInfo, error) {
-	stdout, _, err := runner.Run(ctx, exec.CommandContext(ctx, gem, gemListArgs...))
+	stdout, err := runWithDeadline(ctx, gemListTimeout, gem, gemListArgs)
 	if err != nil {
 		return nil, err
 	}

--- a/packages/packages.go
+++ b/packages/packages.go
@@ -127,6 +127,12 @@ func run(ctx context.Context, cmd string, args []string) ([]byte, error) {
 	return stdout, nil
 }
 
+func runWithDeadline(ctx context.Context, timeout time.Duration, cmd string, args []string) ([]byte, error) {
+	ctxWithTimeout, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+	return run(ctxWithTimeout, cmd, args)
+}
+
 type ptyRunner struct{}
 
 func (p *ptyRunner) Run(ctx context.Context, cmd *exec.Cmd) ([]byte, []byte, error) {

--- a/packages/pip.go
+++ b/packages/pip.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"encoding/json"
 	"runtime"
+	"time"
 
 	"github.com/GoogleCloudPlatform/osconfig/util"
 )
@@ -27,6 +28,7 @@ var (
 
 	pipListArgs     = []string{"list", "--format=json"}
 	pipOutdatedArgs = append(pipListArgs, "--outdated")
+	pipListTimeout  = 15 * time.Second
 )
 
 func init() {
@@ -68,7 +70,7 @@ func PipUpdates(ctx context.Context) ([]*PkgInfo, error) {
 
 // InstalledPipPackages queries for all installed pip packages.
 func InstalledPipPackages(ctx context.Context) ([]*PkgInfo, error) {
-	out, err := run(ctx, pip, pipListArgs)
+	out, err := runWithDeadline(ctx, pipListTimeout, pip, pipListArgs)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
The pip and gem list commands take a very long time to timeout in case of no internet access. This leads to the agent being stuck for a very long time.
With the default time, the list commands will fail fast.