### PR TITLE
Change zone for el9-arm64 cloud build

### DIFF
--- a/packagebuild/workflows/build_el8_arm64.wf.json
+++ b/packagebuild/workflows/build_el8_arm64.wf.json
@@ -35,7 +35,7 @@
           "git_ref": "${git_ref}",
           "build_dir": "${build_dir}",
           "machine_type": "t2a-standard-2",
-          "zone": "us-central1-a",
+          "zone": "us-central1-b",
           "version": "${version}"
         }
       }

--- a/packagebuild/workflows/build_el9_arm64.wf.json
+++ b/packagebuild/workflows/build_el9_arm64.wf.json
@@ -35,7 +35,7 @@
           "git_ref": "${git_ref}",
           "build_dir": "${build_dir}",
           "machine_type": "t2a-standard-2",
-          "zone": "us-central1-a",
+          "zone": "us-central1-b",
           "version": "${version}"
         }
       }

--- a/packagebuild/workflows/build_package.wf.json
+++ b/packagebuild/workflows/build_package.wf.json
@@ -37,7 +37,7 @@
       "Description": "machine type"
     },
     "zone": {
-      "Value": "us-central1-a",
+      "Value": "us-central1-b",
       "Description": "zone"
     }
   },


### PR DESCRIPTION
Google Cloud Build for el9-arm64 is failing because of resource stockout in us-central1-a zone. I want to try changing the zone to see if it will unblock presubmits.