### PR TITLE
Scanners fixes

### DIFF
--- a/policies/recipes/recipe.go
+++ b/policies/recipes/recipe.go
@@ -85,8 +85,8 @@ func convertVersion(version string) ([]int, error) {
 		if idx > 3 {
 			return nil, fmt.Errorf("invalid Version string")
 		}
-		val, err := strconv.ParseUint(element, 10, 0)
-		if err != nil {
+		val, err := strconv.ParseInt(element, 10, 0)
+		if err != nil || val < 0 {
 			return nil, fmt.Errorf("invalid Version string")
 		}
 		ret = append(ret, int(val))

--- a/policies/recipes/steps.go
+++ b/policies/recipes/steps.go
@@ -289,7 +289,7 @@ func extractTar(ctx context.Context, tarName string, dst string, archiveType age
 		if err != nil {
 			return err
 		}
-		filen, err := util.NormPath(util.SanitizePath(filepath.Join(dst, header.Name)))
+		filen, err := util.NormPath(filepath.Join(dst, util.SanitizePath(header.Name)))
 		if err != nil {
 			return err
 		}

--- a/policies/recipes/steps.go
+++ b/policies/recipes/steps.go
@@ -136,7 +136,7 @@ func extractZip(zipPath string, dst string) error {
 
 	// Check for conflicts
 	for _, f := range zr.File {
-		filen, err := util.NormPath(filepath.Join(dst, f.Name))
+		filen, err := util.NormPath(util.SanitizePath(filepath.Join(dst, f.Name)))
 		if err != nil {
 			return err
 		}
@@ -156,7 +156,7 @@ func extractZip(zipPath string, dst string) error {
 
 	// Create files.
 	for _, f := range zr.File {
-		filen, err := util.NormPath(filepath.Join(dst, f.Name))
+		filen, err := util.NormPath(util.SanitizePath(filepath.Join(dst, f.Name)))
 		if err != nil {
 			return err
 		}
@@ -289,7 +289,7 @@ func extractTar(ctx context.Context, tarName string, dst string, archiveType age
 		if err != nil {
 			return err
 		}
-		filen, err := util.NormPath(filepath.Join(dst, header.Name))
+		filen, err := util.NormPath(util.SanitizePath(filepath.Join(dst, header.Name)))
 		if err != nil {
 			return err
 		}

--- a/util/util.go
+++ b/util/util.go
@@ -43,6 +43,14 @@ type Logger struct {
 	Fatalf   func(string, ...any)
 }
 
+// SanitizePath ensures that relative path does not contains ".." to avoid directory traversal attacks.
+// As well run filepath.Clean to remove redundant path segments.
+func SanitizePath(path string) (string) {
+	sanitized := strings.ReplaceAll(path, "..", "")
+
+	return filepath.Clean(sanitized)
+}
+
 // NormPath transforms a windows path into an extended-length path as described in
 // https://msdn.microsoft.com/en-us/library/windows/desktop/aa365247(v=vs.85).aspx#maxpath
 // when not running on windows it will just return the input path.

--- a/util/util.go
+++ b/util/util.go
@@ -45,7 +45,7 @@ type Logger struct {
 
 // SanitizePath ensures that relative path does not contains ".." to avoid directory traversal attacks.
 // As well run filepath.Clean to remove redundant path segments.
-func SanitizePath(path string) (string) {
+func SanitizePath(path string) string {
 	sanitized := strings.ReplaceAll(path, "../", "")
 
 	return filepath.Clean(sanitized)

--- a/util/util.go
+++ b/util/util.go
@@ -46,7 +46,7 @@ type Logger struct {
 // SanitizePath ensures that relative path does not contains ".." to avoid directory traversal attacks.
 // As well run filepath.Clean to remove redundant path segments.
 func SanitizePath(path string) (string) {
-	sanitized := strings.ReplaceAll(path, "..", "")
+	sanitized := strings.ReplaceAll(path, "../", "")
 
 	return filepath.Clean(sanitized)
 }

--- a/util/util_test.go
+++ b/util/util_test.go
@@ -5,42 +5,36 @@ import (
 )
 
 func TestSanitizePath(t *testing.T) {
-	tests := []struct{
-		name string
-		input string
+	tests := []struct {
+		name           string
+		input          string
 		expectedOutput string
 	}{
 		{
-			name: "Basic file name",
-			input: "test.yaml",
+			name:           "Basic file name",
+			input:          "test.yaml",
 			expectedOutput: "test.yaml",
-
 		},
 		{
-			name: "Basic full path",
-			input: "/x/test.yaml",
+			name:           "Basic full path",
+			input:          "/x/test.yaml",
 			expectedOutput: "/x/test.yaml",
-
 		},
 		{
-			name: "Relative path",
-			input: "x/test.yaml",
+			name:           "Relative path",
+			input:          "x/test.yaml",
 			expectedOutput: "x/test.yaml",
-
 		},
 		{
-			name: "Relative path with traversal segment",
-			input: "../x/test.yaml",
+			name:           "Relative path with traversal segment",
+			input:          "../x/test.yaml",
 			expectedOutput: "x/test.yaml",
-
 		},
 		{
-			name: "Relative path with traversal segment",
-			input: "/../x/test.yaml",
+			name:           "Relative path with traversal segment",
+			input:          "/../x/test.yaml",
 			expectedOutput: "/x/test.yaml",
-
 		},
-
 	}
 
 	for _, tt := range tests {

--- a/util/util_test.go
+++ b/util/util_test.go
@@ -1,0 +1,52 @@
+package util
+
+import (
+	"testing"
+)
+
+func TestSanitizePath(t *testing.T) {
+	tests := []struct{
+		name string
+		input string
+		expectedOutput string
+	}{
+		{
+			name: "Basic file name",
+			input: "test.yaml",
+			expectedOutput: "test.yaml",
+
+		},
+		{
+			name: "Basic full path",
+			input: "/x/test.yaml",
+			expectedOutput: "/x/test.yaml",
+
+		},
+		{
+			name: "Relative path",
+			input: "x/test.yaml",
+			expectedOutput: "x/test.yaml",
+
+		},
+		{
+			name: "Relative path with traversal segment",
+			input: "../x/test.yaml",
+			expectedOutput: "x/test.yaml",
+
+		},
+		{
+			name: "Relative path with traversal segment",
+			input: "/../x/test.yaml",
+			expectedOutput: "/x/test.yaml",
+
+		},
+
+	}
+
+	for _, tt := range tests {
+		if result := SanitizePath(tt.input); result != tt.expectedOutput {
+			t.Errorf("Test %q failed, expectedOutput %q, got %q", tt.name, tt.expectedOutput, result)
+		}
+
+	}
+}


### PR DESCRIPTION
Fix scanner issues:

[Incorrect conversion between integer types](https://github.com/GoogleCloudPlatform/osconfig/security/code-scanning/7)

[Arbitrary file access during archive extraction ("Zip Slip")](https://github.com/GoogleCloudPlatform/osconfig/security/code-scanning/6)

[Arbitrary file access during archive extraction ("Zip Slip")](https://github.com/GoogleCloudPlatform/osconfig/security/code-scanning/5)

[Arbitrary file access during archive extraction ("Zip Slip")](https://github.com/GoogleCloudPlatform/osconfig/security/code-scanning/4)

[Arbitrary file access during archive extraction ("Zip Slip")
](https://github.com/GoogleCloudPlatform/osconfig/security/code-scanning/3)

[Arbitrary file write extracting an archive containing symbolic links](https://github.com/GoogleCloudPlatform/osconfig/security/code-scanning/2)

[Arbitrary file write extracting an archive containing symbolic links](https://github.com/GoogleCloudPlatform/osconfig/security/code-scanning/1)
