### PR TITLE
Rename `RebootCount` to `PostPatchRebootCount` and only increment it for post-patch reboots.

### DIFF
--- a/agentendpoint/task_state_test.go
+++ b/agentendpoint/task_state_test.go
@@ -28,7 +28,7 @@ import (
 )
 
 var (
-	testPatchTaskStateString = "{\"PatchTask\":{\"TaskID\":\"foo\",\"Task\":{\"patchConfig\":{\"apt\":{\"type\":\"DIST\",\"excludes\":[\"foo\",\"bar\"],\"exclusivePackages\":[\"foo\",\"bar\"]},\"windowsUpdate\":{\"classifications\":[\"CRITICAL\",\"SECURITY\"],\"excludes\":[\"foo\",\"bar\"],\"exclusivePatches\":[\"foo\",\"bar\"]}}},\"StartedAt\":\"0001-01-01T00:00:00Z\",\"RebootCount\":0},\"Labels\":{\"foo\":\"bar\"}}"
+	testPatchTaskStateString = "{\"PatchTask\":{\"TaskID\":\"foo\",\"Task\":{\"patchConfig\":{\"apt\":{\"type\":\"DIST\",\"excludes\":[\"foo\",\"bar\"],\"exclusivePackages\":[\"foo\",\"bar\"]},\"windowsUpdate\":{\"classifications\":[\"CRITICAL\",\"SECURITY\"],\"excludes\":[\"foo\",\"bar\"],\"exclusivePatches\":[\"foo\",\"bar\"]}}},\"StartedAt\":\"0001-01-01T00:00:00Z\",\"PrePatchRebootCount\":2,\"PostPatchRebootCount\":1},\"Labels\":{\"foo\":\"bar\"}}"
 	testPatchTaskState       = &taskState{
 		Labels: map[string]string{"foo": "bar"},
 		PatchTask: &patchTask{
@@ -41,6 +41,8 @@ var (
 					},
 				},
 			},
+			PrePatchRebootCount:  2,
+			PostPatchRebootCount: 1,
 		},
 	}
 )
@@ -82,6 +84,20 @@ func TestLoadState(t *testing.T) {
 			[]byte(testPatchTaskStateString),
 			false,
 			testPatchTaskState,
+		},
+		{
+			"IgnoresOldRebootFieldName",
+			[]byte("{\"PatchTask\":{\"Task\":{},\"RebootCount\":1}}"),
+			false,
+			&taskState{
+				PatchTask: &patchTask{
+					Task: &applyPatchesTask{
+						&agentendpointpb.ApplyPatchesTask{},
+					},
+					PrePatchRebootCount:  0,
+					PostPatchRebootCount: 0,
+				},
+			},
 		},
 	}
 	for _, tt := range tests {


### PR DESCRIPTION
`RebootCount` was used only for forcing post-patch reboots via `RebootConfig = always`, but incremented for every reboot. As a result, the forced post-patch reboot was skipped if pre-patch reboot was required.

Note that the rename should be fine, since reading the old state file will result with counter being reset (so worst case, we will have one additional restart, but not more)

Closes: #755