### PR TITLE
Adding what exit codes mean for OS Config policy

### DIFF
--- a/examples/OSPolicyAssignments/console/README.md
+++ b/examples/OSPolicyAssignments/console/README.md
@@ -1,0 +1,3 @@
+
+### Exit Codes
+An exit code of 100 indicates "in desired state", and exit code of 101 indicates "not in desired state". Any other exit code indicates a failure running validate.

--- a/examples/OSPolicyAssignments/console/win-ensure-openssh.yaml
+++ b/examples/OSPolicyAssignments/console/win-ensure-openssh.yaml
@@ -7,6 +7,10 @@ resourceGroups:
       exec:
         validate:
           interpreter: POWERSHELL
+          # An exit code 100 to indicates that exec resource is already in desired state. 
+          # In this scenario, the `enforce` step will not be run.
+          # Otherwise return an exit code of 101 to indicate that exec resource is not in
+          # desired state. In this scenario, the `enforce` step will be run.
           script: |
             $service = Get-Service -Name 'sshd'
             if ($service.Status -eq 'Running') {exit 100} else {exit 101}

--- a/examples/OSPolicyAssignments/console/win-validation-powershell.yaml
+++ b/examples/OSPolicyAssignments/console/win-validation-powershell.yaml
@@ -5,6 +5,8 @@ resourceGroups:
       exec:
         validate:
           interpreter: POWERSHELL
+          # An exit code 100 to indicates that exec resource is already in desired state. 
+          # An exit code of 101 to indicate that exec resource is not in desired state. 
           script: |
             $service = Get-Service -Name 'WinRM'
             if ($service.Status -eq 'Running') {exit 100} else {exit 101}


### PR DESCRIPTION
OSPolicy examples refer to exit codes but what exit codes 100 and 101 mean is missing on all samples and in Readme.md