### PR TITLE
Report RPM inventory as YUM instead of empty SoftwarePackage when neither Zypper nor YUM tools are installed.

### DIFF
--- a/agentendpoint/inventory.go
+++ b/agentendpoint/inventory.go
@@ -159,13 +159,13 @@ func formatPackages(ctx context.Context, pkgs *packages.Packages, shortName stri
 	}
 	if pkgs.Rpm != nil {
 		temp := make([]*agentendpointpb.Inventory_SoftwarePackage, len(pkgs.Rpm))
-		if packages.YumExists {
+		if packages.YumExists || !packages.ZypperExists {
 			for i, pkg := range pkgs.Rpm {
 				temp[i] = &agentendpointpb.Inventory_SoftwarePackage{
 					Details: formatYumPackage(pkg),
 				}
 			}
-		} else if packages.ZypperExists {
+		} else {
 			for i, pkg := range pkgs.Rpm {
 				temp[i] = &agentendpointpb.Inventory_SoftwarePackage{
 					Details: formatZypperPackage(pkg),

--- a/agentendpoint/inventory_test.go
+++ b/agentendpoint/inventory_test.go
@@ -434,7 +434,6 @@ func TestWrite(t *testing.T) {
 
 func TestReport(t *testing.T) {
 	ctx := context.Background()
-	packages.YumExists = true
 	srv := &agentEndpointServiceInventoryTestServer{}
 	tc, err := newTestClient(ctx, srv)
 	if err != nil {
@@ -458,7 +457,8 @@ func TestReport(t *testing.T) {
 
 			tc.client.report(ctx, tt.inventoryState)
 
-			if diff := cmp.Diff(srv.lastReportInventoryRequest.Inventory, tt.wantInventory, protocmp.Transform()); diff != "" {
+			actualInventory := srv.lastReportInventoryRequest.Inventory
+			if diff := cmp.Diff(tt.wantInventory, actualInventory, protocmp.Transform()); diff != "" {
 				t.Fatalf("ReportInventoryRequest.Inventory mismatch (-want +got):\n%s", diff)
 			}
 		})


### PR DESCRIPTION
User custom setup may have `rpm` package manager installed without `yum` (redhat family default) or `zypper` (suse family default). In setup like this, agent reports empty SoftwarePackage with no details for every `rpm` package to **agentendpoint**, as a result whole inventory reporting fails with `Unsupported software package.`.
Bug introduced in #386.

Current consensus is that reporting a non-updatable RPM package is better than ignoring it.
Both solutions (ignoring as well as reporting) would be better than failing whole inventory reporting.

[Reversion of #386 test override](https://github.com/GoogleCloudPlatform/osconfig/pull/386/files#diff-97c1483086e27560a7248457f5bf35daa0fb2eb8c42cdb512db692423b6c832bR399) makes this fix covered by existing test.