### PR TITLE
Fix Debian-12 failing test by using gcsfuse pkg & Fix fetching gpg key unit tests

### DIFF
--- a/config/repository_resource_test.go
+++ b/config/repository_resource_test.go
@@ -287,10 +287,6 @@ func TestFetchGPGKey(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if len(entityList) != 2 {
-		t.Errorf("Expected: %v key(s), got: %v", 2, len(entityList))
-	}
-
 	// check if Artifact Regitry key exist or not
 	artifactRegistryKeyFound := false
 	for _, e := range entityList {

--- a/e2e_tests/utils/utils.go
+++ b/e2e_tests/utils/utils.go
@@ -129,7 +129,7 @@ func InstallOSConfigDeb(image string) string {
 	if config.AgentRepo() == "" {
 		return CurlPost
 	}
-	osName := getDebOsName(image)
+	osName := GetDebOsName(image)
 	return fmt.Sprintf(`
 sleep 10
 systemctl stop google-osconfig-agent
@@ -313,7 +313,7 @@ func InstallOSConfigSUSE() string {
 }
 
 // getDebOsType returns the equivalent os_name for deb version (e.g. debian-11 --> bullseye)
-func getDebOsName(image string) string {
+func GetDebOsName(image string) string {
 	imageName := path.Base(image)
 	switch {
 	case image == "10" || containsAnyOf(imageName, []string{"debian-10", "buster"}):

--- a/e2e_tests/utils/utils.go
+++ b/e2e_tests/utils/utils.go
@@ -312,7 +312,7 @@ func InstallOSConfigSUSE() string {
 	return getZypperRepoSetup("el8") + zypperInstallAgent
 }
 
-// getDebOsType returns the equivalent os_name for deb version (e.g. debian-11 --> bullseye)
+// GetDebOsName returns the equivalent os_name for deb version (e.g. debian-11 --> bullseye)
 func GetDebOsName(image string) string {
 	imageName := path.Base(image)
 	switch {

--- a/policies/apt_test.go
+++ b/policies/apt_test.go
@@ -90,10 +90,6 @@ func TestGetAptGPGKey(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if len(entityList) != 2 {
-		t.Errorf("Expected: %v key(s), got: %v", 2, len(entityList))
-	}
-
 	// check if Artifact Regitry key exist or not
 	artifactRegistryKeyFound := false
 	for _, e := range entityList {


### PR DESCRIPTION
- Use gcsfuse pkg instead of osconfig-agent-test deprecated pkg for some e2e tests
- Fix fetching gpg key unit tests which is no longer has rapture key - only AR key

/assign @ekremenetskii
/cc @dowgird
/cc @MarcMarc