### PR TITLE
Fix: Add RHEL 10 support to RPM startup script

### DIFF
--- a/packagebuild/daisy_startupscript_rpm.sh
+++ b/packagebuild/daisy_startupscript_rpm.sh
@@ -69,6 +69,13 @@ if [[ ${VERSION_ID} = 9 ]]; then
   fi
 fi
 
+
+if [[ ${VERSION_ID} = 10 ]]; then
+  echo "Enabling CRB repo for el10"
+  dnf config-manager --set-enabled crb
+fi
+
+
 try_command yum install -y $GIT rpmdevtools yum-utils python3-devel
 
 git_checkout "$REPO_OWNER" "$REPO_NAME" "$GIT_REF"


### PR DESCRIPTION
This PR fixes the build process for RHEL 10.

Previously, the `el10` build was incorrectly producing `el9` packages. This change adds the necessary logic to the startup script to enable the CRB repository, allowing for a proper `el10` build.