### PR TITLE
Binary cleanup, add to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+/osconfig


### PR DESCRIPTION
Introduced recently in https://github.com/GoogleCloudPlatform/osconfig/pull/835 during rebase.
Would be good to squash with #835 merge-commit to allow git GC clean it up from history