### PR TITLE
Remove +win from the package file name

### DIFF
--- a/packaging/googet/google-osconfig-agent.goospec
+++ b/packaging/googet/google-osconfig-agent.goospec
@@ -1,6 +1,6 @@
 {
   "name": "google-osconfig-agent",
-  {{$package_version := printf "%s.0+win@1" .version -}}
+  {{$package_version := printf "%s.0@1" .version -}}
   "version": "{{$package_version}}",
   "arch": "x86_64",
   "authors": "Google Inc.",


### PR DESCRIPTION
https://github.com/GoogleCloudPlatform/guest-test-infra/pull/1185

Artifact Registry does not detect the version properly when the googet file is named with "+win".