### PR TITLE
Update feature names in the README file

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,8 @@ This repository contains the OS Config agent and associated end to end tests.
 
 The OS Config agent currently supports the following three main features:
 - [OS inventory management](https://cloud.google.com/compute/docs/instances/os-inventory-management)
-- [OS patch management](https://cloud.google.com/compute/docs/os-patch-management)
-- [OS configuration management](https://cloud.google.com/compute/docs/os-config-management)
+- [Patch](https://cloud.google.com/compute/docs/os-patch-management)
+- [OS policies](https://cloud.google.com/compute/docs/os-config-management)
 
 For instructions on how to install the OS Config agent on a [Compute Engine](https://cloud.google.com/compute) VM instance, see [Installing the OS Config agent](https://cloud.google.com/compute/docs/manage-os#agent-install).
 


### PR DESCRIPTION
Replaced 'OS Patch Management' with 'Patch' and 'OS configuration management' with 'OS policies' per the recent name changes.