### PR TITLE
Fix SUSE pkg-update and pkg-no-update e2e tests

### DIFF
--- a/e2e_tests/test_suites/guestpolicies/guest_policies_test_data.go
+++ b/e2e_tests/test_suites/guestpolicies/guest_policies_test_data.go
@@ -92,6 +92,9 @@ func buildPkgUpdateTestSetup(name, image, pkgManager, key string) *guestPolicyTe
 		packageName = "cowsay"
 		machineType = "e2-standard-4"
 	}
+	if pkgManager == "zypper" {
+		packageName = "cowsay"
+	}
 	instanceName := fmt.Sprintf("%s-%s-%s-%s", path.Base(name), testName, key, utils.RandString(3))
 	gp := &osconfigpb.GuestPolicy{
 		Packages:   osconfigserver.BuildPackagePolicy(nil, nil, []string{packageName}),
@@ -126,6 +129,9 @@ func buildPkgDoesNotUpdateTestSetup(name, image, pkgManager, key string) *guestP
 	if pkgManager == "googet" {
 		packageName = "cowsay"
 		machineType = "e2-standard-4"
+	}
+	if pkgManager == "zypper" {
+		packageName = "cowsay"
 	}
 
 	instanceName := fmt.Sprintf("%s-%s-%s-%s", path.Base(name), testName, key, utils.RandString(3))

--- a/e2e_tests/test_suites/guestpolicies/guest_policies_utils.go
+++ b/e2e_tests/test_suites/guestpolicies/guest_policies_utils.go
@@ -239,22 +239,18 @@ while(1) {
 	case "zypper":
 		ss = `
 echo 'Adding test repo'
-cat > /etc/zypp/repos.d/google-osconfig-agent.repo <<EOM
-[test-repo]
-name=test repo
-baseurl=https://packages.cloud.google.com/yum/repos/osconfig-agent-test-repository
-enabled=1
-gpgcheck=0
-EOM
-zypper -n remove ed
+zypper ar --no-gpgcheck -f "https://packages.cloud.google.com/yum/repos/osconfig-agent-test-repository" "test-repo"
+zypper refresh
+zypper -n remove cowsay
 zypper -n --no-gpg-checks install cowsay-3.03-20.el7
 %[1]s
 %[2]s
 while true; do
-  isinstalled=$(/usr/bin/rpmquery -a ed)
+  isinstalled=$(/usr/bin/rpmquery -a cowsay)
   if [[ $isinstalled =~ 3.03-20.el7 ]]; then
     uri=http://metadata.google.internal/computeMetadata/v1/instance/guest-attributes/%[3]s
   else
+    # For package update tests, the new version after the agent update it should be cowsay-3.04-2.el7.noarch
     uri=http://metadata.google.internal/computeMetadata/v1/instance/guest-attributes/%[4]s
   fi
   curl -X PUT --data "1" $uri -H "Metadata-Flavor: Google"


### PR DESCRIPTION
zypper repo `test-repo` was not reachable when it is added as a `.repo` file in the test VM, and the agent failed to update the package from this repo according to the added policy. However, it works fine with a local VM.

Adding this repo using `zypper addrepo` command + `zypper refresh` after it fixed this issue for the tests.

/assign @dowgird
/cc @paulinakania
/cc @dowgird