### PR TITLE
Add unit tests for packages/pty_linux.go

### DIFF
--- a/packages/pty_linux_test.go
+++ b/packages/pty_linux_test.go
@@ -1,0 +1,130 @@
+//  Copyright 2026 Google Inc. All Rights Reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
+package packages
+
+import (
+	"os"
+	"os/exec"
+	"strings"
+	"testing"
+	"unsafe"
+
+	"github.com/GoogleCloudPlatform/osconfig/util/utiltest"
+	"golang.org/x/sys/unix"
+)
+
+// CheckPtmxAvailability skips the test if /dev/ptmx is not available
+func CheckPtmxAvailability(t *testing.T) {
+	if _, err := os.Stat("/dev/ptmx"); os.IsNotExist(err) {
+		t.Skip("/dev/ptmx not found, skipping PTY tests")
+	}
+}
+
+// TestIoctl verifies that the ioctl wrapper correctly performs a system call on a valid file descriptor
+func TestIoctl(t *testing.T) {
+	CheckPtmxAvailability(t)
+
+	f, err := os.OpenFile("/dev/ptmx", os.O_RDWR, 0)
+	if err != nil {
+		t.Fatalf("unable to open /dev/ptmx: %v", err)
+	}
+	defer f.Close()
+
+	// TIOCSPTLCK (unlockpt)
+	var i int
+	if err := ioctl(f.Fd(), unix.TIOCSPTLCK, uintptr(unsafe.Pointer(&i))); err != nil {
+		t.Errorf("ioctl() unexpected error: %v", err)
+	}
+}
+
+// TestIoctlError ensures that the ioctl function correctly handles and returns errors
+func TestIoctlError(t *testing.T) {
+	// Use an invalid file descriptor to trigger an error in ioctl
+	err := ioctl(^uintptr(0), unix.TIOCSPTLCK, 0)
+	if err == nil {
+		t.Error("ioctl() expected error with invalid fd, got nil")
+	}
+}
+
+// TestRunWithPty tests the runWithPty function with various cases:
+// successful command execution, commands returning non-zero exit codes, handling execution errors like missing binaries
+func TestRunWithPty(t *testing.T) {
+	CheckPtmxAvailability(t)
+
+	tests := []struct {
+		name       string
+		cmd        *exec.Cmd
+		wantOut    string
+		wantStderr string
+		wantErr    error
+	}{
+		{
+			name:    "command with exit code 0 returns nil",
+			cmd:     exec.Command("echo", "hello"),
+			wantOut: "",
+			wantErr: nil,
+		},
+		{
+			name:    "command with exit code 1 returns output",
+			cmd:     exec.Command("sh", "-c", "echo 'updates found'; exit 1"),
+			wantOut: "updates found",
+			wantErr: nil,
+		},
+		{
+			name:       "command with stderr and exit code 1",
+			cmd:        exec.Command("sh", "-c", "echo 'stdout message'; echo 'stderr message' >&2; exit 1"),
+			wantOut:    "stdout message",
+			wantStderr: "stderr message",
+			wantErr:    nil,
+		},
+		{
+			name:    "command with multiple lines of output",
+			cmd:     exec.Command("sh", "-c", "printf 'line1\nline2\nline3\n'; exit 1"),
+			wantOut: "line1\nline2\nline3\n",
+			wantErr: nil,
+		},
+		{
+			name:    "non existent command returns error",
+			cmd:     exec.Command("this-command-does-not-exist"),
+			wantOut: "",
+			// We use &exec.Error to match the type returned by exec.Command.Run()
+			wantErr: &exec.Error{Name: "this-command-does-not-exist", Err: exec.ErrNotFound},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			stdout, stderr, err := runWithPty(tt.cmd)
+
+			utiltest.AssertErrorMatch(t, err, tt.wantErr)
+			if tt.wantErr != nil {
+				return
+			}
+
+			if err != nil {
+				t.Errorf("runWithPty() unexpected error: %v", err)
+			}
+
+			// PTY often converts \n to \r\n, normalize for comparison.
+			gotOut := strings.ReplaceAll(string(stdout), "\r\n", "\n")
+			if !strings.Contains(gotOut, tt.wantOut) {
+				t.Errorf("runWithPty() stdout = %q, wantOut %q", gotOut, tt.wantOut)
+			}
+			if !strings.Contains(string(stderr), tt.wantStderr) {
+				t.Errorf("runWithPty() stderr = %q, wantStderr %q", string(stderr), tt.wantStderr)
+			}
+		})
+	}
+}

