### PR TITLE
Using the default reviewer set for PR approvals

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,12 +9,3 @@ updates:
       interval: "daily"
     allow:
       - dependency-type: "all"
-    reviewers:
-      - "burov"
-      - "dowgird"
-      - "ekremenetskii"
-      - "Gulio"
-      - "MahmoudOuka"
-      - "MarcMarc"
-      - "michaljankowiak"
-      - "paulinakania"


### PR DESCRIPTION
Removing the reviewer list to leverage the existing reviewer set