### PR TITLE
Fix for lock location

### DIFF
--- a/agentconfig/agentconfig.go
+++ b/agentconfig/agentconfig.go
@@ -69,6 +69,7 @@ const (
 
 	oldConfigDirLinux = "/etc/osconfig"
 	cacheDirLinux     = "/var/lib/google_osconfig_agent"
+	windowsCacheDir = `Google\OSConfig`
 
 	taskStateFileLinux    = cacheDirLinux + "/osconfig_task.state"
 	oldTaskStateFileLinux = oldConfigDirLinux + "/osconfig_task.state"
@@ -418,12 +419,12 @@ func getMetadata(suffix string) ([]byte, string, error) {
 	return all, resp.Header.Get("Etag"), nil
 }
 
-func getCacheDirWindows() string {
+func GetCacheDirWindows() string {
 	cacheDir, dirErr := os.UserCacheDir()
-	if dirErr == nil {
-		return cacheDir
+	if dirErr != nil {
+		cacheDir = os.TempDir()
 	}
-	return os.TempDir()
+	return filepath.Join(cacheDir, windowsCacheDir)
 }
 
 // WatchConfig looks for changes in metadata keys. Upon receiving successful response,
@@ -705,7 +706,7 @@ func Capabilities() []string {
 // TaskStateFile is the location of the task state file.
 func TaskStateFile() string {
 	if runtime.GOOS == "windows" {
-		return filepath.Join(getCacheDirWindows(), "osconfig_task.state")
+		return filepath.Join(GetCacheDirWindows(), "osconfig_task.state")
 	}
 
 	return taskStateFileLinux
@@ -720,7 +721,7 @@ func OldTaskStateFile() string {
 func RestartFile() string {
 	if runtime.GOOS == "windows" {
 		return filepath.Join(
-			getCacheDirWindows(), "osconfig_agent_restart_required")
+			GetCacheDirWindows(), "osconfig_agent_restart_required")
 	}
 
 	return restartFileLinux
@@ -734,7 +735,7 @@ func OldRestartFile() string {
 // CacheDir is the location of the cache directory.
 func CacheDir() string {
 	if runtime.GOOS == "windows" {
-		return getCacheDirWindows()
+		return GetCacheDirWindows()
 	}
 
 	return cacheDirLinux

--- a/agentconfig/agentconfig.go
+++ b/agentconfig/agentconfig.go
@@ -419,6 +419,7 @@ func getMetadata(suffix string) ([]byte, string, error) {
 	return all, resp.Header.Get("Etag"), nil
 }
 
+// GetCacheDirWindows returns the folder for the temp files location on Windows.
 func GetCacheDirWindows() string {
 	cacheDir, dirErr := os.UserCacheDir()
 	if dirErr != nil {

--- a/agentconfig/agentconfig.go
+++ b/agentconfig/agentconfig.go
@@ -69,7 +69,7 @@ const (
 
 	oldConfigDirLinux = "/etc/osconfig"
 	cacheDirLinux     = "/var/lib/google_osconfig_agent"
-	windowsCacheDir = `Google\OSConfig`
+	windowsCacheDir   = `Google\OSConfig`
 
 	taskStateFileLinux    = cacheDirLinux + "/osconfig_task.state"
 	oldTaskStateFileLinux = oldConfigDirLinux + "/osconfig_task.state"

--- a/main_windows.go
+++ b/main_windows.go
@@ -25,8 +25,8 @@ import (
 	"unsafe"
 
 	"github.com/GoogleCloudPlatform/guest-logging-go/logger"
-	"github.com/GoogleCloudPlatform/osconfig/packages"
 	"github.com/GoogleCloudPlatform/osconfig/agentconfig"
+	"github.com/GoogleCloudPlatform/osconfig/packages"
 	"golang.org/x/sys/windows"
 	"golang.org/x/sys/windows/svc"
 )

--- a/main_windows.go
+++ b/main_windows.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/GoogleCloudPlatform/guest-logging-go/logger"
 	"github.com/GoogleCloudPlatform/osconfig/packages"
+	"github.com/GoogleCloudPlatform/osconfig/agentconfig"
 	"golang.org/x/sys/windows"
 	"golang.org/x/sys/windows/svc"
 )
@@ -76,7 +77,7 @@ func unlockFileEx(hFile uintptr, nNumberOfBytesToLockLow, nNumberOfBytesToLockHi
 }
 
 func obtainLock() {
-	lockFile := `C:\Program Files\Google\OSConfig\lock`
+	lockFile := filepath.Join(agentconfig.GetCacheDirWindows(), "lock")
 
 	err := os.MkdirAll(filepath.Dir(lockFile), 0755)
 	if err != nil && !os.IsExist(err) {


### PR DESCRIPTION
    All files written by osconfig should be placed in AppData directory
    local to the Windows VM.