--- a/packages/pty_linux_test.go
+++ b/packages/pty_linux_test.go
@@ -87,12 +87,7 @@ func TestRunWithPty(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			stdout, stderr, err := runWithPty(tt.cmd)
-
 			utiltest.AssertErrorMatch(t, err, tt.wantErr)
-			if tt.wantErr != nil {
-				return
-			}
-
 			utiltest.AssertEquals(t, string(stdout), tt.wantOut)
 			utiltest.AssertEquals(t, string(stderr), tt.wantStderr)
 		})

--- a/packages/pty_linux_test.go
+++ b/packages/pty_linux_test.go
@@ -17,9 +17,7 @@ package packages
 import (
 	"os"
 	"os/exec"
-	"strings"
 	"testing"
-	"unsafe"
 
 	"github.com/GoogleCloudPlatform/osconfig/util/utiltest"
 	"golang.org/x/sys/unix"
@@ -29,23 +27,6 @@ import (
 func CheckPtmxAvailability(t *testing.T) {
 	if _, err := os.Stat("/dev/ptmx"); os.IsNotExist(err) {
 		t.Skip("/dev/ptmx not found, skipping PTY tests")
-	}
-}
-
-// TestIoctl verifies that the ioctl wrapper correctly performs a system call on a valid file descriptor
-func TestIoctl(t *testing.T) {
-	CheckPtmxAvailability(t)
-
-	f, err := os.OpenFile("/dev/ptmx", os.O_RDWR, 0)
-	if err != nil {
-		t.Fatalf("unable to open /dev/ptmx: %v", err)
-	}
-	defer f.Close()
-
-	// TIOCSPTLCK (unlockpt)
-	var i int
-	if err := ioctl(f.Fd(), unix.TIOCSPTLCK, uintptr(unsafe.Pointer(&i))); err != nil {
-		t.Errorf("ioctl() unexpected error: %v", err)
 	}
 }
 
@@ -72,34 +53,33 @@ func TestRunWithPty(t *testing.T) {
 	}{
 		{
 			name:    "command with exit code 0 returns nil",
-			cmd:     exec.Command("echo", "hello"),
+			cmd:     exec.Command("echo"),
 			wantOut: "",
 			wantErr: nil,
 		},
 		{
 			name:    "command with exit code 1 returns output",
 			cmd:     exec.Command("sh", "-c", "echo 'updates found'; exit 1"),
-			wantOut: "updates found",
+			wantOut: "updates found\r\n",
 			wantErr: nil,
 		},
 		{
 			name:       "command with stderr and exit code 1",
 			cmd:        exec.Command("sh", "-c", "echo 'stdout message'; echo 'stderr message' >&2; exit 1"),
-			wantOut:    "stdout message",
-			wantStderr: "stderr message",
+			wantOut:    "stdout message\r\n",
+			wantStderr: "stderr message\n",
 			wantErr:    nil,
 		},
 		{
 			name:    "command with multiple lines of output",
 			cmd:     exec.Command("sh", "-c", "printf 'line1\nline2\nline3\n'; exit 1"),
-			wantOut: "line1\nline2\nline3\n",
+			wantOut: "line1\r\nline2\r\nline3\r\n",
 			wantErr: nil,
 		},
 		{
 			name:    "non existent command returns error",
 			cmd:     exec.Command("this-command-does-not-exist"),
 			wantOut: "",
-			// We use &exec.Error to match the type returned by exec.Command.Run()
 			wantErr: &exec.Error{Name: "this-command-does-not-exist", Err: exec.ErrNotFound},
 		},
 	}
@@ -113,18 +93,8 @@ func TestRunWithPty(t *testing.T) {
 				return
 			}
 
-			if err != nil {
-				t.Errorf("runWithPty() unexpected error: %v", err)
-			}
-
-			// PTY often converts \n to \r\n, normalize for comparison.
-			gotOut := strings.ReplaceAll(string(stdout), "\r\n", "\n")
-			if !strings.Contains(gotOut, tt.wantOut) {
-				t.Errorf("runWithPty() stdout = %q, wantOut %q", gotOut, tt.wantOut)
-			}
-			if !strings.Contains(string(stderr), tt.wantStderr) {
-				t.Errorf("runWithPty() stderr = %q, wantStderr %q", string(stderr), tt.wantStderr)
-			}
+			utiltest.AssertEquals(t, string(stdout), tt.wantOut)
+			utiltest.AssertEquals(t, string(stderr), tt.wantStderr)
 		})
 	}
 }


### PR DESCRIPTION
New test coverage for this file:
github.com/GoogleCloudPlatform/osconfig/packages/pty_linux.go:33:	ioctl 0.0% -> 100.0%
github.com/GoogleCloudPlatform/osconfig/packages/pty_linux.go:45:	runWithPty 0.0% -> 82.0%