### PR TITLE
Bugfixes for OSConfig agent TPC awareness

### DIFF
--- a/agentconfig/agentconfig.go
+++ b/agentconfig/agentconfig.go
@@ -213,7 +213,7 @@ type projectJSON struct {
 }
 
 type universeJSON struct {
-	UniverseDomain string `json:"universe-domain"`
+	UniverseDomain string `json:"universeDomain"`
 }
 
 type attributesJSON struct {

--- a/agentconfig/agentconfig_test.go
+++ b/agentconfig/agentconfig_test.go
@@ -233,7 +233,7 @@ func TestSvcEndpoint(t *testing.T) {
 			fmt.Fprintln(w, `{"instance": {"id": 12345,"name": "name","zone": "fakezone","attributes": {"osconfig-endpoint": "{zone}-dev.osconfig.googleapis.com"}}}`)
 		case 1:
 			w.Header().Set("Etag", "etag-1")
-			fmt.Fprintln(w, `{"universe": {"universe-domain": "domain.com"}, "instance": {"id": 12345,"name": "name","zone": "fakezone","attributes": {"osconfig-endpoint": "{zone}-dev.osconfig.googleapis.com"}}}`)
+			fmt.Fprintln(w, `{"universe": {"universeDomain": "domain.com"}, "instance": {"id": 12345,"name": "name","zone": "fakezone","attributes": {"osconfig-endpoint": "{zone}-dev.osconfig.googleapis.com"}}}`)
 		}
 	}))
 	defer ts.Close()
@@ -277,7 +277,7 @@ func TestDisableCloudLogging(t *testing.T) {
 		switch request {
 		case 0:
 			w.Header().Set("Etag", "etag-0")
-			fmt.Fprintln(w, `{"universe":{"universe-domain": "domain.com"}}`)
+			fmt.Fprintln(w, `{"universe":{"universeDomain": "domain.com"}}`)
 		case 1:
 			w.Header().Set("Etag", "etag-1")
 			fmt.Fprintln(w, `{"instance": {"zone": "fake-zone"}}`)

--- a/main.go
+++ b/main.go
@@ -98,7 +98,7 @@ func registerAgent(ctx context.Context) {
 
 func run(ctx context.Context) {
 	// Setup logging.
-	opts := logger.LogOpts{LoggerName: "OSConfigAgent", UserAgent: agentconfig.UserAgent(), DisableLocalLogging: agentconfig.DisableLocalLogging(), DisableCloudLogging: agentconfig.DisableCloudLogging()}
+	opts := logger.LogOpts{LoggerName: "OSConfigAgent", UserAgent: agentconfig.UserAgent(), DisableLocalLogging: agentconfig.DisableLocalLogging()}
 	if agentconfig.Stdout() {
 		opts.Writers = []io.Writer{os.Stdout}
 	}
@@ -114,6 +114,7 @@ func run(ctx context.Context) {
 	opts.Debug = agentconfig.Debug()
 	clog.DebugEnabled = agentconfig.Debug()
 	opts.ProjectName = agentconfig.ProjectID()
+	opts.DisableCloudLogging = agentconfig.DisableCloudLogging()
 
 	if err := logger.Init(ctx, opts); err != nil {
 		fmt.Printf("Error initializing logger: %v", err)


### PR DESCRIPTION
Fixed JSON identifier for the universe domain and moved initialization of DisableCloudLogging parameter after querying metadata.