### PR TITLE
Set DEBIAN_FRONTEND=noninteractive for apt-get interactions

### DIFF
--- a/config/package_resource_test.go
+++ b/config/package_resource_test.go
@@ -412,6 +412,9 @@ func TestPackageResourceEnforceState(t *testing.T) {
 			aptInstalled,
 			func() []*exec.Cmd {
 				cmd1 := exec.Command("/usr/bin/apt-get", "update")
+				cmd1.Env = append(os.Environ(),
+					"DEBIAN_FRONTEND=noninteractive",
+				)
 				cmd2 := exec.Command("/usr/bin/apt-get", "install", "-y", "foo")
 				cmd2.Env = append(os.Environ(),
 					"DEBIAN_FRONTEND=noninteractive",

--- a/packages/apt_deb.go
+++ b/packages/apt_deb.go
@@ -319,7 +319,11 @@ func AptUpdates(ctx context.Context, opts ...AptGetUpgradeOption) ([]*PkgInfo, e
 		return nil, err
 	}
 
-	out, _, err := runAptGetWithDowngradeRetrial(ctx, args, []cmdModifier{})
+	out, _, err := runAptGetWithDowngradeRetrial(ctx, args, []cmdModifier{
+		func(cmd *exec.Cmd) {
+			cmd.Env = append(os.Environ(), "DEBIAN_FRONTEND=noninteractive")
+		},
+	})
 	if err != nil {
 		return nil, err
 	}
@@ -329,7 +333,11 @@ func AptUpdates(ctx context.Context, opts ...AptGetUpgradeOption) ([]*PkgInfo, e
 
 // AptUpdate runs apt-get update.
 func AptUpdate(ctx context.Context) ([]byte, error) {
-	stdout, _, err := runAptGet(ctx, aptGetUpdateArgs, []cmdModifier{})
+	stdout, _, err := runAptGet(ctx, aptGetUpdateArgs, []cmdModifier{
+		func(cmd *exec.Cmd) {
+			cmd.Env = append(os.Environ(), "DEBIAN_FRONTEND=noninteractive")
+		},
+	})
 	return stdout, err
 }
 

--- a/packages/apt_deb_test.go
+++ b/packages/apt_deb_test.go
@@ -155,8 +155,18 @@ func TestAptUpdates(t *testing.T) {
 
 	mockCommandRunner := utilmocks.NewMockCommandRunner(mockCtrl)
 	runner = mockCommandRunner
-	updateCmd := utilmocks.EqCmd(exec.Command(aptGet, aptGetUpdateArgs...))
-	expectedCmd := utilmocks.EqCmd(exec.Command(aptGet, append(aptGetUpgradableArgs, aptGetUpgradeCmd)...))
+
+	aptUpdateCmd := exec.Command(aptGet, aptGetUpdateArgs...)
+	aptUpdateCmd.Env = append(os.Environ(),
+		"DEBIAN_FRONTEND=noninteractive",
+	)
+	updateCmd := utilmocks.EqCmd(aptUpdateCmd)
+
+	aptUpgradeCmd := exec.Command(aptGet, append(aptGetUpgradableArgs, aptGetUpgradeCmd)...)
+	aptUpgradeCmd.Env = append(os.Environ(),
+		"DEBIAN_FRONTEND=noninteractive",
+	)
+	expectedCmd := utilmocks.EqCmd(aptUpgradeCmd)
 	data := []byte("Inst google-cloud-sdk [245.0.0-0] (246.0.0-0 cloud-sdk-stretch:cloud-sdk-stretch [amd64])")
 
 	first := mockCommandRunner.EXPECT().Run(testCtx, updateCmd).Return(data, []byte("stderr"), nil).Times(1)


### PR DESCRIPTION
Agent doesn't support interactive frontend, apt-get will always use default options in all interactions if DEBIAN_FRONTEND=noninteractive is set.