### PR TITLE
Add a new CloudBuild trigger config-file

### DIFF
--- a/presubmit_packagebuild/docker-image/build-container-img-cloudbuild.yaml
+++ b/presubmit_packagebuild/docker-image/build-container-img-cloudbuild.yaml
@@ -1,0 +1,11 @@
+timeout: 5400s
+
+steps:
+- name: 'gcr.io/kaniko-project/executor:v1.23.2'
+  args:
+  - --destination=europe-docker.pkg.dev/osconfig-agent-presubmits/osconfig-package-build-presubmit/osconfig-package-build-presubmit:latest
+  - --context=/workspace
+  - --dockerfile=presubmit_packagebuild/docker-image/Dockerfile
+
+options:
+  defaultLogsBucketBehavior: REGIONAL_USER_OWNED_BUCKET


### PR DESCRIPTION
This trigger will be used for auto updating the presubmit test container image on every new commit