### PR TITLE
Write inventory to attributes only if enabled

### DIFF
--- a/agentconfig/agentconfig.go
+++ b/agentconfig/agentconfig.go
@@ -130,6 +130,7 @@ type config struct {
 	taskNotificationEnabled bool
 	guestPoliciesEnabled    bool
 	osInventoryEnabled      bool
+	guestAttributesEnabled  bool
 }
 
 func (c *config) parseFeatures(features string, enabled bool) {
@@ -216,6 +217,7 @@ type attributesJSON struct {
 	OSConfigEndpoint      string       `json:"osconfig-endpoint"`
 	OSConfigEnabled       string       `json:"enable-osconfig"`
 	DisabledFeatures      string       `json:"osconfig-disabled-features"`
+	EnableGuestAttributes string       `json:"enable-guest-attributes"`
 }
 
 func createConfigFromMetadata(md metadataJSON) *config {
@@ -332,6 +334,13 @@ func createConfigFromMetadata(md metadataJSON) *config {
 		c.debugEnabled = true
 	case "info":
 		c.debugEnabled = false
+	}
+
+	if md.Project.Attributes.EnableGuestAttributes != "" {
+		c.guestAttributesEnabled = parseBool(md.Project.Attributes.EnableGuestAttributes)
+	}
+	if md.Instance.Attributes.EnableGuestAttributes != "" {
+		c.guestAttributesEnabled = parseBool(md.Instance.Attributes.EnableGuestAttributes)
 	}
 
 	// Flags take precedence over metadata.
@@ -625,6 +634,11 @@ func Name() string {
 // ID is the instance id.
 func ID() string {
 	return getAgentConfig().instanceID
+}
+
+// GuestAttributesEnabled is a boolean flag that signal that guest attributes feature is enabled.
+func GuestAttributesEnabled() bool {
+	return getAgentConfig().guestAttributesEnabled
 }
 
 type idToken struct {

--- a/agentendpoint/inventory.go
+++ b/agentendpoint/inventory.go
@@ -26,9 +26,12 @@ const (
 // ReportInventory writes inventory to guest attributes and reports it to agent endpoint.
 func (c *Client) ReportInventory(ctx context.Context) {
 	state := inventory.Get(ctx)
-	if !agentconfig.DisableInventoryWrite() {
+
+	if agentconfig.GuestAttributesEnabled() && !agentconfig.DisableInventoryWrite() {
+		clog.Infof(ctx, "Writing inventory to guest attributes")
 		write(ctx, state, inventoryURL)
 	}
+
 	c.report(ctx, state)
 }
 


### PR DESCRIPTION
* Add enable-guest-attributes to the config.
* Write inventory to guest attributes only if guest attributes enabled.