### PR TITLE
Added [main] section with gpgcheck to the agent-managed repo file.

### DIFF
--- a/policies/yum.go
+++ b/policies/yum.go
@@ -45,6 +45,8 @@ func yumRepositories(ctx context.Context, repos []*agentendpointpb.YumRepository
 	*/
 	var buf bytes.Buffer
 	buf.WriteString("# Repo file managed by Google OSConfig agent\n")
+	buf.WriteString("[main]\n")
+	buf.WriteString("gpgcheck=1\n")
 	for _, repo := range repos {
 		buf.WriteString(fmt.Sprintf("\n[%s]\n", repo.Id))
 		if repo.DisplayName == "" {

--- a/policies/yum_test.go
+++ b/policies/yum_test.go
@@ -51,13 +51,13 @@ func TestYumRepositories(t *testing.T) {
 		repos []*agentendpointpb.YumRepository
 		want  string
 	}{
-		{"no repos", []*agentendpointpb.YumRepository{}, "# Repo file managed by Google OSConfig agent\n"},
+		{"no repos", []*agentendpointpb.YumRepository{}, "# Repo file managed by Google OSConfig agent\n[main]\ngpgcheck=1\n"},
 		{
 			"1 repo",
 			[]*agentendpointpb.YumRepository{
 				{BaseUrl: "http://repo1-url/", Id: "id"},
 			},
-			"# Repo file managed by Google OSConfig agent\n\n[id]\nname=id\nbaseurl=http://repo1-url/\nenabled=1\ngpgcheck=1\n",
+			"# Repo file managed by Google OSConfig agent\n[main]\ngpgcheck=1\n\n[id]\nname=id\nbaseurl=http://repo1-url/\nenabled=1\ngpgcheck=1\n",
 		},
 		{
 			"2 repos",
@@ -65,7 +65,7 @@ func TestYumRepositories(t *testing.T) {
 				{BaseUrl: "http://repo1-url/", Id: "id1", DisplayName: "displayName1", GpgKeys: []string{"https://url/key"}},
 				{BaseUrl: "http://repo1-url/", Id: "id2", DisplayName: "displayName2", GpgKeys: []string{"https://url/key1", "https://url/key2"}},
 			},
-			"# Repo file managed by Google OSConfig agent\n\n[id1]\nname=displayName1\nbaseurl=http://repo1-url/\nenabled=1\ngpgcheck=1\ngpgkey=https://url/key\n\n[id2]\nname=displayName2\nbaseurl=http://repo1-url/\nenabled=1\ngpgcheck=1\ngpgkey=https://url/key1\n       https://url/key2\n",
+			"# Repo file managed by Google OSConfig agent\n[main]\ngpgcheck=1\n\n[id1]\nname=displayName1\nbaseurl=http://repo1-url/\nenabled=1\ngpgcheck=1\ngpgkey=https://url/key\n\n[id2]\nname=displayName2\nbaseurl=http://repo1-url/\nenabled=1\ngpgcheck=1\ngpgkey=https://url/key1\n       https://url/key2\n",
 		},
 	}
 


### PR DESCRIPTION
This adds a `[main]` section to `google_osconfig_managed.repo` with `gpgcheck=1`.

The purpose is to avoid triggering security scanners that detect `.repo` files without `gpgcheck` enabled, which currently happens when the repo file contains no repositories (the agent does add `gpgcheck` but does so on a per-repository basis).