### PR TITLE
Initial config of dependabot for the dependency updates scanning

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,20 @@
+version: 2
+updates:
+  - package-ecosystem: gomod
+    directory: "/"
+    labels:
+      - dependencies
+      - go
+    schedule:
+      interval: "daily"
+    allow:
+      - dependency-type: "all"
+reviewers:
+  - burov
+  - dowgird
+  - Gulio
+  - michaljankowiak
+  - paulinakania
+  - ekremenetskii
+  - MahmoudOuka
+  - MarcMarc


### PR DESCRIPTION
Enabling daily scanning of the gomod dependencies (direct and indirect)