### PR TITLE
defaultSleeper: tolerate 10% difference to reduce test flakiness

### DIFF
--- a/retryutil/retry_test.go
+++ b/retryutil/retry_test.go
@@ -202,8 +202,9 @@ func Test_defaultSleeper(t *testing.T) {
 	after := time.Now()
 	elapsed := after.Sub(before)
 
-	// To reduce flakiness we accept 1ms diff.
-	if abs(elapsed.Milliseconds()-timeToSleep.Milliseconds()) > 1 {
+	// Tolerate 10% difference to reduce test flakiness.
+	maxTimeDifference := timeToSleep / 10
+	if abs(elapsed.Milliseconds()-timeToSleep.Milliseconds()) > maxTimeDifference.Milliseconds() {
 		t.Errorf("sleeper.Sleep, elapsed time %s bigger than expected %s", elapsed, timeToSleep)
 	}
 }


### PR DESCRIPTION
See
>{Failed      retry_test.go:207: sleeper.Sleep, elapsed time 203.483272ms bigger than expected 200ms}

[source](https://oss.gprow.dev/view/gs/oss-prow/pr-logs/pull/GoogleCloudPlatform_osconfig/805/osconfig-presubmit-gotest/1912247155062476800)