### PR TITLE
Fix exclude packages field processing

### DIFF
--- a/agentendpoint/patch_linux_test.go
+++ b/agentendpoint/patch_linux_test.go
@@ -24,23 +24,20 @@ import (
 )
 
 func TestExcludeConversion(t *testing.T) {
-	strictString := "PackageName"
 	regex, _ := regexp.Compile("PackageName")
 	emptyRegex, _ := regexp.Compile("")
-	slashString := "/"
-	emptyString := ""
 
 	tests := []struct {
 		name  string
 		input []string
 		want  []*ospatch.Exclude
 	}{
-		{name: "StrictStringConversion", input: []string{"PackageName"}, want: []*ospatch.Exclude{ospatch.CreateStringExclude(&strictString)}},
+		{name: "StrictStringConversion", input: []string{"PackageName"}, want: CreateStringExcludes("PackageName")},
 		{name: "MultipleStringConversion", input: []string{"PackageName1", "PackageName2"}, want: CreateStringExcludes("PackageName1", "PackageName2")},
 		{name: "RegexConversion", input: []string{"/PackageName/"}, want: []*ospatch.Exclude{ospatch.CreateRegexExclude(regex)}},
 		{name: "CornerCaseRegex", input: []string{"//"}, want: []*ospatch.Exclude{ospatch.CreateRegexExclude(emptyRegex)}},
-		{name: "CornerCaseStrictString", input: []string{"/"}, want: []*ospatch.Exclude{ospatch.CreateStringExclude(&slashString)}},
-		{name: "CornerCaseEmptyString", input: []string{""}, want: []*ospatch.Exclude{ospatch.CreateStringExclude(&emptyString)}},
+		{name: "CornerCaseStrictString", input: []string{"/"}, want: CreateStringExcludes("/")},
+		{name: "CornerCaseEmptyString", input: []string{""}, want: CreateStringExcludes("")},
 	}
 
 	for _, tt := range tests {

--- a/agentendpoint/patch_linux_test.go
+++ b/agentendpoint/patch_linux_test.go
@@ -17,6 +17,7 @@ package agentendpoint
 import (
 	"reflect"
 	"regexp"
+	"strings"
 	"testing"
 
 	"github.com/GoogleCloudPlatform/osconfig/ospatch"
@@ -35,6 +36,7 @@ func TestExcludeConversion(t *testing.T) {
 		want  []*ospatch.Exclude
 	}{
 		{name: "StrictStringConversion", input: []string{"PackageName"}, want: []*ospatch.Exclude{ospatch.CreateStringExclude(&strictString)}},
+		{name: "MultipleStringConversion", input: []string{"PackageName1", "PackageName2"}, want: CreateStringExcludes("PackageName1", "PackageName2")},
 		{name: "RegexConversion", input: []string{"/PackageName/"}, want: []*ospatch.Exclude{ospatch.CreateRegexExclude(regex)}},
 		{name: "CornerCaseRegex", input: []string{"//"}, want: []*ospatch.Exclude{ospatch.CreateRegexExclude(emptyRegex)}},
 		{name: "CornerCaseStrictString", input: []string{"/"}, want: []*ospatch.Exclude{ospatch.CreateStringExclude(&slashString)}},
@@ -48,8 +50,27 @@ func TestExcludeConversion(t *testing.T) {
 				t.Errorf("err = %v, want %v", err, nil)
 			}
 			if !reflect.DeepEqual(excludes, tt.want) {
-				t.Errorf("convertInputToExcludes() = %v, want = %v", excludes, tt.want)
+				t.Errorf("convertInputToExcludes() = %s, want = %s", toString(excludes), toString(tt.want))
 			}
 		})
 	}
+}
+
+func toString(excludes []*ospatch.Exclude) string {
+	results := make([]string, len(excludes))
+	for i, exc := range excludes {
+		results[i] = exc.String()
+	}
+
+	return strings.Join(results, ",")
+}
+
+func CreateStringExcludes(pkgs ...string) []*ospatch.Exclude {
+	excludes := make([]*ospatch.Exclude, len(pkgs))
+	for i := 0; i < len(pkgs); i++ {
+		pkg := pkgs[i]
+		excludes[i] = ospatch.CreateStringExclude(&pkg)
+	}
+
+	return excludes
 }

--- a/ospatch/exclude.go
+++ b/ospatch/exclude.go
@@ -26,8 +26,8 @@ type Exclude struct {
 	strictString *string
 }
 
-func (e Exclude) String() string {
-	return fmt.Sprintf("{isRegexp: %t, regex: %+v, strictString: %s}", e.isRegexp, e.regex, *e.strictString)
+func (exclude Exclude) String() string {
+	return fmt.Sprintf("{isRegexp: %t, regex: %+v, strictString: %s}", exclude.isRegexp, exclude.regex, *exclude.strictString)
 }
 
 // CreateRegexExclude returns new Exclude struct that represents exclusion with regex

--- a/ospatch/exclude.go
+++ b/ospatch/exclude.go
@@ -15,6 +15,7 @@
 package ospatch
 
 import (
+	"fmt"
 	"regexp"
 )
 
@@ -23,6 +24,10 @@ type Exclude struct {
 	isRegexp     bool
 	regex        *regexp.Regexp
 	strictString *string
+}
+
+func (e Exclude) String() string {
+	return fmt.Sprintf("{isRegexp: %t, regex: %+v, strictString: %s}", e.isRegexp, e.regex, *e.strictString)
 }
 
 // CreateRegexExclude returns new Exclude struct that represents exclusion with regex
@@ -35,9 +40,10 @@ func CreateRegexExclude(regex *regexp.Regexp) *Exclude {
 
 // CreateStringExclude returns new Exclude struct that represents exclusion with string
 func CreateStringExclude(strictString *string) *Exclude {
+	strictStringCopied := *strictString //copy the string for safety reason
 	return &Exclude{
 		isRegexp:     false,
-		strictString: strictString,
+		strictString: &strictStringCopied,
 	}
 }
 


### PR DESCRIPTION
In Golang, foreach loop create only one variable per a whole loop.

It is unsafe to pass pointer to the variable, cause after the loop,
all pointers will point to last element in array.

To make code safe by design, function ospatch.CreateStringExclude,
refactored to copy pointer to a string before memorizing it.