### PR TITLE
Extract source name and version for dpkg packages.

### DIFF
--- a/packages/apt_deb_test.go
+++ b/packages/apt_deb_test.go
@@ -4,8 +4,7 @@
 //  you may not use this file except in compliance with the License.
 //  You may obtain a copy of the License at
 //
-//      http://www.apache.org/licenses/LICENSE-2.0
-//
+//      http://www.apache.org/licenses/LICENSE-2.0 //
 //  Unless required by applicable law or agreed to in writing, software
 //  distributed under the License is distributed on an "AS IS" BASIS,
 //  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -16,85 +15,532 @@ package packages
 
 import (
 	"errors"
+	"fmt"
 	"os"
 	"os/exec"
 	"reflect"
+	"slices"
 	"testing"
 
 	utilmocks "github.com/GoogleCloudPlatform/osconfig/util/mocks"
 	"github.com/golang/mock/gomock"
 )
 
+type expectedCommand struct {
+	cmd    *exec.Cmd
+	envs   []string
+	stdout []byte
+	stderr []byte
+	err    error
+}
+
 func TestInstallAptPackages(t *testing.T) {
-	mockCtrl := gomock.NewController(t)
-	defer mockCtrl.Finish()
+	tests := []struct {
+		name string
+		pkgs []string
 
-	mockCommandRunner := utilmocks.NewMockCommandRunner(mockCtrl)
-	runner = mockCommandRunner
+		expectedCommandsChain []expectedCommand
+		expectedError         error
+	}{
+		{
+			name: "basic installation",
+			pkgs: []string{"pkg1", "pkg2"},
 
-	expectedCmd := exec.Command(aptGet, append(aptGetInstallArgs, pkgs...)...)
-	expectedCmd.Env = append(os.Environ(),
-		"DEBIAN_FRONTEND=noninteractive",
-	)
+			expectedCommandsChain: []expectedCommand{
+				{
+					cmd:    exec.Command(aptGet, append(aptGetInstallArgs, pkgs...)...),
+					envs:   []string{"DEBIAN_FRONTEND=noninteractive"},
+					stdout: []byte("stdout"),
+					stderr: []byte("stderr"),
+					err:    nil,
+				},
+			},
+			expectedError: nil,
+		},
+		{
+			name: "allow downgrade added if specific error",
+			pkgs: []string{"pkg1", "pkg2"},
 
-	mockCommandRunner.EXPECT().Run(testCtx, utilmocks.EqCmd(expectedCmd)).Return([]byte("stdout"), []byte("stderr"), nil).Times(1)
-	if err := InstallAptPackages(testCtx, pkgs); err != nil {
-		t.Errorf("unexpected error: %v", err)
+			expectedCommandsChain: []expectedCommand{
+				{
+					cmd:    exec.Command(aptGet, append(aptGetInstallArgs, pkgs...)...),
+					envs:   []string{"DEBIAN_FRONTEND=noninteractive"},
+					stdout: []byte("stdout"),
+					stderr: []byte("E: Packages were downgraded and -y was used without --allow-downgrades."),
+					err:    errors.New("unexpected error"),
+				},
+				{
+					cmd:    exec.Command(aptGet, append(append(aptGetInstallArgs, pkgs...), allowDowngradesArg)...),
+					envs:   []string{"DEBIAN_FRONTEND=noninteractive"},
+					stdout: []byte("stdout"),
+					stderr: []byte("stderr"),
+					err:    nil,
+				},
+			},
+			expectedError: nil,
+		},
+		{
+			name: "run dpkg repair on dpkg error",
+			pkgs: []string{"pkg1", "pkg2"},
+
+			expectedCommandsChain: []expectedCommand{
+				{
+					cmd:    exec.Command(aptGet, append(aptGetInstallArgs, pkgs...)...),
+					envs:   []string{"DEBIAN_FRONTEND=noninteractive"},
+					stdout: []byte("stdout"),
+					stderr: dpkgErr,
+					err:    errors.New("unexpected error"),
+				},
+				{
+					cmd:    exec.CommandContext(testCtx, dpkg, dpkgRepairArgs...),
+					envs:   nil,
+					stdout: []byte("stdout"),
+					stderr: []byte("stderr"),
+					err:    nil,
+				},
+				{
+					cmd:    exec.Command(aptGet, append(aptGetInstallArgs, pkgs...)...),
+					envs:   []string{"DEBIAN_FRONTEND=noninteractive"},
+					stdout: []byte("stdout"),
+					stderr: []byte("stderr"),
+					err:    nil,
+				},
+			},
+			expectedError: nil,
+		},
+		{
+			name: "throw an error if non dpkgErr",
+			pkgs: []string{"pkg1", "pkg2"},
+			expectedCommandsChain: []expectedCommand{
+				{
+					cmd:    exec.Command(aptGet, append(slices.Clone(aptGetInstallArgs), pkgs...)...),
+					envs:   []string{"DEBIAN_FRONTEND=noninteractive"},
+					stdout: []byte("stdout"),
+					stderr: []byte("stderr"),
+					err:    errors.New("unexpected error"),
+				},
+			},
+			expectedError: errors.New("error running /usr/bin/apt-get with args" +
+				" [\"install\" \"-y\" \"pkg1\" \"pkg2\"]:" +
+				" unexpected error, stdout: \"stdout\", stderr: \"stderr\""),
+		},
+		{
+			name: "throw an error if any at the end",
+			pkgs: []string{"pkg1", "pkg2"},
+
+			expectedCommandsChain: []expectedCommand{
+				{
+					cmd:    exec.Command(aptGet, append(aptGetInstallArgs, pkgs...)...),
+					envs:   []string{"DEBIAN_FRONTEND=noninteractive"},
+					stdout: []byte("stdout"),
+					stderr: dpkgErr,
+					err:    errors.New("unexpected error"),
+				},
+				{
+					cmd:    exec.CommandContext(testCtx, dpkg, dpkgRepairArgs...),
+					envs:   nil,
+					stdout: []byte("stdout"),
+					stderr: []byte("stderr"),
+					err:    nil,
+				},
+				{
+					cmd:    exec.Command(aptGet, append(aptGetInstallArgs, pkgs...)...),
+					envs:   []string{"DEBIAN_FRONTEND=noninteractive"},
+					stdout: []byte("stdout"),
+					stderr: []byte("stderr"),
+					err:    errors.New("unexpected error"),
+				},
+			},
+			expectedError: errors.New("error running /usr/bin/apt-get with args" +
+				" [\"install\" \"-y\" \"pkg1\" \"pkg2\"]:" +
+				" unexpected error, stdout: \"stdout\", stderr: \"stderr\""),
+		},
 	}
 
-	first := mockCommandRunner.EXPECT().Run(testCtx, utilmocks.EqCmd(expectedCmd)).Return([]byte("stdout"), dpkgErr, errors.New("error")).Times(1)
-	repair := mockCommandRunner.EXPECT().Run(testCtx, utilmocks.EqCmd(exec.Command(dpkg, dpkgRepairArgs...))).After(first).Return([]byte("stdout"), []byte("stderr"), nil).Times(1)
-	mockCommandRunner.EXPECT().Run(testCtx, utilmocks.EqCmd(expectedCmd)).After(repair).Return([]byte("stdout"), []byte("stderr"), errors.New("error")).Times(1)
-	if err := InstallAptPackages(testCtx, pkgs); err == nil {
-		t.Errorf("did not get expected error")
+	for _, tt := range tests {
+		mockCtrl := gomock.NewController(t)
+		defer mockCtrl.Finish()
+
+		mockCommandRunner := utilmocks.NewMockCommandRunner(mockCtrl)
+		runner = mockCommandRunner
+
+		t.Run(tt.name, func(t *testing.T) {
+			setExpectations(mockCommandRunner, tt.expectedCommandsChain)
+
+			err := InstallAptPackages(testCtx, tt.pkgs)
+			if !reflect.DeepEqual(err, tt.expectedError) {
+				t.Errorf("InstallAptPackages: unexpected error, expect %q, got %q", formatError(tt.expectedError), formatError(err))
+			}
+		})
+	}
+}
+
+func TestAptUpdates(t *testing.T) {
+	tests := []struct {
+		name                  string
+		args                  []AptGetUpgradeOption
+		expectedCommandsChain []expectedCommand
+		expectedResult        []*PkgInfo
+		expectedError         error
+	}{
+		{
+			name:                  "UnexpectedUpgradeType",
+			args:                  []AptGetUpgradeOption{AptGetUpgradeType(10)},
+			expectedCommandsChain: nil,
+			expectedResult:        nil,
+			expectedError:         fmt.Errorf("unknown upgrade type: %q", 10),
+		},
+		{
+			name: "apt-get update",
+			args: nil,
+			expectedCommandsChain: []expectedCommand{
+				{
+					cmd:    exec.Command(aptGet, aptGetUpdateArgs...),
+					envs:   []string{"DEBIAN_FRONTEND=noninteractive"},
+					stdout: []byte("stdout"),
+					stderr: []byte("stderr"),
+					err:    errors.New("unexpected error"),
+				},
+			},
+			expectedResult: nil,
+			expectedError:  errors.New("unexpected error"),
+		},
+		{
+			name: "apt-get upgrade fail",
+			args: nil,
+			expectedCommandsChain: []expectedCommand{
+				{
+					cmd:    exec.Command(aptGet, aptGetUpdateArgs...),
+					envs:   []string{"DEBIAN_FRONTEND=noninteractive"},
+					stdout: []byte("stdout"),
+					stderr: []byte(""),
+					err:    nil,
+				},
+				{
+					cmd:    exec.Command(aptGet, append(slices.Clone(aptGetUpgradableArgs), aptGetUpgradeCmd)...),
+					envs:   []string{"DEBIAN_FRONTEND=noninteractive"},
+					stdout: []byte("stdout"),
+					stderr: []byte("stderr"),
+					err:    errors.New("unexpected error"),
+				},
+			},
+			expectedResult: nil,
+			expectedError:  errors.New("unexpected error"),
+		},
+		{
+			name: "Default upgrade type",
+			args: nil,
+			expectedCommandsChain: []expectedCommand{
+				{
+					cmd:    exec.Command(aptGet, aptGetUpdateArgs...),
+					envs:   []string{"DEBIAN_FRONTEND=noninteractive"},
+					stdout: []byte("stdout"),
+					stderr: []byte(""),
+					err:    nil,
+				},
+				{
+					cmd:    exec.Command(aptGet, append(slices.Clone(aptGetUpgradableArgs), aptGetUpgradeCmd)...),
+					envs:   []string{"DEBIAN_FRONTEND=noninteractive"},
+					stdout: []byte("Inst google-cloud-sdk [245.0.0-0] (246.0.0-0 cloud-sdk-stretch:cloud-sdk-stretch [amd64])"),
+					stderr: []byte(""),
+					err:    nil,
+				},
+			},
+			expectedResult: []*PkgInfo{{Name: "google-cloud-sdk", Arch: "x86_64", Version: "246.0.0-0"}},
+			expectedError:  nil,
+		},
+		{
+			name: "Dist upgrade type",
+			args: []AptGetUpgradeOption{AptGetUpgradeType(AptGetDistUpgrade)},
+			expectedCommandsChain: []expectedCommand{
+				{
+					cmd:    exec.Command(aptGet, aptGetUpdateArgs...),
+					envs:   []string{"DEBIAN_FRONTEND=noninteractive"},
+					stdout: []byte("stdout"),
+					stderr: []byte(""),
+					err:    nil,
+				},
+				{
+					cmd:    exec.Command(aptGet, append(slices.Clone(aptGetUpgradableArgs), aptGetDistUpgradeCmd)...),
+					envs:   []string{"DEBIAN_FRONTEND=noninteractive"},
+					stdout: []byte("Inst google-cloud-sdk [245.0.0-0] (246.0.0-0 cloud-sdk-stretch:cloud-sdk-stretch [amd64])"),
+					stderr: []byte(""),
+					err:    nil,
+				},
+			},
+			expectedResult: []*PkgInfo{{Name: "google-cloud-sdk", Arch: "x86_64", Version: "246.0.0-0"}},
+			expectedError:  nil,
+		},
+		{
+			name: "Full upgrade type",
+			args: []AptGetUpgradeOption{AptGetUpgradeType(AptGetFullUpgrade)},
+			expectedCommandsChain: []expectedCommand{
+				{
+					cmd:    exec.Command(aptGet, aptGetUpdateArgs...),
+					envs:   []string{"DEBIAN_FRONTEND=noninteractive"},
+					stdout: []byte("stdout"),
+					stderr: []byte(""),
+					err:    nil,
+				},
+				{
+					cmd:    exec.Command(aptGet, append(slices.Clone(aptGetUpgradableArgs), aptGetFullUpgradeCmd)...),
+					envs:   []string{"DEBIAN_FRONTEND=noninteractive"},
+					stdout: []byte("Inst google-cloud-sdk [245.0.0-0] (246.0.0-0 cloud-sdk-stretch:cloud-sdk-stretch [amd64])"),
+					stderr: []byte(""),
+					err:    nil,
+				},
+			},
+			expectedResult: []*PkgInfo{{Name: "google-cloud-sdk", Arch: "x86_64", Version: "246.0.0-0"}},
+			expectedError:  nil,
+		},
+		{
+			name: "Default upgrade type with showNew equals true",
+			args: []AptGetUpgradeOption{AptGetUpgradeShowNew(true)},
+			expectedCommandsChain: []expectedCommand{
+				{
+					cmd:    exec.Command(aptGet, aptGetUpdateArgs...),
+					envs:   []string{"DEBIAN_FRONTEND=noninteractive"},
+					stdout: []byte("stdout"),
+					stderr: []byte(""),
+					err:    nil,
+				},
+				{
+					cmd:  exec.Command(aptGet, append(slices.Clone(aptGetUpgradableArgs), aptGetUpgradeCmd)...),
+					envs: []string{"DEBIAN_FRONTEND=noninteractive"},
+					stdout: []byte(
+						"Inst google-cloud-sdk [245.0.0-0] (246.0.0-0 cloud-sdk-stretch:cloud-sdk-stretch [amd64])\n" +
+							"Inst firmware-linux-free (3.4 Debian:9.9/stable [all]) []"),
+					stderr: []byte(""),
+					err:    nil,
+				},
+			},
+			expectedResult: []*PkgInfo{
+				{Name: "google-cloud-sdk", Arch: "x86_64", Version: "246.0.0-0"},
+				{Name: "firmware-linux-free", Arch: "all", Version: "3.4"},
+			},
+			expectedError: nil,
+		},
+		{
+			name: "Default upgrade type with showNew equals false",
+			args: []AptGetUpgradeOption{AptGetUpgradeShowNew(false)},
+			expectedCommandsChain: []expectedCommand{
+				{
+					cmd:    exec.Command(aptGet, aptGetUpdateArgs...),
+					envs:   []string{"DEBIAN_FRONTEND=noninteractive"},
+					stdout: []byte("stdout"),
+					stderr: []byte(""),
+					err:    nil,
+				},
+				{
+					cmd:  exec.Command(aptGet, append(slices.Clone(aptGetUpgradableArgs), aptGetUpgradeCmd)...),
+					envs: []string{"DEBIAN_FRONTEND=noninteractive"},
+					stdout: []byte(
+						"Inst google-cloud-sdk [245.0.0-0] (246.0.0-0 cloud-sdk-stretch:cloud-sdk-stretch [amd64])\n" +
+							"Inst firmware-linux-free (3.4 Debian:9.9/stable [all]) []"),
+					stderr: []byte(""),
+					err:    nil,
+				},
+			},
+			expectedResult: []*PkgInfo{
+				{Name: "google-cloud-sdk", Arch: "x86_64", Version: "246.0.0-0"},
+			},
+			expectedError: nil,
+		},
+		{
+			name: "Add --allow-downgrades when specific error provided.",
+			args: nil,
+			expectedCommandsChain: []expectedCommand{
+				{
+					cmd:    exec.Command(aptGet, aptGetUpdateArgs...),
+					envs:   []string{"DEBIAN_FRONTEND=noninteractive"},
+					stdout: []byte("stdout"),
+					stderr: []byte(""),
+					err:    nil,
+				},
+				{
+					cmd:    exec.Command(aptGet, append(slices.Clone(aptGetUpgradableArgs), aptGetUpgradeCmd)...),
+					envs:   []string{"DEBIAN_FRONTEND=noninteractive"},
+					stdout: []byte("stdout"),
+					stderr: []byte("E: Packages were downgraded and -y was used without --allow-downgrades."),
+					err:    errors.New("failure"),
+				},
+				{
+					cmd:    exec.Command(aptGet, append(slices.Clone(aptGetUpgradableArgs), aptGetUpgradeCmd, allowDowngradesArg)...),
+					envs:   []string{"DEBIAN_FRONTEND=noninteractive"},
+					stdout: []byte("Inst google-cloud-sdk [245.0.0-0] (246.0.0-0 cloud-sdk-stretch:cloud-sdk-stretch [amd64])"),
+					stderr: []byte("stderr"),
+					err:    nil,
+				},
+			},
+			expectedResult: []*PkgInfo{
+				{Name: "google-cloud-sdk", Arch: "x86_64", Version: "246.0.0-0"},
+			},
+			expectedError: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		mockCtrl := gomock.NewController(t)
+		defer mockCtrl.Finish()
+
+		mockCommandRunner := utilmocks.NewMockCommandRunner(mockCtrl)
+		runner = mockCommandRunner
+
+		t.Run(tt.name, func(t *testing.T) {
+			setExpectations(mockCommandRunner, tt.expectedCommandsChain)
+
+			pkgs, err := AptUpdates(testCtx, tt.args...)
+			if !reflect.DeepEqual(err, tt.expectedError) {
+				t.Errorf("AptUpdates: unexpected error, expect %q, got %q", formatError(tt.expectedError), formatError(err))
+			}
+
+			if !reflect.DeepEqual(pkgs, tt.expectedResult) {
+				t.Errorf("AptUpdates: unexpected result, expect %v, got %v", pkgs, tt.expectedResult)
+			}
+		})
 	}
 }
 
 func TestRemoveAptPackages(t *testing.T) {
-	mockCtrl := gomock.NewController(t)
-	defer mockCtrl.Finish()
+	tests := []struct {
+		name string
+		pkgs []string
 
-	mockCommandRunner := utilmocks.NewMockCommandRunner(mockCtrl)
-	runner = mockCommandRunner
-	expectedCmd := exec.Command(aptGet, append(aptGetRemoveArgs, pkgs...)...)
-	expectedCmd.Env = append(os.Environ(),
-		"DEBIAN_FRONTEND=noninteractive",
-	)
+		expectedCommandsChain []expectedCommand
+		expectedError         error
+	}{
+		{
+			name: "Successful path",
+			pkgs: []string{"pkg1", "pkg2"},
+			expectedCommandsChain: []expectedCommand{
+				{
+					cmd:    exec.Command(aptGet, append(slices.Clone(aptGetRemoveArgs), pkgs...)...),
+					envs:   []string{"DEBIAN_FRONTEND=noninteractive"},
+					stdout: []byte("stdout"),
+					stderr: []byte("stderr"),
+					err:    nil,
+				},
+			},
+			expectedError: nil,
+		},
+		{
+			name: "Run dpkg repair on dpkg error",
+			pkgs: []string{"pkg1", "pkg2"},
+			expectedCommandsChain: []expectedCommand{
+				{
+					cmd:    exec.Command(aptGet, append(slices.Clone(aptGetRemoveArgs), pkgs...)...),
+					envs:   []string{"DEBIAN_FRONTEND=noninteractive"},
+					stdout: []byte("stdout"),
+					stderr: dpkgErr,
+					err:    errors.New("error"),
+				},
+				{
+					cmd:    exec.CommandContext(testCtx, dpkg, dpkgRepairArgs...),
+					envs:   nil,
+					stdout: []byte("stdout"),
+					stderr: []byte("stderr"),
+					err:    nil,
+				},
+				{
+					cmd:    exec.Command(aptGet, append(slices.Clone(aptGetRemoveArgs), pkgs...)...),
+					envs:   []string{"DEBIAN_FRONTEND=noninteractive"},
+					stdout: []byte("stdout"),
+					stderr: []byte("stderr"),
+					err:    nil,
+				},
+			},
+			expectedError: nil,
+		},
+		{
+			name: "throw an error if non dpkgErr",
+			pkgs: []string{"pkg1", "pkg2"},
+			expectedCommandsChain: []expectedCommand{
+				{
+					cmd:    exec.Command(aptGet, append(slices.Clone(aptGetRemoveArgs), pkgs...)...),
+					envs:   []string{"DEBIAN_FRONTEND=noninteractive"},
+					stdout: []byte("stdout"),
+					stderr: []byte("stderr"),
+					err:    errors.New("unexpected error"),
+				},
+			},
+			expectedError: errors.New("error running /usr/bin/apt-get with args" +
+				" [\"remove\" \"-y\" \"pkg1\" \"pkg2\"]:" +
+				" unexpected error, stdout: \"stdout\", stderr: \"stderr\""),
+		},
+		{
+			name: "throw an error if any at the end",
+			pkgs: []string{"pkg1", "pkg2"},
 
-	mockCommandRunner.EXPECT().Run(testCtx, utilmocks.EqCmd(expectedCmd)).Return([]byte("stdout"), []byte("stderr"), nil).Times(1)
-	if err := RemoveAptPackages(testCtx, pkgs); err != nil {
-		t.Errorf("unexpected error: %v", err)
+			expectedCommandsChain: []expectedCommand{
+				{
+					cmd:    exec.Command(aptGet, append(aptGetRemoveArgs, pkgs...)...),
+					envs:   []string{"DEBIAN_FRONTEND=noninteractive"},
+					stdout: []byte("stdout"),
+					stderr: dpkgErr,
+					err:    errors.New("unexpected error"),
+				},
+				{
+					cmd:    exec.CommandContext(testCtx, dpkg, dpkgRepairArgs...),
+					envs:   nil,
+					stdout: []byte("stdout"),
+					stderr: []byte("stderr"),
+					err:    nil,
+				},
+				{
+					cmd:    exec.Command(aptGet, append(aptGetRemoveArgs, pkgs...)...),
+					envs:   []string{"DEBIAN_FRONTEND=noninteractive"},
+					stdout: []byte("stdout"),
+					stderr: []byte("stderr"),
+					err:    errors.New("unexpected error"),
+				},
+			},
+			expectedError: errors.New("error running /usr/bin/apt-get with args" +
+				" [\"remove\" \"-y\" \"pkg1\" \"pkg2\"]:" +
+				" unexpected error, stdout: \"stdout\", stderr: \"stderr\""),
+		},
+	}
+	for _, tt := range tests {
+		mockCtrl := gomock.NewController(t)
+		defer mockCtrl.Finish()
+
+		mockCommandRunner := utilmocks.NewMockCommandRunner(mockCtrl)
+		runner = mockCommandRunner
+
+		t.Run(tt.name, func(t *testing.T) {
+			setExpectations(mockCommandRunner, tt.expectedCommandsChain)
+
+			err := RemoveAptPackages(testCtx, tt.pkgs)
+			if !reflect.DeepEqual(err, tt.expectedError) {
+				t.Errorf("RemoveAptPackages: unexpected error, expect %q, got %q", formatError(tt.expectedError), formatError(err))
+			}
+		})
 	}
 
-	first := mockCommandRunner.EXPECT().Run(testCtx, utilmocks.EqCmd(expectedCmd)).Return([]byte("stdout"), dpkgErr, errors.New("error")).Times(1)
-	repair := mockCommandRunner.EXPECT().Run(testCtx, utilmocks.EqCmd(exec.Command(dpkg, dpkgRepairArgs...))).After(first).Return([]byte("stdout"), []byte("stderr"), nil).Times(1)
-	mockCommandRunner.EXPECT().Run(testCtx, utilmocks.EqCmd(expectedCmd)).After(repair).Return([]byte("stdout"), []byte("stderr"), errors.New("error")).Times(1)
-	if err := RemoveAptPackages(testCtx, pkgs); err == nil {
-		t.Errorf("did not get expected error")
-	}
 }
 
 func TestInstalledDebPackages(t *testing.T) {
 	mockCtrl := gomock.NewController(t)
 	defer mockCtrl.Finish()
-
 	mockCommandRunner := utilmocks.NewMockCommandRunner(mockCtrl)
 	runner = mockCommandRunner
-	expectedCmd := utilmocks.EqCmd(exec.Command(dpkgQuery, dpkgQueryArgs...))
-	data := []byte("foo amd64 1.2.3-4 installed")
 
-	mockCommandRunner.EXPECT().Run(testCtx, expectedCmd).Return(data, []byte("stderr"), nil).Times(1)
-	ret, err := InstalledDebPackages(testCtx)
+	//Successfully returns result
+	dpkgQueryCmd := utilmocks.EqCmd(exec.Command(dpkgQuery, dpkgQueryArgs...))
+	stdout, stderr := []byte("foo amd64 1.2.3-4 installed"), []byte("stderr")
+	mockCommandRunner.EXPECT().Run(testCtx, dpkgQueryCmd).Return(stdout, stderr, nil).Times(1)
+
+	result, err := InstalledDebPackages(testCtx)
 	if err != nil {
-		t.Errorf("unexpected error: %v", err)
+		t.Errorf("InstalledDebPackages(): got unexpected error: %v", err)
 	}
 
 	want := []*PkgInfo{{Name: "foo", Arch: "x86_64", Version: "1.2.3-4"}}
-	if !reflect.DeepEqual(ret, want) {
-		t.Errorf("InstalledDebPackages() = %v, want %v", ret, want)
+	if !reflect.DeepEqual(result, want) {
+		t.Errorf("InstalledDebPackages() = %v, want %v", result, want)
 	}
 
-	mockCommandRunner.EXPECT().Run(testCtx, expectedCmd).Return(data, []byte("stderr"), errors.New("error")).Times(1)
+	//Returns error if any
+	mockCommandRunner.EXPECT().Run(testCtx, dpkgQueryCmd).Return(stdout, stderr, errors.New("error")).Times(1)
 	if _, err := InstalledDebPackages(testCtx); err == nil {
 		t.Errorf("did not get expected error")
 	}
@@ -102,18 +548,35 @@ func TestInstalledDebPackages(t *testing.T) {
 
 func TestParseInstalledDebpackages(t *testing.T) {
 	tests := []struct {
-		name string
-		data []byte
-		want []*PkgInfo
+		name  string
+		input []byte
+		want  []*PkgInfo
 	}{
-		{"NormalCase", []byte("foo amd64 1.2.3-4 installed\nbar noarch 1.2.3-4 installed\nbaz noarch 1.2.3-4 config-files"), []*PkgInfo{{Name: "foo", Arch: "x86_64", Version: "1.2.3-4"}, {Name: "bar", Arch: "all", Version: "1.2.3-4"}}},
-		{"NoPackages", []byte("nothing here"), nil},
-		{"nil", nil, nil},
-		{"UnrecognizedPackage", []byte("something we dont understand\n bar noarch 1.2.3-4 installed"), []*PkgInfo{{Name: "bar", Arch: "all", Version: "1.2.3-4"}}},
+		{
+			name:  "Two valid packages in input",
+			input: []byte("foo amd64 1.2.3-4 installed\nbar noarch 1.2.3-4 installed\nbaz noarch 1.2.3-4 config-files"),
+			want:  []*PkgInfo{{Name: "foo", Arch: "x86_64", Version: "1.2.3-4"}, {Name: "bar", Arch: "all", Version: "1.2.3-4"}},
+		},
+		{
+			name:  "No lines formatted as a package info",
+			input: []byte("nothing here"),
+			want:  nil,
+		},
+		{
+			name:  "Nil as input does not panic",
+			input: nil,
+			want:  nil,
+		},
+		{
+			name:  "Skip wrongly formatted lines",
+			input: []byte("something we dont understand\n bar noarch 1.2.3-4 installed"),
+			want:  []*PkgInfo{{Name: "bar", Arch: "all", Version: "1.2.3-4"}},
+		},
 	}
+
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := parseInstalledDebpackages(tt.data); !reflect.DeepEqual(got, tt.want) {
+			if got := parseInstalledDebpackages(tt.input); !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("parseInstalledDebpackages() = %v, want %v", got, tt.want)
 			}
 		})
@@ -130,61 +593,56 @@ Conf firmware-linux-free (3.4 Debian:9.9/stable [all])
 
 	tests := []struct {
 		name    string
-		data    []byte
+		input   []byte
 		showNew bool
 		want    []*PkgInfo
 	}{
-		{"NormalCase", []byte(normalCase), false, []*PkgInfo{{Name: "libldap-common", Arch: "all", Version: "2.4.45+dfsg-1ubuntu1.3"}, {Name: "google-cloud-sdk", Arch: "x86_64", Version: "246.0.0-0"}}},
-		{"NormalCaseShowNew", []byte(normalCase), true, []*PkgInfo{{Name: "libldap-common", Arch: "all", Version: "2.4.45+dfsg-1ubuntu1.3"}, {Name: "google-cloud-sdk", Arch: "x86_64", Version: "246.0.0-0"}, {Name: "firmware-linux-free", Arch: "all", Version: "3.4"}}},
-		{"NoPackages", []byte("nothing here"), false, nil},
-		{"nil", nil, false, nil},
-		{"UnrecognizedPackage", []byte("Inst something [we dont understand\n Inst google-cloud-sdk [245.0.0-0] (246.0.0-0 cloud-sdk-stretch:cloud-sdk-stretch [amd64])"), false, []*PkgInfo{{Name: "google-cloud-sdk", Arch: "x86_64", Version: "246.0.0-0"}}},
+		{
+			name:    "Set of packages with new, show new - false",
+			input:   []byte(normalCase),
+			showNew: false,
+			want: []*PkgInfo{
+				{Name: "libldap-common", Arch: "all", Version: "2.4.45+dfsg-1ubuntu1.3"},
+				{Name: "google-cloud-sdk", Arch: "x86_64", Version: "246.0.0-0"},
+			},
+		},
+		{
+			name:    "Set of packages with new, show new - true",
+			input:   []byte(normalCase),
+			showNew: true,
+			want: []*PkgInfo{
+				{Name: "libldap-common", Arch: "all", Version: "2.4.45+dfsg-1ubuntu1.3"},
+				{Name: "google-cloud-sdk", Arch: "x86_64", Version: "246.0.0-0"},
+				{Name: "firmware-linux-free", Arch: "all", Version: "3.4"},
+			},
+		},
+		{
+			name:    "No lines formatted as a package info",
+			input:   []byte("nothing here"),
+			showNew: false,
+			want:    nil,
+		},
+		{
+			name:    "Nil as input does not panic",
+			input:   nil,
+			showNew: false,
+			want:    nil,
+		},
+		{
+			name:    "Skip wrongly formatted lines",
+			input:   []byte("Inst something [we dont understand\n Inst google-cloud-sdk [245.0.0-0] (246.0.0-0 cloud-sdk-stretch:cloud-sdk-stretch [amd64])"),
+			showNew: false,
+			want: []*PkgInfo{
+				{Name: "google-cloud-sdk", Arch: "x86_64", Version: "246.0.0-0"},
+			},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := parseAptUpdates(testCtx, tt.data, tt.showNew); !reflect.DeepEqual(got, tt.want) {
+			if got := parseAptUpdates(testCtx, tt.input, tt.showNew); !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("parseAptUpdates() = %v, want %v", got, tt.want)
 			}
 		})
-	}
-}
-
-func TestAptUpdates(t *testing.T) {
-	mockCtrl := gomock.NewController(t)
-	defer mockCtrl.Finish()
-
-	mockCommandRunner := utilmocks.NewMockCommandRunner(mockCtrl)
-	runner = mockCommandRunner
-
-	aptUpdateCmd := exec.Command(aptGet, aptGetUpdateArgs...)
-	aptUpdateCmd.Env = append(os.Environ(),
-		"DEBIAN_FRONTEND=noninteractive",
-	)
-	updateCmd := utilmocks.EqCmd(aptUpdateCmd)
-
-	aptUpgradeCmd := exec.Command(aptGet, append(aptGetUpgradableArgs, aptGetUpgradeCmd)...)
-	aptUpgradeCmd.Env = append(os.Environ(),
-		"DEBIAN_FRONTEND=noninteractive",
-	)
-	expectedCmd := utilmocks.EqCmd(aptUpgradeCmd)
-	data := []byte("Inst google-cloud-sdk [245.0.0-0] (246.0.0-0 cloud-sdk-stretch:cloud-sdk-stretch [amd64])")
-
-	first := mockCommandRunner.EXPECT().Run(testCtx, updateCmd).Return(data, []byte("stderr"), nil).Times(1)
-	mockCommandRunner.EXPECT().Run(testCtx, expectedCmd).After(first).Return(data, []byte("stderr"), nil).Times(1)
-	ret, err := AptUpdates(testCtx)
-	if err != nil {
-		t.Errorf("unexpected error: %v", err)
-	}
-
-	want := []*PkgInfo{{Name: "google-cloud-sdk", Arch: "x86_64", Version: "246.0.0-0"}}
-	if !reflect.DeepEqual(ret, want) {
-		t.Errorf("AptUpdates() = %v, want %v", ret, want)
-	}
-
-	first = mockCommandRunner.EXPECT().Run(testCtx, updateCmd).Return(data, []byte("stderr"), nil).Times(1)
-	mockCommandRunner.EXPECT().Run(testCtx, expectedCmd).After(first).Return(data, []byte("stderr"), errors.New("error")).Times(1)
-	if _, err := AptUpdates(testCtx); err == nil {
-		t.Errorf("did not get expected error")
 	}
 }
 
@@ -194,6 +652,7 @@ func TestDebPkgInfo(t *testing.T) {
 
 	mockCommandRunner := utilmocks.NewMockCommandRunner(mockCtrl)
 	runner = mockCommandRunner
+
 	testPkg := "test.deb"
 	expectedCmd := utilmocks.EqCmd(exec.Command(dpkgDeb, "-I", testPkg))
 	out := []byte(`new Debian package, version 2.0.
@@ -238,22 +697,101 @@ func TestDebPkgInfo(t *testing.T) {
 	}
 }
 
-func TestAllowDowngradesLogic(t *testing.T) {
+func Test_dpkgRepair(t *testing.T) {
+
+	tests := []struct {
+		name        string
+		input       []byte
+		expected    bool
+		expectedCmd *exec.Cmd
+	}{
+		{
+			name:        "NonDpkgError",
+			input:       []byte("some random error"),
+			expected:    false,
+			expectedCmd: nil,
+		},
+		{
+			name:        "DpkgError",
+			input:       dpkgErr,
+			expected:    true,
+			expectedCmd: exec.CommandContext(testCtx, dpkg, dpkgRepairArgs...),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mockCtrl := gomock.NewController(t)
+			defer mockCtrl.Finish()
+
+			mockCommandRunner := utilmocks.NewMockCommandRunner(mockCtrl)
+			runner = mockCommandRunner
+
+			if tt.expectedCmd != nil {
+				mockCommandRunner.EXPECT().Run(testCtx, utilmocks.EqCmd(tt.expectedCmd)).Return([]byte("output"), []byte(""), nil).Times(1)
+
+			}
+
+			if result := dpkgRepair(testCtx, tt.input); result != tt.expected {
+				t.Errorf("unexpected result of dpkgRepair, expected %t, got %t", tt.expected, result)
+			}
+		})
+	}
+}
+
+func TestDpkgInstall(t *testing.T) {
 	mockCtrl := gomock.NewController(t)
 	defer mockCtrl.Finish()
 
 	mockCommandRunner := utilmocks.NewMockCommandRunner(mockCtrl)
 	runner = mockCommandRunner
-	cmdWithoutAllowDowngradesFlag := utilmocks.EqCmd(exec.Command(aptGet, []string{}...))
-	cmdWithAllowDowngradesFlag := utilmocks.EqCmd(exec.Command(aptGet, []string{"--allow-downgrades"}...))
 
-	mockCommandRunner.EXPECT().Run(testCtx, cmdWithoutAllowDowngradesFlag).Return([]byte(""), []byte("E: Packages were downgraded and -y was used without --allow-downgrades.\n"), errors.New("error")).Times(1)
-	stdoutBytes := []byte("stdout")
-	stderrBytes := []byte("stderr")
-	mockCommandRunner.EXPECT().Run(testCtx, cmdWithAllowDowngradesFlag).Return(stdoutBytes, stderrBytes, nil).Times(1)
+	path := "/tmp/test.dpkg"
+	dpkgInstallCmd := exec.CommandContext(testCtx, dpkg, append(dpkgInstallArgs, path)...)
 
-	stdout, stderr, err := runAptGetWithDowngradeRetrial(testCtx, []string{}, []cmdModifier{})
-	if err != nil || !reflect.DeepEqual(stderr, stderrBytes) || !reflect.DeepEqual(stdout, stdoutBytes) {
-		t.Errorf("unexpected output: err - %v, stderr - %v, stdout - %v", err, string(stderr), string(stdout))
+	//Dpkg install fail
+	wantErr := errors.New("unexpected error")
+	mockCommandRunner.EXPECT().Run(testCtx, utilmocks.EqCmd(dpkgInstallCmd)).Return([]byte("stdout"), []byte("stderr"), wantErr).Times(1)
+	if err := DpkgInstall(testCtx, path); err == nil {
+		t.Errorf("DpkgInstall: expected error %q, but got <nil>", formatError(wantErr))
 	}
+
+	//Dpkg install succeeded
+	mockCommandRunner.EXPECT().Run(testCtx, utilmocks.EqCmd(dpkgInstallCmd)).Return([]byte("stdout"), []byte("stderr"), nil).Times(1)
+	if err := DpkgInstall(testCtx, path); err != nil {
+		t.Errorf("DpkgInstall: got unexpected error %q", err)
+	}
+}
+
+func setExpectations(mockCommandRunner *utilmocks.MockCommandRunner, expectedCommandsChain []expectedCommand) {
+	if len(expectedCommandsChain) == 0 {
+		return
+	}
+
+	var prev *gomock.Call
+	for _, expectedCmd := range expectedCommandsChain {
+		cmd := expectedCmd.cmd
+		if len(expectedCmd.envs) > 0 {
+			cmd.Env = append(os.Environ(), expectedCmd.envs...)
+		}
+
+		if prev == nil {
+			prev = mockCommandRunner.EXPECT().
+				Run(testCtx, utilmocks.EqCmd(cmd)).
+				Return(expectedCmd.stdout, expectedCmd.stderr, expectedCmd.err).Times(1)
+		} else {
+			prev = mockCommandRunner.EXPECT().
+				Run(testCtx, utilmocks.EqCmd(cmd)).
+				After(prev).
+				Return(expectedCmd.stdout, expectedCmd.stderr, expectedCmd.err).Times(1)
+		}
+	}
+}
+
+func formatError(err error) string {
+	if err == nil {
+		return "<nil>"
+	}
+
+	return err.Error()
 }

--- a/packages/apt_deb_test.go
+++ b/packages/apt_deb_test.go
@@ -89,7 +89,7 @@ func TestInstalledDebPackages(t *testing.T) {
 		t.Errorf("unexpected error: %v", err)
 	}
 
-	want := []*PkgInfo{{"foo", "x86_64", "1.2.3-4"}}
+	want := []*PkgInfo{{Name: "foo", Arch: "x86_64", Version: "1.2.3-4"}}
 	if !reflect.DeepEqual(ret, want) {
 		t.Errorf("InstalledDebPackages() = %v, want %v", ret, want)
 	}
@@ -106,10 +106,10 @@ func TestParseInstalledDebpackages(t *testing.T) {
 		data []byte
 		want []*PkgInfo
 	}{
-		{"NormalCase", []byte("foo amd64 1.2.3-4 installed\nbar noarch 1.2.3-4 installed\nbaz noarch 1.2.3-4 config-files"), []*PkgInfo{{"foo", "x86_64", "1.2.3-4"}, {"bar", "all", "1.2.3-4"}}},
+		{"NormalCase", []byte("foo amd64 1.2.3-4 installed\nbar noarch 1.2.3-4 installed\nbaz noarch 1.2.3-4 config-files"), []*PkgInfo{{Name: "foo", Arch: "x86_64", Version: "1.2.3-4"}, {Name: "bar", Arch: "all", Version: "1.2.3-4"}}},
 		{"NoPackages", []byte("nothing here"), nil},
 		{"nil", nil, nil},
-		{"UnrecognizedPackage", []byte("something we dont understand\n bar noarch 1.2.3-4 installed"), []*PkgInfo{{"bar", "all", "1.2.3-4"}}},
+		{"UnrecognizedPackage", []byte("something we dont understand\n bar noarch 1.2.3-4 installed"), []*PkgInfo{{Name: "bar", Arch: "all", Version: "1.2.3-4"}}},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -134,11 +134,11 @@ Conf firmware-linux-free (3.4 Debian:9.9/stable [all])
 		showNew bool
 		want    []*PkgInfo
 	}{
-		{"NormalCase", []byte(normalCase), false, []*PkgInfo{{"libldap-common", "all", "2.4.45+dfsg-1ubuntu1.3"}, {"google-cloud-sdk", "x86_64", "246.0.0-0"}}},
-		{"NormalCaseShowNew", []byte(normalCase), true, []*PkgInfo{{"libldap-common", "all", "2.4.45+dfsg-1ubuntu1.3"}, {"google-cloud-sdk", "x86_64", "246.0.0-0"}, {"firmware-linux-free", "all", "3.4"}}},
+		{"NormalCase", []byte(normalCase), false, []*PkgInfo{{Name: "libldap-common", Arch: "all", Version: "2.4.45+dfsg-1ubuntu1.3"}, {Name: "google-cloud-sdk", Arch: "x86_64", Version: "246.0.0-0"}}},
+		{"NormalCaseShowNew", []byte(normalCase), true, []*PkgInfo{{Name: "libldap-common", Arch: "all", Version: "2.4.45+dfsg-1ubuntu1.3"}, {Name: "google-cloud-sdk", Arch: "x86_64", Version: "246.0.0-0"}, {Name: "firmware-linux-free", Arch: "all", Version: "3.4"}}},
 		{"NoPackages", []byte("nothing here"), false, nil},
 		{"nil", nil, false, nil},
-		{"UnrecognizedPackage", []byte("Inst something [we dont understand\n Inst google-cloud-sdk [245.0.0-0] (246.0.0-0 cloud-sdk-stretch:cloud-sdk-stretch [amd64])"), false, []*PkgInfo{{"google-cloud-sdk", "x86_64", "246.0.0-0"}}},
+		{"UnrecognizedPackage", []byte("Inst something [we dont understand\n Inst google-cloud-sdk [245.0.0-0] (246.0.0-0 cloud-sdk-stretch:cloud-sdk-stretch [amd64])"), false, []*PkgInfo{{Name: "google-cloud-sdk", Arch: "x86_64", Version: "246.0.0-0"}}},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -176,7 +176,7 @@ func TestAptUpdates(t *testing.T) {
 		t.Errorf("unexpected error: %v", err)
 	}
 
-	want := []*PkgInfo{{"google-cloud-sdk", "x86_64", "246.0.0-0"}}
+	want := []*PkgInfo{{Name: "google-cloud-sdk", Arch: "x86_64", Version: "246.0.0-0"}}
 	if !reflect.DeepEqual(ret, want) {
 		t.Errorf("AptUpdates() = %v, want %v", ret, want)
 	}
@@ -221,7 +221,7 @@ func TestDebPkgInfo(t *testing.T) {
 		t.Errorf("unexpected error: %v", err)
 	}
 
-	want := &PkgInfo{"google-guest-agent", "x86_64", "1:1dummy-g1"}
+	want := &PkgInfo{Name: "google-guest-agent", Arch: "x86_64", Version: "1:1dummy-g1"}
 	if !reflect.DeepEqual(ret, want) {
 		t.Errorf("DebPkgInfo() = %+v, want %+v", ret, want)
 	}

--- a/packages/cos_test.go
+++ b/packages/cos_test.go
@@ -41,9 +41,9 @@ func TestParseInstalledCOSPackages(t *testing.T) {
 	}
 
 	pkg0 := cos.Package{Category: "dev-util", Name: "foo-x", Version: "1.2.3", EbuildVersion: "someversion"}
-	expect0 := &PkgInfo{"dev-util/foo-x", "x86_64", "1.2.3"}
+	expect0 := &PkgInfo{Name: "dev-util/foo-x", Arch: "x86_64", Version: "1.2.3"}
 	pkg1 := cos.Package{Category: "app-admin", Name: "bar", Version: "0.1"}
-	expect1 := &PkgInfo{"app-admin/bar", "x86_64", "0.1"}
+	expect1 := &PkgInfo{Name: "app-admin/bar", Arch: "x86_64", Version: "0.1"}
 
 	pkgInfo := &cos.PackageInfo{InstalledPackages: []cos.Package{pkg0, pkg1}}
 	parsed, err := parseInstalledCOSPackages(pkgInfo)
@@ -145,19 +145,19 @@ func TestInstalledCOSPackages(t *testing.T) {
 	}
 
 	expected := []*PkgInfo{
-		{"app-arch/gzip", "x86_64", "1.9"},
-		{"dev-libs/popt", "x86_64", "1.16"},
-		{"app-emulation/docker-credential-helpers", "x86_64", "0.6.3"},
-		{"_not.real-category1+/_not-real_package1", "x86_64", "12.34.56.78"},
-		{"_not.real-category1+/_not-real_package2", "x86_64", "12.34.56.78"},
-		{"_not.real-category1+/_not-real_package3", "x86_64", "12.34.56.78_rc3"},
-		{"_not.real-category1+/_not-real_package4", "x86_64", "12.34.56.78_rc3"},
-		{"_not.real-category1+/_not-real_package5", "x86_64", "12.34.56.78_pre2_rc3"},
-		{"_not.real-category2+/_not-real_package1", "x86_64", "12.34.56.78q"},
-		{"_not.real-category2+/_not-real_package2", "x86_64", "12.34.56.78q"},
-		{"_not.real-category2+/_not-real_package3", "x86_64", "12.34.56.78q_rc3"},
-		{"_not.real-category2+/_not-real_package4", "x86_64", "12.34.56.78q_rc3"},
-		{"_not.real-category2+/_not-real_package5", "x86_64", "12.34.56.78q_pre2_rc3"},
+		{Name: "app-arch/gzip", Arch: "x86_64", Version: "1.9"},
+		{Name: "dev-libs/popt", Arch: "x86_64", Version: "1.16"},
+		{Name: "app-emulation/docker-credential-helpers", Arch: "x86_64", Version: "0.6.3"},
+		{Name: "_not.real-category1+/_not-real_package1", Arch: "x86_64", Version: "12.34.56.78"},
+		{Name: "_not.real-category1+/_not-real_package2", Arch: "x86_64", Version: "12.34.56.78"},
+		{Name: "_not.real-category1+/_not-real_package3", Arch: "x86_64", Version: "12.34.56.78_rc3"},
+		{Name: "_not.real-category1+/_not-real_package4", Arch: "x86_64", Version: "12.34.56.78_rc3"},
+		{Name: "_not.real-category1+/_not-real_package5", Arch: "x86_64", Version: "12.34.56.78_pre2_rc3"},
+		{Name: "_not.real-category2+/_not-real_package1", Arch: "x86_64", Version: "12.34.56.78q"},
+		{Name: "_not.real-category2+/_not-real_package2", Arch: "x86_64", Version: "12.34.56.78q"},
+		{Name: "_not.real-category2+/_not-real_package3", Arch: "x86_64", Version: "12.34.56.78q_rc3"},
+		{Name: "_not.real-category2+/_not-real_package4", Arch: "x86_64", Version: "12.34.56.78q_rc3"},
+		{Name: "_not.real-category2+/_not-real_package5", Arch: "x86_64", Version: "12.34.56.78q_pre2_rc3"},
 	}
 
 	readMachineArch = func() (string, error) {

--- a/packages/googet_test.go
+++ b/packages/googet_test.go
@@ -68,10 +68,10 @@ func TestParseInstalledGooGetPackages(t *testing.T) {
 		data []byte
 		want []*PkgInfo
 	}{
-		{"NormalCase", []byte(" Installed Packages:\nfoo.x86_64 1.2.3@4\nbar.noarch 1.2.3@4"), []*PkgInfo{{"foo", "x86_64", "1.2.3@4"}, {"bar", "noarch", "1.2.3@4"}}},
+		{"NormalCase", []byte(" Installed Packages:\nfoo.x86_64 1.2.3@4\nbar.noarch 1.2.3@4"), []*PkgInfo{{Name: "foo", Arch: "x86_64", Version: "1.2.3@4"}, {Name: "bar", Arch: "noarch", Version: "1.2.3@4"}}},
 		{"NoPackages", []byte("nothing here"), nil},
 		{"nil", nil, nil},
-		{"UnrecognizedPackage", []byte("Inst something we dont understand\n foo.x86_64 1.2.3@4"), []*PkgInfo{{"foo", "x86_64", "1.2.3@4"}}},
+		{"UnrecognizedPackage", []byte("Inst something we dont understand\n foo.x86_64 1.2.3@4"), []*PkgInfo{{Name: "foo", Arch: "x86_64", Version: "1.2.3@4"}}},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -96,7 +96,7 @@ func TestInstalledGooGetPackages(t *testing.T) {
 		t.Errorf("unexpected error: %v", err)
 	}
 
-	want := []*PkgInfo{{"foo", "x86_64", "1.2.3@4"}}
+	want := []*PkgInfo{{Name: "foo", Arch: "x86_64", Version: "1.2.3@4"}}
 	if !reflect.DeepEqual(ret, want) {
 		t.Errorf("InstalledGooGetPackages() = %v, want %v", ret, want)
 	}
@@ -113,10 +113,10 @@ func TestParseGooGetUpdates(t *testing.T) {
 		data []byte
 		want []*PkgInfo
 	}{
-		{"NormalCase", []byte("Searching for available updates...\nfoo.noarch, 3.5.4@1 --> 3.6.7@1 from repo\nbar.x86_64, 1.0.0@1 --> 2.0.0@1 from repo\nPerform update? (y/N):"), []*PkgInfo{{"foo", "noarch", "3.6.7@1"}, {"bar", "x86_64", "2.0.0@1"}}},
+		{"NormalCase", []byte("Searching for available updates...\nfoo.noarch, 3.5.4@1 --> 3.6.7@1 from repo\nbar.x86_64, 1.0.0@1 --> 2.0.0@1 from repo\nPerform update? (y/N):"), []*PkgInfo{{Name: "foo", Arch: "noarch", Version: "3.6.7@1"}, {Name: "bar", Arch: "x86_64", Version: "2.0.0@1"}}},
 		{"NoPackages", []byte("nothing here"), nil},
 		{"nil", nil, nil},
-		{"UnrecognizedPackage", []byte("Inst something we dont understand\n foo.noarch, 3.5.4@1 --> 3.6.7@1 from repo"), []*PkgInfo{{"foo", "noarch", "3.6.7@1"}}},
+		{"UnrecognizedPackage", []byte("Inst something we dont understand\n foo.noarch, 3.5.4@1 --> 3.6.7@1 from repo"), []*PkgInfo{{Name: "foo", Arch: "noarch", Version: "3.6.7@1"}}},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -141,7 +141,7 @@ func TestGooGetUpdates(t *testing.T) {
 		t.Errorf("unexpected error: %v", err)
 	}
 
-	want := []*PkgInfo{{"foo", "noarch", "3.6.7@1"}}
+	want := []*PkgInfo{{Name: "foo", Arch: "noarch", Version: "3.6.7@1"}}
 	if !reflect.DeepEqual(ret, want) {
 		t.Errorf("GooGetUpdates() = %v, want %v", ret, want)
 	}

--- a/packages/packages.go
+++ b/packages/packages.go
@@ -80,6 +80,13 @@ type Packages struct {
 // PkgInfo describes a package.
 type PkgInfo struct {
 	Name, Arch, Version string
+
+	Source Source
+}
+
+// Source represents source package from which binary package was built.
+type Source struct {
+	Name, Version string
 }
 
 func (i *PkgInfo) String() string {

--- a/packages/rpm_test.go
+++ b/packages/rpm_test.go
@@ -30,10 +30,10 @@ func TestParseInstalledRPMPackages(t *testing.T) {
 		data []byte
 		want []*PkgInfo
 	}{
-		{"NormalCase", []byte("foo x86_64 1.2.3-4\nbar noarch 1.2.3-4"), []*PkgInfo{{"foo", "x86_64", "1.2.3-4"}, {"bar", "all", "1.2.3-4"}}},
+		{"NormalCase", []byte("foo x86_64 1.2.3-4\nbar noarch 1.2.3-4"), []*PkgInfo{{Name: "foo", Arch: "x86_64", Version: "1.2.3-4"}, {Name: "bar", Arch: "all", Version: "1.2.3-4"}}},
 		{"NoPackages", []byte("nothing here"), nil},
 		{"nil", nil, nil},
-		{"UnrecognizedPackage", []byte("foo.x86_64 1.2.3-4\nsomething we dont understand\n bar noarch 1.2.3-4 "), []*PkgInfo{{"bar", "all", "1.2.3-4"}}},
+		{"UnrecognizedPackage", []byte("foo.x86_64 1.2.3-4\nsomething we dont understand\n bar noarch 1.2.3-4 "), []*PkgInfo{{Name: "bar", Arch: "all", Version: "1.2.3-4"}}},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -59,7 +59,7 @@ func TestInstalledRPMPackages(t *testing.T) {
 		t.Errorf("unexpected error: %v", err)
 	}
 
-	want := []*PkgInfo{{"foo", "x86_64", "1.2.3-4"}}
+	want := []*PkgInfo{{Name: "foo", Arch: "x86_64", Version: "1.2.3-4"}}
 	if !reflect.DeepEqual(ret, want) {
 		t.Errorf("InstalledRPMPackages() = %v, want %v", ret, want)
 	}
@@ -85,7 +85,7 @@ func TestRPMPkgInfo(t *testing.T) {
 		t.Errorf("unexpected error: %v", err)
 	}
 
-	want := &PkgInfo{"foo", "x86_64", "1.2.3-4"}
+	want := &PkgInfo{Name: "foo", Arch: "x86_64", Version: "1.2.3-4"}
 	if !reflect.DeepEqual(ret, want) {
 		t.Errorf("RPMPkgInfo() = %v, want %v", ret, want)
 	}

--- a/packages/yum_test.go
+++ b/packages/yum_test.go
@@ -207,7 +207,7 @@ func TestParseYumUpdates(t *testing.T) {
 		data []byte
 		want []*PkgInfo
 	}{
-		{"NormalCase", data, []*PkgInfo{{"kernel", "x86_64", "2.6.32-754.24.3.el6"}, {"foo", "all", "2.0.0-1"}, {"bar", "x86_64", "2.0.0-1"}}},
+		{"NormalCase", data, []*PkgInfo{{Name: "kernel", Arch: "x86_64", Version: "2.6.32-754.24.3.el6"}, {Name: "foo", Arch: "all", Version: "2.0.0-1"}, {Name: "bar", Arch: "x86_64", Version: "2.0.0-1"}}},
 		{"NoPackages", []byte("nothing here"), nil},
 		{"nil", nil, nil},
 	}
@@ -237,7 +237,7 @@ func TestParseYumUpdatesWithInstallingDependenciesKeywords(t *testing.T) {
 		data []byte
 		want []*PkgInfo
 	}{
-		{"NormalCase", data, []*PkgInfo{{"kernel", "x86_64", "2.6.32-754.24.3.el6"}, {"foo", "all", "2.0.0-1"}, {"bar", "x86_64", "2.0.0-1"}}},
+		{"NormalCase", data, []*PkgInfo{{Name: "kernel", Arch: "x86_64", Version: "2.6.32-754.24.3.el6"}, {Name: "foo", Arch: "all", Version: "2.0.0-1"}, {Name: "bar", Arch: "x86_64", Version: "2.0.0-1"}}},
 		{"NoPackages", []byte("nothing here"), nil},
 		{"nil", nil, nil},
 	}

--- a/packages/zypper_test.go
+++ b/packages/zypper_test.go
@@ -76,7 +76,7 @@ this is junk data`
 		data []byte
 		want []*PkgInfo
 	}{
-		{"NormalCase", []byte(normalCase), []*PkgInfo{{"at", "x86_64", "3.1.14-8.3.1"}, {"autoyast2-installation", "all", "3.2.22-2.9.2"}}},
+		{"NormalCase", []byte(normalCase), []*PkgInfo{{Name: "at", Arch: "x86_64", Version: "3.1.14-8.3.1"}, {Name: "autoyast2-installation", Arch: "all", Version: "3.2.22-2.9.2"}}},
 		{"NoPackages", []byte("nothing here"), nil},
 		{"nil", nil, nil},
 	}
@@ -104,7 +104,7 @@ func TestZypperUpdates(t *testing.T) {
 		t.Errorf("unexpected error: %v", err)
 	}
 
-	want := []*PkgInfo{{"at", "x86_64", "3.1.14-8.3.1"}}
+	want := []*PkgInfo{{Name: "at", Arch: "x86_64", Version: "3.1.14-8.3.1"}}
 	if !reflect.DeepEqual(ret, want) {
 		t.Errorf("ZypperUpdates() = %v, want %v", ret, want)
 	}


### PR DESCRIPTION
* Add source name and version to PkgInfo structure.
* Refactor tests to make them more readable and improve coverage.
* Extract source name and version for dpkg packages. 
