### PR TITLE
Change disk size for deb11

### DIFF
--- a/packagebuild/test_build.sh
+++ b/packagebuild/test_build.sh
@@ -24,7 +24,7 @@
 
 DEFAULT_TYPE='deb11'
 DEFAULT_PROJECT='gcp-guest'
-DEFAULT_ZONE='us-west1-a'
+DEFAULT_ZONE='us-central1-a'
 DEFAULT_OWNER='GoogleCloudPlatform'
 DEFAULT_GIT_REF='master'
 DEFAULT_GCS_PATH='${SCRATCHPATH}/packages'

--- a/packagebuild/workflows/build_deb12_arm64.wf.json
+++ b/packagebuild/workflows/build_deb12_arm64.wf.json
@@ -35,7 +35,7 @@
           "git_ref": "${git_ref}",
           "build_dir": "${build_dir}",
           "machine_type": "c4a-standard-2",
-	  "disk_type": "hyperdisk-balanced",
+          "disk_type": "hyperdisk-balanced",
           "zone": "us-central1-a",
           "version": "${version}"
         }

--- a/packagebuild/workflows/build_deb13_arm64.wf.json
+++ b/packagebuild/workflows/build_deb13_arm64.wf.json
@@ -35,7 +35,7 @@
           "git_ref": "${git_ref}",
           "build_dir": "${build_dir}",
           "machine_type": "c4a-standard-2",
-	  "disk_type": "hyperdisk-balanced",
+          "disk_type": "hyperdisk-balanced",
           "zone": "us-central1-a",
           "version": "${version}"
         }

--- a/packagebuild/workflows/build_el10_arm64.wf.json
+++ b/packagebuild/workflows/build_el10_arm64.wf.json
@@ -35,7 +35,7 @@
           "git_ref": "${git_ref}",
           "build_dir": "${build_dir}",
           "machine_type": "c4a-standard-2",
-	  "disk_type": "hyperdisk-balanced",
+          "disk_type": "hyperdisk-balanced",
           "zone": "us-central1-a",
           "version": "${version}"
         }

--- a/packagebuild/workflows/build_el8_arm64.wf.json
+++ b/packagebuild/workflows/build_el8_arm64.wf.json
@@ -35,7 +35,7 @@
           "git_ref": "${git_ref}",
           "build_dir": "${build_dir}",
           "machine_type": "c4a-standard-2",
-	  "disk_type": "hyperdisk-balanced",
+          "disk_type": "hyperdisk-balanced",
           "zone": "us-central1-a",
           "version": "${version}"
         }

--- a/packagebuild/workflows/build_el9_arm64.wf.json
+++ b/packagebuild/workflows/build_el9_arm64.wf.json
@@ -35,7 +35,7 @@
           "git_ref": "${git_ref}",
           "build_dir": "${build_dir}",
           "machine_type": "c4a-standard-2",
-	  "disk_type": "hyperdisk-balanced",
+          "disk_type": "hyperdisk-balanced",
           "zone": "us-central1-a",
           "version": "${version}"
         }

--- a/packagebuild/workflows/build_package.wf.json
+++ b/packagebuild/workflows/build_package.wf.json
@@ -44,18 +44,29 @@
        "Value": "pd-ssd",
        "Description": "Type of the disk used in the workflow."
 
+    },
+    "disk_size_gb": {
+      "Value": "20",
+      "Description": "Size of the disk in GB."
     }
   },
   "Steps": {
+    "create-disks": {
+      "CreateDisks": [
+        {
+          "name": "inst-build-pkg-disk",
+          "sizeGb": "${disk_size_gb}",
+          "sourceImage": "${sourceImage}",
+          "type": "${disk_type}"
+        }
+      ]
+    },
     "build-packages": {
       "CreateInstances": [
         {
           "disks": [
             {
-              "initializeParams": {
-                "diskType": "${disk_type}",
-                "sourceImage": "${sourceImage}"
-              }
+              "source": "inst-build-pkg-disk"
             }
           ],
           "Metadata": {
@@ -96,6 +107,7 @@
     }
   },
   "Dependencies": {
+    "build-packages": ["create-disks"],
     "wait-for-build": [
       "build-packages"
     ],


### PR DESCRIPTION
Deb11 presubmits are failing because of no disk space left. Let's try bigger disk size