### PR TITLE
Update Golang version and Skip backports repo for debian 11

### DIFF
--- a/packagebuild/common.sh
+++ b/packagebuild/common.sh
@@ -37,7 +37,7 @@ function install_go() {
     arch="arm64"
   fi
 
-  local GOLANG="go1.22.2.linux-${arch}.tar.gz"
+  local GOLANG="go1.24.2.linux-${arch}.tar.gz"
   export GOPATH=/usr/share/gocode
   export GOCACHE=/tmp/.cache
 

--- a/packagebuild/daisy_startupscript_deb.sh
+++ b/packagebuild/daisy_startupscript_deb.sh
@@ -32,6 +32,8 @@ gsutil cp "${SRC_PATH}/common.sh" ./
 
 # disable the backports repo for debian-10
 sed -i 's/^.*debian buster-backports main.*$//g' /etc/apt/sources.list
+# disable the backports repo for debian-11
+sed -i 's/^.*debian bullseye-backports main.*$//g' /etc/apt/sources.list
 
 try_command apt-get -y update
 try_command apt-get install -y --no-install-{suggests,recommends} git-core \


### PR DESCRIPTION
This fix build failure as debian 11 does not have backports repo anymore 