### PR TITLE
docs(osconfig):add OS policy example for CIS scanning

### DIFF
--- a/examples/OSPolicyAssignments/CIS/cis-level1-once-a-day-policy.yaml
+++ b/examples/OSPolicyAssignments/CIS/cis-level1-once-a-day-policy.yaml
@@ -1,0 +1,36 @@
+# An OS policy to check CIS level 1 compliance once a day.
+osPolicies:
+- id: ensure-cis-level1-compliance-once-a-day-policy
+  mode: ENFORCEMENT
+  resourceGroups:
+  - resources:
+      id: ensure-cis-level1-compliance-once-a-day
+      exec:
+        validate:
+          interpreter: SHELL
+          # If cis-compliance-scanner.service is active, return an exit code
+          # 100 to indicate that the instance is in compliant state.
+          # Otherwise, return an exit code of 101 to run `enforce` step.
+          script: |-
+            is_active=$(systemctl is-active cis-compliance-scanner.timer)
+            result=$(systemctl show -p Result --value cis-compliance-scanner.service)
+
+            if [ "$is_active" == "active" ] && [ "$result" == "success" ]; then
+              exit 100;
+            else
+              exit 101;
+            fi
+        enforce:
+          interpreter: SHELL
+          # COS 97 images are by-default CIS Level 1 compliant and there is no
+          # additional configuration needed. However, if certain changes
+          # cause non-compliance because of the workload on the instance, this
+          # section can be used to automate to make fixes. For example, the
+          # workload might generate a file that does not comply with the
+          # recommended file permissions.
+          # Return an exit code of 100 to indicate that the desired changes
+          # successfully applied.
+          script: |-
+            # optional <your code>
+            # Check the compliance of the instance once a day.
+            systemctl start cis-compliance-scanner.timer && exit 100


### PR DESCRIPTION
Move examples from the CIS document to the examples folder in git