### PR TITLE
Add unit tests for policies/policies.go

### DIFF
--- a/policies/policies.go
+++ b/policies/policies.go
@@ -78,6 +78,8 @@ var (
 	yumChangesFunc         = yumChanges
 	zypperRepositoriesFunc = zypperRepositories
 	zypperChangesFunc      = zypperChanges
+
+	retryRPC = retryutil.RetryFunc
 )
 
 func installRecipes(ctx context.Context, egp *agentendpointpb.EffectiveGuestPolicy) error {
@@ -183,7 +185,7 @@ func setConfig(ctx context.Context, egp *agentendpointpb.EffectiveGuestPolicy) {
 		if err := googetRepositoriesFunc(ctx, gooRepos, agentconfig.GooGetRepoFilePath()); err != nil {
 			clog.Errorf(ctx, "Error writing googet repo file: %v", err)
 		}
-		if err := retryutil.RetryFunc(ctx, 1*time.Minute, "Applying googet changes", func() error {
+		if err := retryRPC(ctx, 1*time.Minute, "Applying googet changes", func() error {
 			return googetChangesFunc(ctx, gooInstallPkgs, gooRemovePkgs, gooUpdatePkgs)
 		}); err != nil {
 			clog.Errorf(ctx, "Error performing googet changes: %v", err)
@@ -194,7 +196,7 @@ func setConfig(ctx context.Context, egp *agentendpointpb.EffectiveGuestPolicy) {
 		if err := aptRepositoriesFunc(ctx, aptRepos, agentconfig.AptRepoFilePath()); err != nil {
 			clog.Errorf(ctx, "Error writing apt repo file: %v", err)
 		}
-		if err := retryutil.RetryFunc(ctx, 1*time.Minute, "Applying apt changes", func() error {
+		if err := retryRPC(ctx, 1*time.Minute, "Applying apt changes", func() error {
 			return aptChangesFunc(ctx, aptInstallPkgs, aptRemovePkgs, aptUpdatePkgs)
 		}); err != nil {
 			clog.Errorf(ctx, "Error performing apt changes: %v", err)
@@ -205,7 +207,7 @@ func setConfig(ctx context.Context, egp *agentendpointpb.EffectiveGuestPolicy) {
 		if err := yumRepositoriesFunc(ctx, yumRepos, agentconfig.YumRepoFilePath()); err != nil {
 			clog.Errorf(ctx, "Error writing yum repo file: %v", err)
 		}
-		if err := retryutil.RetryFunc(ctx, 1*time.Minute, "Applying yum changes", func() error {
+		if err := retryRPC(ctx, 1*time.Minute, "Applying yum changes", func() error {
 			return yumChangesFunc(ctx, yumInstallPkgs, yumRemovePkgs, yumUpdatePkgs)
 		}); err != nil {
 			clog.Errorf(ctx, "Error performing yum changes: %v", err)
@@ -216,7 +218,7 @@ func setConfig(ctx context.Context, egp *agentendpointpb.EffectiveGuestPolicy) {
 		if err := zypperRepositoriesFunc(ctx, zypperRepos, agentconfig.ZypperRepoFilePath()); err != nil {
 			clog.Errorf(ctx, "Error writing zypper repo file: %v", err)
 		}
-		if err := retryutil.RetryFunc(ctx, 1*time.Minute, "Applying zypper changes.", func() error {
+		if err := retryRPC(ctx, 1*time.Minute, "Applying zypper changes.", func() error {
 			return zypperChangesFunc(ctx, zypperInstallPkgs, zypperRemovePkgs, zypperUpdatePkgs)
 		}); err != nil {
 			clog.Errorf(ctx, "Error performing zypper changes: %v", err)

--- a/policies/policies.go
+++ b/policies/policies.go
@@ -67,10 +67,23 @@ func Run(ctx context.Context) {
 	tasker.Enqueue(ctx, "Run GuestPolicies", func() { run(ctx) })
 }
 
+var (
+	installRecipe = recipes.InstallRecipe
+
+	googetRepositoriesFunc = googetRepositories
+	googetChangesFunc      = googetChanges
+	aptRepositoriesFunc    = aptRepositories
+	aptChangesFunc         = aptChanges
+	yumRepositoriesFunc    = yumRepositories
+	yumChangesFunc         = yumChanges
+	zypperRepositoriesFunc = zypperRepositories
+	zypperChangesFunc      = zypperChanges
+)
+
 func installRecipes(ctx context.Context, egp *agentendpointpb.EffectiveGuestPolicy) error {
 	for _, recipe := range egp.GetSoftwareRecipes() {
 		if r := recipe.GetSoftwareRecipe(); r != nil {
-			if err := recipes.InstallRecipe(ctx, r); err != nil {
+			if err := installRecipe(ctx, r); err != nil {
 				clog.Errorf(ctx, "Error installing recipe: %v", err)
 			}
 		}
@@ -167,44 +180,44 @@ func setConfig(ctx context.Context, egp *agentendpointpb.EffectiveGuestPolicy) {
 	}
 
 	if packages.GooGetExists {
-		if err := googetRepositories(ctx, gooRepos, agentconfig.GooGetRepoFilePath()); err != nil {
+		if err := googetRepositoriesFunc(ctx, gooRepos, agentconfig.GooGetRepoFilePath()); err != nil {
 			clog.Errorf(ctx, "Error writing googet repo file: %v", err)
 		}
 		if err := retryutil.RetryFunc(ctx, 1*time.Minute, "Applying googet changes", func() error {
-			return googetChanges(ctx, gooInstallPkgs, gooRemovePkgs, gooUpdatePkgs)
+			return googetChangesFunc(ctx, gooInstallPkgs, gooRemovePkgs, gooUpdatePkgs)
 		}); err != nil {
 			clog.Errorf(ctx, "Error performing googet changes: %v", err)
 		}
 	}
 
 	if packages.AptExists {
-		if err := aptRepositories(ctx, aptRepos, agentconfig.AptRepoFilePath()); err != nil {
+		if err := aptRepositoriesFunc(ctx, aptRepos, agentconfig.AptRepoFilePath()); err != nil {
 			clog.Errorf(ctx, "Error writing apt repo file: %v", err)
 		}
 		if err := retryutil.RetryFunc(ctx, 1*time.Minute, "Applying apt changes", func() error {
-			return aptChanges(ctx, aptInstallPkgs, aptRemovePkgs, aptUpdatePkgs)
+			return aptChangesFunc(ctx, aptInstallPkgs, aptRemovePkgs, aptUpdatePkgs)
 		}); err != nil {
 			clog.Errorf(ctx, "Error performing apt changes: %v", err)
 		}
 	}
 
 	if packages.YumExists {
-		if err := yumRepositories(ctx, yumRepos, agentconfig.YumRepoFilePath()); err != nil {
+		if err := yumRepositoriesFunc(ctx, yumRepos, agentconfig.YumRepoFilePath()); err != nil {
 			clog.Errorf(ctx, "Error writing yum repo file: %v", err)
 		}
 		if err := retryutil.RetryFunc(ctx, 1*time.Minute, "Applying yum changes", func() error {
-			return yumChanges(ctx, yumInstallPkgs, yumRemovePkgs, yumUpdatePkgs)
+			return yumChangesFunc(ctx, yumInstallPkgs, yumRemovePkgs, yumUpdatePkgs)
 		}); err != nil {
 			clog.Errorf(ctx, "Error performing yum changes: %v", err)
 		}
 	}
 
 	if packages.ZypperExists {
-		if err := zypperRepositories(ctx, zypperRepos, agentconfig.ZypperRepoFilePath()); err != nil {
+		if err := zypperRepositoriesFunc(ctx, zypperRepos, agentconfig.ZypperRepoFilePath()); err != nil {
 			clog.Errorf(ctx, "Error writing zypper repo file: %v", err)
 		}
 		if err := retryutil.RetryFunc(ctx, 1*time.Minute, "Applying zypper changes.", func() error {
-			return zypperChanges(ctx, zypperInstallPkgs, zypperRemovePkgs, zypperUpdatePkgs)
+			return zypperChangesFunc(ctx, zypperInstallPkgs, zypperRemovePkgs, zypperUpdatePkgs)
 		}); err != nil {
 			clog.Errorf(ctx, "Error performing zypper changes: %v", err)
 		}

--- a/policies/policies_test.go
+++ b/policies/policies_test.go
@@ -38,7 +38,7 @@ type managerCalls struct {
 }
 
 func setupMocks(googetExists, aptExists, yumExists, zypperExists bool, gotCalls map[string]*managerCalls) func() {
-	// Сохраняем оригиналы
+	// preserve original functions
 	oldGooE, oldAptE, oldYumE, oldZypE := packages.GooGetExists, packages.AptExists, packages.YumExists, packages.ZypperExists
 	oldGooR, oldGooC := googetRepositoriesFunc, googetChangesFunc
 	oldAptR, oldAptC := aptRepositoriesFunc, aptChangesFunc
@@ -46,11 +46,11 @@ func setupMocks(googetExists, aptExists, yumExists, zypperExists bool, gotCalls 
 	oldZypR, oldZypC := zypperRepositoriesFunc, zypperChangesFunc
 	oldRetry := retryRPC
 
-	// Настраиваем существование
+	// mock Exists functions
 	packages.GooGetExists, packages.AptExists = googetExists, aptExists
 	packages.YumExists, packages.ZypperExists = yumExists, zypperExists
 
-	// Настраиваем Retry
+	// replace retryRPC function to avoid long awaits
 	retryRPC = func(ctx context.Context, timeout time.Duration, desc string, f func() error) error { return f() }
 
 	getCalls := func(m string) *managerCalls {
@@ -128,7 +128,9 @@ func TestChecksum(t *testing.T) {
 	}
 
 	for _, tt := range tests {
+		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			r := bytes.NewReader(tt.data)
 			h := checksum(r)
 
@@ -172,7 +174,9 @@ func TestWriteIfChanged(t *testing.T) {
 	}
 
 	for _, tt := range tests {
+		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			td := t.TempDir()
 			path := filepath.Join(td, "test_file")
 
@@ -203,17 +207,34 @@ func TestInstallRecipes(t *testing.T) {
 	ctx := context.Background()
 
 	tests := []struct {
-		name     string
-		recipes  []*agentendpointpb.SoftwareRecipe
-		wantInst []string
+		name       string
+		recipes    []*agentendpointpb.EffectiveGuestPolicy_SourcedSoftwareRecipe
+		installErr error
+		wantInst   []string
 	}{
 		{
 			name: "multiple recipes",
-			recipes: []*agentendpointpb.SoftwareRecipe{
-				{Name: "recipe1"},
-				{Name: "recipe2"},
+			recipes: []*agentendpointpb.EffectiveGuestPolicy_SourcedSoftwareRecipe{
+				{SoftwareRecipe: &agentendpointpb.SoftwareRecipe{Name: "recipe1"}},
+				{SoftwareRecipe: &agentendpointpb.SoftwareRecipe{Name: "recipe2"}},
 			},
 			wantInst: []string{"recipe1", "recipe2"},
+		},
+		{
+			name: "nil SoftwareRecipe",
+			recipes: []*agentendpointpb.EffectiveGuestPolicy_SourcedSoftwareRecipe{
+				{SoftwareRecipe: &agentendpointpb.SoftwareRecipe{Name: "recipe1"}},
+				{SoftwareRecipe: nil},
+			},
+			wantInst: []string{"recipe1"},
+		},
+		{
+			name: "installation error",
+			recipes: []*agentendpointpb.EffectiveGuestPolicy_SourcedSoftwareRecipe{
+				{SoftwareRecipe: &agentendpointpb.SoftwareRecipe{Name: "recipe1"}},
+			},
+			installErr: errors.New("install error"),
+			wantInst:   []string{"recipe1"},
 		},
 		{
 			name:     "no recipes",
@@ -223,24 +244,19 @@ func TestInstallRecipes(t *testing.T) {
 	}
 
 	for _, tt := range tests {
+		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			var installed []string
 			oldInstallRecipe := installRecipe
 			installRecipe = func(ctx context.Context, recipe *agentendpointpb.SoftwareRecipe) error {
 				installed = append(installed, recipe.Name)
-				return nil
+				return tt.installErr
 			}
 			defer func() { installRecipe = oldInstallRecipe }()
 
-			var sourcedRecipes []*agentendpointpb.EffectiveGuestPolicy_SourcedSoftwareRecipe
-			for _, r := range tt.recipes {
-				sourcedRecipes = append(sourcedRecipes, &agentendpointpb.EffectiveGuestPolicy_SourcedSoftwareRecipe{
-					SoftwareRecipe: r,
-				})
-			}
-
 			egp := &agentendpointpb.EffectiveGuestPolicy{
-				SoftwareRecipes: sourcedRecipes,
+				SoftwareRecipes: tt.recipes,
 			}
 
 			if err := installRecipes(ctx, egp); err != nil {
@@ -292,7 +308,7 @@ func TestSetConfig(t *testing.T) {
 			},
 		},
 		{
-			name:      "manager not existing",
+			name:      "manager doesnt exist",
 			aptExists: true,
 			packages: []*agentendpointpb.Package{
 				{Name: "apt-pkg", Manager: agentendpointpb.Package_APT, DesiredState: agentendpointpb.DesiredState_INSTALLED},
@@ -326,7 +342,9 @@ func TestSetConfig(t *testing.T) {
 	}
 
 	for _, tt := range tests {
+		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			gotCalls := make(map[string]*managerCalls)
 			defer setupMocks(tt.googetExists, tt.aptExists, tt.yumExists, tt.zypperExists, gotCalls)()
 

--- a/policies/policies_test.go
+++ b/policies/policies_test.go
@@ -128,7 +128,6 @@ func TestChecksum(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			r := bytes.NewReader(tt.data)
@@ -174,7 +173,6 @@ func TestWriteIfChanged(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			td := t.TempDir()
@@ -244,7 +242,6 @@ func TestInstallRecipes(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			var installed []string
@@ -342,7 +339,6 @@ func TestSetConfig(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			gotCalls := make(map[string]*managerCalls)

--- a/policies/policies_test.go
+++ b/policies/policies_test.go
@@ -18,15 +18,98 @@ import (
 	"bytes"
 	"context"
 	"crypto/sha256"
+	"errors"
 	"os"
 	"path/filepath"
 	"reflect"
 	"testing"
+	"time"
 
 	"cloud.google.com/go/osconfig/agentendpoint/apiv1beta/agentendpointpb"
 	"github.com/GoogleCloudPlatform/osconfig/packages"
 	"github.com/GoogleCloudPlatform/osconfig/util/utiltest"
 )
+
+type managerCalls struct {
+	install []string
+	remove  []string
+	update  []string
+	repos   int
+}
+
+func setupMocks(googetExists, aptExists, yumExists, zypperExists bool, gotCalls map[string]*managerCalls) func() {
+	// Сохраняем оригиналы
+	oldGooE, oldAptE, oldYumE, oldZypE := packages.GooGetExists, packages.AptExists, packages.YumExists, packages.ZypperExists
+	oldGooR, oldGooC := googetRepositoriesFunc, googetChangesFunc
+	oldAptR, oldAptC := aptRepositoriesFunc, aptChangesFunc
+	oldYumR, oldYumC := yumRepositoriesFunc, yumChangesFunc
+	oldZypR, oldZypC := zypperRepositoriesFunc, zypperChangesFunc
+	oldRetry := retryRPC
+
+	// Настраиваем существование
+	packages.GooGetExists, packages.AptExists = googetExists, aptExists
+	packages.YumExists, packages.ZypperExists = yumExists, zypperExists
+
+	// Настраиваем Retry
+	retryRPC = func(ctx context.Context, timeout time.Duration, desc string, f func() error) error { return f() }
+
+	getCalls := func(m string) *managerCalls {
+		if _, ok := gotCalls[m]; !ok {
+			gotCalls[m] = &managerCalls{}
+		}
+		return gotCalls[m]
+	}
+
+	capture := func(m string) func(ctx context.Context, inst, rem, upd []*agentendpointpb.Package) error {
+		return func(ctx context.Context, inst, rem, upd []*agentendpointpb.Package) error {
+			c := getCalls(m)
+			for _, p := range inst {
+				c.install = append(c.install, p.Name)
+			}
+			for _, p := range rem {
+				c.remove = append(c.remove, p.Name)
+			}
+			for _, p := range upd {
+				c.update = append(c.update, p.Name)
+			}
+			return nil
+		}
+	}
+
+	googetRepositoriesFunc = func(ctx context.Context, repos []*agentendpointpb.GooRepository, path string) error {
+		getCalls("googet").repos += len(repos)
+		return nil
+	}
+	googetChangesFunc = capture("googet")
+
+	aptRepositoriesFunc = func(ctx context.Context, repos []*agentendpointpb.AptRepository, path string) error {
+		getCalls("apt").repos += len(repos)
+		return nil
+	}
+	aptChangesFunc = capture("apt")
+
+	yumRepositoriesFunc = func(ctx context.Context, repos []*agentendpointpb.YumRepository, path string) error {
+		getCalls("yum").repos += len(repos)
+		return nil
+	}
+	yumChangesFunc = capture("yum")
+
+	zypperRepositoriesFunc = func(ctx context.Context, repos []*agentendpointpb.ZypperRepository, path string) error {
+		getCalls("zypper").repos += len(repos)
+		return nil
+	}
+	zypperChangesFunc = capture("zypper")
+
+	return func() {
+		packages.GooGetExists, packages.AptExists = oldGooE, oldAptE
+		packages.YumExists, packages.ZypperExists = oldYumE, oldZypE
+		googetRepositoriesFunc, googetChangesFunc = oldGooR, oldGooC
+		aptRepositoriesFunc, aptChangesFunc = oldAptR, oldAptC
+		yumRepositoriesFunc, yumChangesFunc = oldYumR, oldYumC
+		zypperRepositoriesFunc, zypperChangesFunc = oldZypR, oldZypC
+		retryRPC = oldRetry
+	}
+}
 
 // TestChecksum verifies that checksum correctly calculates the SHA256 hash of the input reader.
 func TestChecksum(t *testing.T) {
@@ -171,111 +254,147 @@ func TestInstallRecipes(t *testing.T) {
 	}
 }
 
-// TestSetConfig verifies that setConfig correctly distributes packages to different managers.
+// TestSetConfig verifies that setConfig correctly distributes packages and repositories to different managers.
 func TestSetConfig(t *testing.T) {
 	ctx := context.Background()
 
 	tests := []struct {
-		name             string
-		aptExists        bool
-		yumExists        bool
-		packages         []*agentendpointpb.Package
-		wantAptInstalled []string
-		wantYumInstalled []string
+		name         string
+		googetExists bool
+		aptExists    bool
+		yumExists    bool
+		zypperExists bool
+		packages     []*agentendpointpb.Package
+		repos        []*agentendpointpb.PackageRepository
+		wantCalls    map[string]managerCalls
 	}{
 		{
-			name:      "mixed managers and packages",
-			aptExists: true,
-			yumExists: true,
+			name:         "all managers and all states",
+			googetExists: true, aptExists: true, yumExists: true, zypperExists: true,
 			packages: []*agentendpointpb.Package{
-				{Name: "any-pkg", Manager: agentendpointpb.Package_ANY, DesiredState: agentendpointpb.DesiredState_INSTALLED},
+				{Name: "p-any-rem", Manager: agentendpointpb.Package_ANY, DesiredState: agentendpointpb.DesiredState_REMOVED},
+				{Name: "p-apt-upd", Manager: agentendpointpb.Package_APT, DesiredState: agentendpointpb.DesiredState_UPDATED},
+				{Name: "p-goo-inst", Manager: agentendpointpb.Package_GOO, DesiredState: agentendpointpb.DesiredState_INSTALLED},
+				{Name: "p-yum-inst", Manager: agentendpointpb.Package_YUM, DesiredState: agentendpointpb.DesiredState_DESIRED_STATE_UNSPECIFIED},
+				{Name: "p-zyp-upd", Manager: agentendpointpb.Package_ZYPPER, DesiredState: agentendpointpb.DesiredState_UPDATED},
+			},
+			repos: []*agentendpointpb.PackageRepository{
+				{Repository: &agentendpointpb.PackageRepository_Apt{Apt: &agentendpointpb.AptRepository{}}},
+				{Repository: &agentendpointpb.PackageRepository_Yum{Yum: &agentendpointpb.YumRepository{}}},
+				{Repository: &agentendpointpb.PackageRepository_Zypper{Zypper: &agentendpointpb.ZypperRepository{}}},
+				{Repository: &agentendpointpb.PackageRepository_Goo{Goo: &agentendpointpb.GooRepository{}}},
+			},
+			wantCalls: map[string]managerCalls{
+				"googet": {install: []string{"p-goo-inst"}, remove: []string{"p-any-rem"}, repos: 1},
+				"apt":    {remove: []string{"p-any-rem"}, update: []string{"p-apt-upd"}, repos: 1},
+				"yum":    {install: []string{"p-yum-inst"}, remove: []string{"p-any-rem"}, repos: 1},
+				"zypper": {remove: []string{"p-any-rem"}, update: []string{"p-zyp-upd"}, repos: 1},
+			},
+		},
+		{
+			name:      "manager not existing",
+			aptExists: true,
+			packages: []*agentendpointpb.Package{
 				{Name: "apt-pkg", Manager: agentendpointpb.Package_APT, DesiredState: agentendpointpb.DesiredState_INSTALLED},
 				{Name: "yum-pkg", Manager: agentendpointpb.Package_YUM, DesiredState: agentendpointpb.DesiredState_INSTALLED},
 			},
-			wantAptInstalled: []string{"any-pkg", "apt-pkg"},
-			wantYumInstalled: []string{"any-pkg", "yum-pkg"},
+			wantCalls: map[string]managerCalls{
+				"apt": {install: []string{"apt-pkg"}},
+			},
 		},
 		{
-			name:      "only apt manager exists",
-			aptExists: true,
-			yumExists: false,
+			name:         "exhaustive combinations",
+			googetExists: true, aptExists: true, yumExists: true, zypperExists: true,
 			packages: []*agentendpointpb.Package{
-				{Name: "any-pkg", Manager: agentendpointpb.Package_ANY, DesiredState: agentendpointpb.DesiredState_INSTALLED},
-				{Name: "yum-pkg", Manager: agentendpointpb.Package_YUM, DesiredState: agentendpointpb.DesiredState_INSTALLED},
+				{Name: "any-inst", Manager: agentendpointpb.Package_ANY, DesiredState: agentendpointpb.DesiredState_INSTALLED},
+				{Name: "any-upd", Manager: agentendpointpb.Package_ANY, DesiredState: agentendpointpb.DesiredState_UPDATED},
+				{Name: "unspec-inst", Manager: agentendpointpb.Package_MANAGER_UNSPECIFIED, DesiredState: agentendpointpb.DesiredState_INSTALLED},
+				{Name: "goo-rem", Manager: agentendpointpb.Package_GOO, DesiredState: agentendpointpb.DesiredState_REMOVED},
+				{Name: "goo-upd", Manager: agentendpointpb.Package_GOO, DesiredState: agentendpointpb.DesiredState_UPDATED},
+				{Name: "apt-rem", Manager: agentendpointpb.Package_APT, DesiredState: agentendpointpb.DesiredState_REMOVED},
+				{Name: "yum-rem", Manager: agentendpointpb.Package_YUM, DesiredState: agentendpointpb.DesiredState_REMOVED},
+				{Name: "yum-upd", Manager: agentendpointpb.Package_YUM, DesiredState: agentendpointpb.DesiredState_UPDATED},
+				{Name: "zyp-rem", Manager: agentendpointpb.Package_ZYPPER, DesiredState: agentendpointpb.DesiredState_REMOVED},
 			},
-			wantAptInstalled: []string{"any-pkg"},
-			wantYumInstalled: nil,
-		},
-		{
-			name:      "unspecified manager defaults to all",
-			aptExists: true,
-			yumExists: true,
-			packages: []*agentendpointpb.Package{
-				{Name: "default-pkg", Manager: agentendpointpb.Package_MANAGER_UNSPECIFIED, DesiredState: agentendpointpb.DesiredState_INSTALLED},
+			wantCalls: map[string]managerCalls{
+				"googet": {install: []string{"any-inst", "unspec-inst"}, remove: []string{"goo-rem"}, update: []string{"any-upd", "goo-upd"}},
+				"apt":    {install: []string{"any-inst", "unspec-inst"}, remove: []string{"apt-rem"}, update: []string{"any-upd"}},
+				"yum":    {install: []string{"any-inst", "unspec-inst"}, remove: []string{"yum-rem"}, update: []string{"any-upd", "yum-upd"}},
+				"zypper": {install: []string{"any-inst", "unspec-inst"}, remove: []string{"zyp-rem"}, update: []string{"any-upd"}},
 			},
-			wantAptInstalled: []string{"default-pkg"},
-			wantYumInstalled: []string{"default-pkg"},
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			// Mock managers existence
-			oldAptExists := packages.AptExists
-			oldYumExists := packages.YumExists
-			packages.AptExists = tt.aptExists
-			packages.YumExists = tt.yumExists
-			defer func() {
-				packages.AptExists = oldAptExists
-				packages.YumExists = oldYumExists
-			}()
-
-			var aptInstalled, yumInstalled []string
-			// Mock Apt functions
-			oldAptRepos := aptRepositoriesFunc
-			oldAptChanges := aptChangesFunc
-			aptRepositoriesFunc = func(ctx context.Context, repos []*agentendpointpb.AptRepository, path string) error { return nil }
-			aptChangesFunc = func(ctx context.Context, install, remove, update []*agentendpointpb.Package) error {
-				for _, p := range install {
-					aptInstalled = append(aptInstalled, p.Name)
-				}
-				return nil
-			}
-			defer func() {
-				aptRepositoriesFunc = oldAptRepos
-				aptChangesFunc = oldAptChanges
-			}()
-
-			// Mock Yum functions
-			oldYumRepos := yumRepositoriesFunc
-			oldYumChanges := yumChangesFunc
-			yumRepositoriesFunc = func(ctx context.Context, repos []*agentendpointpb.YumRepository, path string) error { return nil }
-			yumChangesFunc = func(ctx context.Context, install, remove, update []*agentendpointpb.Package) error {
-				for _, p := range install {
-					yumInstalled = append(yumInstalled, p.Name)
-				}
-				return nil
-			}
-			defer func() {
-				yumRepositoriesFunc = oldYumRepos
-				yumChangesFunc = oldYumChanges
-			}()
+			gotCalls := make(map[string]*managerCalls)
+			defer setupMocks(tt.googetExists, tt.aptExists, tt.yumExists, tt.zypperExists, gotCalls)()
 
 			var sourcedPackages []*agentendpointpb.EffectiveGuestPolicy_SourcedPackage
 			for _, p := range tt.packages {
 				sourcedPackages = append(sourcedPackages, &agentendpointpb.EffectiveGuestPolicy_SourcedPackage{Package: p})
 			}
+			var sourcedRepos []*agentendpointpb.EffectiveGuestPolicy_SourcedPackageRepository
+			for _, r := range tt.repos {
+				sourcedRepos = append(sourcedRepos, &agentendpointpb.EffectiveGuestPolicy_SourcedPackageRepository{PackageRepository: r})
+			}
 
-			egp := &agentendpointpb.EffectiveGuestPolicy{Packages: sourcedPackages}
+			egp := &agentendpointpb.EffectiveGuestPolicy{Packages: sourcedPackages, PackageRepositories: sourcedRepos}
 
 			setConfig(ctx, egp)
 
-			if !reflect.DeepEqual(aptInstalled, tt.wantAptInstalled) {
-				t.Errorf("aptInstalled = %v, want %v", aptInstalled, tt.wantAptInstalled)
-			}
-			if !reflect.DeepEqual(yumInstalled, tt.wantYumInstalled) {
-				t.Errorf("yumInstalled = %v, want %v", yumInstalled, tt.wantYumInstalled)
+			for m, want := range tt.wantCalls {
+				got := gotCalls[m]
+				if got == nil {
+					got = &managerCalls{}
+				}
+				if !reflect.DeepEqual(got.install, want.install) {
+					t.Errorf("%s: install = %v, want %v", m, got.install, want.install)
+				}
+				if !reflect.DeepEqual(got.remove, want.remove) {
+					t.Errorf("%s: remove = %v, want %v", m, got.remove, want.remove)
+				}
+				if !reflect.DeepEqual(got.update, want.update) {
+					t.Errorf("%s: update = %v, want %v", m, got.update, want.update)
+				}
+				if got.repos != want.repos {
+					t.Errorf("%s: repos = %d, want %d", m, got.repos, want.repos)
+				}
 			}
 		})
 	}
+}
+
+// TestSetConfigErrors verifies that setConfig handles errors from repository and package operations without panicking.
+func TestSetConfigErrors(t *testing.T) {
+	ctx := context.Background()
+
+	gotCalls := make(map[string]*managerCalls)
+	defer setupMocks(false, true, false, false, gotCalls)()
+
+	// Overwrite some mocks to return errors
+	oldAptRepos := aptRepositoriesFunc
+	oldAptChanges := aptChangesFunc
+	aptRepositoriesFunc = func(ctx context.Context, repos []*agentendpointpb.AptRepository, path string) error {
+		return errors.New("repo error")
+	}
+	aptChangesFunc = func(ctx context.Context, install, remove, update []*agentendpointpb.Package) error {
+		return errors.New("changes error")
+	}
+	defer func() {
+		aptRepositoriesFunc = oldAptRepos
+		aptChangesFunc = oldAptChanges
+	}()
+
+	egp := &agentendpointpb.EffectiveGuestPolicy{
+		PackageRepositories: []*agentendpointpb.EffectiveGuestPolicy_SourcedPackageRepository{
+			{PackageRepository: &agentendpointpb.PackageRepository{Repository: &agentendpointpb.PackageRepository_Apt{Apt: &agentendpointpb.AptRepository{}}}},
+		},
+		Packages: []*agentendpointpb.EffectiveGuestPolicy_SourcedPackage{
+			{Package: &agentendpointpb.Package{Name: "pkg", Manager: agentendpointpb.Package_APT, DesiredState: agentendpointpb.DesiredState_INSTALLED}},
+		},
+	}
+
+	// This should run without panic even if errors occur (errors are logged)
+	setConfig(ctx, egp)
 }

--- a/policies/policies_test.go
+++ b/policies/policies_test.go
@@ -1,0 +1,281 @@
+//  Copyright 2026 Google Inc. All Rights Reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
+package policies
+
+import (
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"os"
+	"path/filepath"
+	"reflect"
+	"testing"
+
+	"cloud.google.com/go/osconfig/agentendpoint/apiv1beta/agentendpointpb"
+	"github.com/GoogleCloudPlatform/osconfig/packages"
+	"github.com/GoogleCloudPlatform/osconfig/util/utiltest"
+)
+
+// TestChecksum verifies that checksum correctly calculates the SHA256 hash of the input reader.
+func TestChecksum(t *testing.T) {
+	tests := []struct {
+		name string
+		data []byte
+	}{
+		{
+			name: "basic string",
+			data: []byte("test data"),
+		},
+		{
+			name: "empty string",
+			data: []byte(""),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := bytes.NewReader(tt.data)
+			h := checksum(r)
+
+			expected := sha256.Sum256(tt.data)
+			got := h.Sum(nil)
+
+			if !bytes.Equal(got, expected[:]) {
+				t.Errorf("checksum() = %x, want %x", got, expected)
+			}
+		})
+	}
+}
+
+// TestWriteIfChanged verifies that writeIfChanged only writes to the file if the content has changed.
+func TestWriteIfChanged(t *testing.T) {
+	ctx := context.Background()
+
+	tests := []struct {
+		name           string
+		initialContent []byte
+		newContent     []byte
+		wantErr        error
+	}{
+		{
+			name:       "new file creation",
+			newContent: []byte("content 1"),
+			wantErr:    nil,
+		},
+		{
+			name:           "no change",
+			initialContent: []byte("content 1"),
+			newContent:     []byte("content 1"),
+			wantErr:        nil,
+		},
+		{
+			name:           "content update",
+			initialContent: []byte("content 1"),
+			newContent:     []byte("content 2"),
+			wantErr:        nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			td := t.TempDir()
+			path := filepath.Join(td, "test_file")
+
+			if tt.initialContent != nil {
+				if err := os.WriteFile(path, tt.initialContent, 0644); err != nil {
+					t.Fatalf("failed to setup initial file: %v", err)
+				}
+			}
+
+			err := writeIfChanged(ctx, tt.newContent, path)
+			utiltest.AssertErrorMatch(t, err, tt.wantErr)
+
+			if err == nil {
+				got, err := os.ReadFile(path)
+				if err != nil {
+					t.Fatalf("failed to read file after test: %v", err)
+				}
+				if !bytes.Equal(got, tt.newContent) {
+					t.Errorf("file content = %q, want %q", string(got), string(tt.newContent))
+				}
+			}
+		})
+	}
+}
+
+// TestInstallRecipes verifies that installRecipes iterates over all recipes and calls the install function.
+func TestInstallRecipes(t *testing.T) {
+	ctx := context.Background()
+
+	tests := []struct {
+		name     string
+		recipes  []*agentendpointpb.SoftwareRecipe
+		wantInst []string
+	}{
+		{
+			name: "multiple recipes",
+			recipes: []*agentendpointpb.SoftwareRecipe{
+				{Name: "recipe1"},
+				{Name: "recipe2"},
+			},
+			wantInst: []string{"recipe1", "recipe2"},
+		},
+		{
+			name:     "no recipes",
+			recipes:  nil,
+			wantInst: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var installed []string
+			oldInstallRecipe := installRecipe
+			installRecipe = func(ctx context.Context, recipe *agentendpointpb.SoftwareRecipe) error {
+				installed = append(installed, recipe.Name)
+				return nil
+			}
+			defer func() { installRecipe = oldInstallRecipe }()
+
+			var sourcedRecipes []*agentendpointpb.EffectiveGuestPolicy_SourcedSoftwareRecipe
+			for _, r := range tt.recipes {
+				sourcedRecipes = append(sourcedRecipes, &agentendpointpb.EffectiveGuestPolicy_SourcedSoftwareRecipe{
+					SoftwareRecipe: r,
+				})
+			}
+
+			egp := &agentendpointpb.EffectiveGuestPolicy{
+				SoftwareRecipes: sourcedRecipes,
+			}
+
+			if err := installRecipes(ctx, egp); err != nil {
+				t.Fatalf("installRecipes() error = %v", err)
+			}
+
+			if !reflect.DeepEqual(installed, tt.wantInst) {
+				t.Errorf("installed recipes = %v, want %v", installed, tt.wantInst)
+			}
+		})
+	}
+}
+
+// TestSetConfig verifies that setConfig correctly distributes packages to different managers.
+func TestSetConfig(t *testing.T) {
+	ctx := context.Background()
+
+	tests := []struct {
+		name             string
+		aptExists        bool
+		yumExists        bool
+		packages         []*agentendpointpb.Package
+		wantAptInstalled []string
+		wantYumInstalled []string
+	}{
+		{
+			name:      "mixed managers and packages",
+			aptExists: true,
+			yumExists: true,
+			packages: []*agentendpointpb.Package{
+				{Name: "any-pkg", Manager: agentendpointpb.Package_ANY, DesiredState: agentendpointpb.DesiredState_INSTALLED},
+				{Name: "apt-pkg", Manager: agentendpointpb.Package_APT, DesiredState: agentendpointpb.DesiredState_INSTALLED},
+				{Name: "yum-pkg", Manager: agentendpointpb.Package_YUM, DesiredState: agentendpointpb.DesiredState_INSTALLED},
+			},
+			wantAptInstalled: []string{"any-pkg", "apt-pkg"},
+			wantYumInstalled: []string{"any-pkg", "yum-pkg"},
+		},
+		{
+			name:      "only apt manager exists",
+			aptExists: true,
+			yumExists: false,
+			packages: []*agentendpointpb.Package{
+				{Name: "any-pkg", Manager: agentendpointpb.Package_ANY, DesiredState: agentendpointpb.DesiredState_INSTALLED},
+				{Name: "yum-pkg", Manager: agentendpointpb.Package_YUM, DesiredState: agentendpointpb.DesiredState_INSTALLED},
+			},
+			wantAptInstalled: []string{"any-pkg"},
+			wantYumInstalled: nil,
+		},
+		{
+			name:      "unspecified manager defaults to all",
+			aptExists: true,
+			yumExists: true,
+			packages: []*agentendpointpb.Package{
+				{Name: "default-pkg", Manager: agentendpointpb.Package_MANAGER_UNSPECIFIED, DesiredState: agentendpointpb.DesiredState_INSTALLED},
+			},
+			wantAptInstalled: []string{"default-pkg"},
+			wantYumInstalled: []string{"default-pkg"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Mock managers existence
+			oldAptExists := packages.AptExists
+			oldYumExists := packages.YumExists
+			packages.AptExists = tt.aptExists
+			packages.YumExists = tt.yumExists
+			defer func() {
+				packages.AptExists = oldAptExists
+				packages.YumExists = oldYumExists
+			}()
+
+			var aptInstalled, yumInstalled []string
+			// Mock Apt functions
+			oldAptRepos := aptRepositoriesFunc
+			oldAptChanges := aptChangesFunc
+			aptRepositoriesFunc = func(ctx context.Context, repos []*agentendpointpb.AptRepository, path string) error { return nil }
+			aptChangesFunc = func(ctx context.Context, install, remove, update []*agentendpointpb.Package) error {
+				for _, p := range install {
+					aptInstalled = append(aptInstalled, p.Name)
+				}
+				return nil
+			}
+			defer func() {
+				aptRepositoriesFunc = oldAptRepos
+				aptChangesFunc = oldAptChanges
+			}()
+
+			// Mock Yum functions
+			oldYumRepos := yumRepositoriesFunc
+			oldYumChanges := yumChangesFunc
+			yumRepositoriesFunc = func(ctx context.Context, repos []*agentendpointpb.YumRepository, path string) error { return nil }
+			yumChangesFunc = func(ctx context.Context, install, remove, update []*agentendpointpb.Package) error {
+				for _, p := range install {
+					yumInstalled = append(yumInstalled, p.Name)
+				}
+				return nil
+			}
+			defer func() {
+				yumRepositoriesFunc = oldYumRepos
+				yumChangesFunc = oldYumChanges
+			}()
+
+			var sourcedPackages []*agentendpointpb.EffectiveGuestPolicy_SourcedPackage
+			for _, p := range tt.packages {
+				sourcedPackages = append(sourcedPackages, &agentendpointpb.EffectiveGuestPolicy_SourcedPackage{Package: p})
+			}
+
+			egp := &agentendpointpb.EffectiveGuestPolicy{Packages: sourcedPackages}
+
+			setConfig(ctx, egp)
+
+			if !reflect.DeepEqual(aptInstalled, tt.wantAptInstalled) {
+				t.Errorf("aptInstalled = %v, want %v", aptInstalled, tt.wantAptInstalled)
+			}
+			if !reflect.DeepEqual(yumInstalled, tt.wantYumInstalled) {
+				t.Errorf("yumInstalled = %v, want %v", yumInstalled, tt.wantYumInstalled)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Current test coverage:

github.com/GoogleCloudPlatform/osconfig/policies/policies.go:39:	run			0.0%
github.com/GoogleCloudPlatform/osconfig/policies/policies.go:66:	Run			0.0%
github.com/GoogleCloudPlatform/osconfig/policies/policies.go:85:	installRecipes		100.0%
github.com/GoogleCloudPlatform/osconfig/policies/policies.go:96:	setConfig		90.8%
github.com/GoogleCloudPlatform/osconfig/policies/policies.go:229:	checksum		100.0%
github.com/GoogleCloudPlatform/osconfig/policies/policies.go:235:	writeIfChanged		91.7%