### PR TITLE
Revert "Call FQDN"

### DIFF
--- a/agentconfig/agentconfig.go
+++ b/agentconfig/agentconfig.go
@@ -60,7 +60,7 @@ const (
 	aptRepoDir         = "/etc/apt/sources.list.d"
 	aptRepoFilePath    = aptRepoDir + "/google_osconfig_managed.list"
 
-	prodEndpoint = "{zone}-osconfig.googleapis.com.:443"
+	prodEndpoint = "{zone}-osconfig.googleapis.com:443"
 
 	osInventoryEnabledDefault      = false
 	guestPoliciesEnabledDefault    = false

--- a/agentconfig/agentconfig_test.go
+++ b/agentconfig/agentconfig_test.go
@@ -206,7 +206,7 @@ func TestSetConfigDefaultValues(t *testing.T) {
 		t.Errorf("Default poll interval: got(%f) != want(%d)", SvcPollInterval().Minutes(), osConfigPollIntervalDefault)
 	}
 
-	expectedEndpoint := "fake-zone-osconfig.googleapis.com.:443"
+	expectedEndpoint := "fake-zone-osconfig.googleapis.com:443"
 	if SvcEndpoint() != expectedEndpoint {
 		t.Errorf("Default endpoint: got(%s) != want(%s)", SvcEndpoint(), expectedEndpoint)
 	}


### PR DESCRIPTION
Reverts GoogleCloudPlatform/osconfig#454

Reverting PR, as recently found usage of FQDN causing problem with wildcard certificate verification on Windows Server 