### PR TITLE
Fix OSPolicies e2e tests for SLES-15 SP5 by removing zypper update from VMs startup script

### DIFF
--- a/e2e_tests/test_suites/ospolicies/ospolicies_utils.go
+++ b/e2e_tests/test_suites/ospolicies/ospolicies_utils.go
@@ -276,8 +276,6 @@ while(1) {
 	case "zypper":
 		ss = `set -x
 sleep 10
-# Update zypper since there were older versions with bugs.
-zypper -n install zypper
 %s
 while true; do
   if [[ -n $(/usr/bin/rpmquery -a %s) ]]; then


### PR DESCRIPTION
/assign @ekremenetskii
/cc @dowgird
/cc @MarcMarc
/cc @ekremenetskii