### PR TITLE
Fix GuestPolicies e2e tests for SLES-15 SP5 by removing zypper update from VMs startup script

### DIFF
--- a/e2e_tests/test_suites/guestpolicies/guest_policies_utils.go
+++ b/e2e_tests/test_suites/guestpolicies/guest_policies_utils.go
@@ -115,8 +115,6 @@ while(1) {
 	case "zypper":
 		ss = `
 sleep 10
-# Update zypper since there were older versions with bugs.
-zypper -n install zypper
 zypper -n remove %[3]s
 %[1]s
 %[2]s


### PR DESCRIPTION

/assign @dowgird
/cc @dowgird
/cc @MarcMarc
/cc @ekremenetskii