### PR TITLE
replace /usr/bin/pip with /usr/bin/pip3

### DIFF
--- a/packages/pip.go
+++ b/packages/pip.go
@@ -34,7 +34,7 @@ var (
 
 func init() {
 	if runtime.GOOS != "windows" {
-		pip = "/usr/bin/pip"
+		pip = "/usr/bin/pip3"
 	}
 	PipExists = util.Exists(pip)
 }


### PR DESCRIPTION
Python2 is deprecated now.