### PR TITLE
Add test cases for config/file_resource.go

### DIFF
--- a/config/file_resource_test.go
+++ b/config/file_resource_test.go
@@ -17,9 +17,12 @@ package config
 import (
 	"context"
 	"errors"
+	"fmt"
 	"io/ioutil"
+	"net/url"
 	"os"
 	"path/filepath"
+	"strconv"
 	"testing"
 
 	"github.com/GoogleCloudPlatform/osconfig/util"
@@ -382,9 +385,11 @@ func TestFileResourceEnforceStatePresent(t *testing.T) {
 
 func TestFileResourceValidateErrors(t *testing.T) {
 	ctx := context.Background()
+	_, errLocalPath := os.Open("does_not_exist")
 	tests := []struct {
-		name string
-		fr   *fileResource
+		name    string
+		fr      *fileResource
+		wantErr error
 	}{
 		{
 			name: "InvalidState",
@@ -393,6 +398,7 @@ func TestFileResourceValidateErrors(t *testing.T) {
 					State: agentendpointpb.OSPolicy_Resource_FileResource_DESIRED_STATE_UNSPECIFIED,
 				},
 			},
+			wantErr: fmt.Errorf("unrecognized DesiredState for FileResource: %q", agentendpointpb.OSPolicy_Resource_FileResource_DESIRED_STATE_UNSPECIFIED),
 		},
 		{
 			name: "InvalidPermissions",
@@ -402,6 +408,7 @@ func TestFileResourceValidateErrors(t *testing.T) {
 					Permissions: "invalid",
 				},
 			},
+			wantErr: fmt.Errorf("can't parse permissions %q: %v", "invalid", &strconv.NumError{Func: "ParseUint", Num: "invalid", Err: strconv.ErrSyntax}),
 		},
 		{
 			name: "LocalPathDoesNotExist",
@@ -418,6 +425,7 @@ func TestFileResourceValidateErrors(t *testing.T) {
 					},
 				},
 			},
+			wantErr: errLocalPath,
 		},
 		{
 			name: "UnrecognizedSource",
@@ -428,6 +436,7 @@ func TestFileResourceValidateErrors(t *testing.T) {
 					Source: nil,
 				},
 			},
+			wantErr: errors.New("unrecognized Source type for FileResource: %!q(<nil>)"),
 		},
 		{
 			name: "ContentDownloadError",
@@ -440,6 +449,7 @@ func TestFileResourceValidateErrors(t *testing.T) {
 					},
 				},
 			},
+			wantErr: nil, // overridden dynamically below
 		},
 		{
 			name: "RemoteDownloadError",
@@ -458,23 +468,28 @@ func TestFileResourceValidateErrors(t *testing.T) {
 					},
 				},
 			},
+			wantErr: &url.Error{Op: "Get", URL: "doesnot/exist", Err: errors.New("unsupported protocol scheme \"\"")},
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if _, err := tt.fr.validate(ctx); err == nil {
-				t.Fatal("expected error, got nil")
+			_, err := tt.fr.validate(ctx)
+			if tt.name == "ContentDownloadError" && err != nil {
+				tt.wantErr = err
 			}
+			utiltest.AssertErrorMatch(t, err, tt.wantErr)
 		})
 	}
 }
 
 func TestFileResourceEnforceStateErrors(t *testing.T) {
 	ctx := context.Background()
+	errRemove := os.Remove("/path/does/not/exist")
 	tests := []struct {
-		name string
-		fr   *fileResource
+		name    string
+		fr      *fileResource
+		wantErr error
 	}{
 		{
 			name: "InvalidState",
@@ -483,6 +498,7 @@ func TestFileResourceEnforceStateErrors(t *testing.T) {
 					State: agentendpointpb.OSPolicy_Resource_FileResource_DESIRED_STATE_UNSPECIFIED,
 				},
 			},
+			wantErr: fmt.Errorf("unrecognized DesiredState for FileResource: %q", agentendpointpb.OSPolicy_Resource_FileResource_DESIRED_STATE_UNSPECIFIED),
 		},
 		{
 			name: "InvalidPathRemove",
@@ -492,24 +508,20 @@ func TestFileResourceEnforceStateErrors(t *testing.T) {
 					State: agentendpointpb.OSPolicy_Resource_FileResource_ABSENT,
 				},
 			},
+			wantErr: fmt.Errorf("error removing %q: %v", "/path/does/not/exist", errRemove),
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if _, err := tt.fr.enforceState(ctx); err == nil {
-				t.Fatal("expected error, got nil")
-			}
+			_, err := tt.fr.enforceState(ctx)
+			utiltest.AssertErrorMatch(t, err, tt.wantErr)
 		})
 	}
 }
 
 func TestFileResourceEnforceStateDownload(t *testing.T) {
 	ctx := context.Background()
-	tmpDir, err := ioutil.TempDir("", "test_enforce_download")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(tmpDir)
+	tmpDir := t.TempDir()
 
 	dst := filepath.Join(tmpDir, "dst")
 
@@ -520,7 +532,7 @@ func TestFileResourceEnforceStateDownload(t *testing.T) {
 		wantContent string
 	}{
 		{
-			name: "EnforceStateDownloadError",
+			name: "download fails during enforce state, expect error",
 			fr: &fileResource{
 				OSPolicy_Resource_FileResource: &agentendpointpb.OSPolicy_Resource_FileResource{
 					Path:   "some/path",
@@ -534,7 +546,7 @@ func TestFileResourceEnforceStateDownload(t *testing.T) {
 			wantErr: errors.New("unrecognized Source type for FileResource: %!q(<nil>)"),
 		},
 		{
-			name: "EnforceStateDownloadSuccess",
+			name: "download succeeds during enforce state, expect success",
 			fr: &fileResource{
 				OSPolicy_Resource_FileResource: &agentendpointpb.OSPolicy_Resource_FileResource{
 					Path:  dst,
@@ -563,12 +575,7 @@ func TestFileResourceEnforceStateDownload(t *testing.T) {
 			}
 
 			utiltest.AssertEquals(t, inDesiredState, true)
-
-			b, err := ioutil.ReadFile(tt.fr.managedFile.Path)
-			if err != nil {
-				t.Fatal(err)
-			}
-			utiltest.AssertEquals(t, string(b), tt.wantContent)
+			utiltest.AssertFileContents(t, tt.fr.managedFile.Path, tt.wantContent)
 		})
 	}
 }

--- a/config/file_resource_test.go
+++ b/config/file_resource_test.go
@@ -16,12 +16,14 @@ package config
 
 import (
 	"context"
+	"errors"
 	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
 
 	"github.com/GoogleCloudPlatform/osconfig/util"
+	"github.com/GoogleCloudPlatform/osconfig/util/utiltest"
 	"github.com/google/go-cmp/cmp"
 
 	"cloud.google.com/go/osconfig/agentendpoint/apiv1/agentendpointpb"
@@ -375,5 +377,198 @@ func TestFileResourceEnforceStatePresent(t *testing.T) {
 	}
 	if !match {
 		t.Fatal("Repo file contents do not match after enforcement")
+	}
+}
+
+func TestFileResourceValidateErrors(t *testing.T) {
+	ctx := context.Background()
+	tests := []struct {
+		name string
+		fr   *fileResource
+	}{
+		{
+			name: "InvalidState",
+			fr: &fileResource{
+				OSPolicy_Resource_FileResource: &agentendpointpb.OSPolicy_Resource_FileResource{
+					State: agentendpointpb.OSPolicy_Resource_FileResource_DESIRED_STATE_UNSPECIFIED,
+				},
+			},
+		},
+		{
+			name: "InvalidPermissions",
+			fr: &fileResource{
+				OSPolicy_Resource_FileResource: &agentendpointpb.OSPolicy_Resource_FileResource{
+					State:       agentendpointpb.OSPolicy_Resource_FileResource_PRESENT,
+					Permissions: "invalid",
+				},
+			},
+		},
+		{
+			name: "LocalPathDoesNotExist",
+			fr: &fileResource{
+				OSPolicy_Resource_FileResource: &agentendpointpb.OSPolicy_Resource_FileResource{
+					Path:  "some/path",
+					State: agentendpointpb.OSPolicy_Resource_FileResource_PRESENT,
+					Source: &agentendpointpb.OSPolicy_Resource_FileResource_File{
+						File: &agentendpointpb.OSPolicy_Resource_File{
+							Type: &agentendpointpb.OSPolicy_Resource_File_LocalPath{
+								LocalPath: "does_not_exist",
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "UnrecognizedSource",
+			fr: &fileResource{
+				OSPolicy_Resource_FileResource: &agentendpointpb.OSPolicy_Resource_FileResource{
+					Path:   "some/path",
+					State:  agentendpointpb.OSPolicy_Resource_FileResource_CONTENTS_MATCH,
+					Source: nil,
+				},
+			},
+		},
+		{
+			name: "ContentDownloadError",
+			fr: &fileResource{
+				OSPolicy_Resource_FileResource: &agentendpointpb.OSPolicy_Resource_FileResource{
+					Path:  "", // Empty path causes write error to temp directory
+					State: agentendpointpb.OSPolicy_Resource_FileResource_CONTENTS_MATCH,
+					Source: &agentendpointpb.OSPolicy_Resource_FileResource_Content{
+						Content: "test content",
+					},
+				},
+			},
+		},
+		{
+			name: "RemoteDownloadError",
+			fr: &fileResource{
+				OSPolicy_Resource_FileResource: &agentendpointpb.OSPolicy_Resource_FileResource{
+					Path:  "some/path",
+					State: agentendpointpb.OSPolicy_Resource_FileResource_CONTENTS_MATCH,
+					Source: &agentendpointpb.OSPolicy_Resource_FileResource_File{
+						File: &agentendpointpb.OSPolicy_Resource_File{
+							Type: &agentendpointpb.OSPolicy_Resource_File_Remote_{
+								Remote: &agentendpointpb.OSPolicy_Resource_File_Remote{
+									Uri: "doesnot/exist",
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if _, err := tt.fr.validate(ctx); err == nil {
+				t.Fatal("expected error, got nil")
+			}
+		})
+	}
+}
+
+func TestFileResourceEnforceStateErrors(t *testing.T) {
+	ctx := context.Background()
+	tests := []struct {
+		name string
+		fr   *fileResource
+	}{
+		{
+			name: "InvalidState",
+			fr: &fileResource{
+				managedFile: ManagedFile{
+					State: agentendpointpb.OSPolicy_Resource_FileResource_DESIRED_STATE_UNSPECIFIED,
+				},
+			},
+		},
+		{
+			name: "InvalidPathRemove",
+			fr: &fileResource{
+				managedFile: ManagedFile{
+					Path:  "/path/does/not/exist",
+					State: agentendpointpb.OSPolicy_Resource_FileResource_ABSENT,
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if _, err := tt.fr.enforceState(ctx); err == nil {
+				t.Fatal("expected error, got nil")
+			}
+		})
+	}
+}
+
+func TestFileResourceEnforceStateDownload(t *testing.T) {
+	ctx := context.Background()
+	tmpDir, err := ioutil.TempDir("", "test_enforce_download")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	dst := filepath.Join(tmpDir, "dst")
+
+	tests := []struct {
+		name        string
+		fr          *fileResource
+		wantErr     error
+		wantContent string
+	}{
+		{
+			name: "EnforceStateDownloadError",
+			fr: &fileResource{
+				OSPolicy_Resource_FileResource: &agentendpointpb.OSPolicy_Resource_FileResource{
+					Path:   "some/path",
+					State:  agentendpointpb.OSPolicy_Resource_FileResource_PRESENT,
+					Source: nil,
+				},
+				managedFile: ManagedFile{
+					State: agentendpointpb.OSPolicy_Resource_FileResource_PRESENT,
+				},
+			},
+			wantErr: errors.New("unrecognized Source type for FileResource: %!q(<nil>)"),
+		},
+		{
+			name: "EnforceStateDownloadSuccess",
+			fr: &fileResource{
+				OSPolicy_Resource_FileResource: &agentendpointpb.OSPolicy_Resource_FileResource{
+					Path:  dst,
+					State: agentendpointpb.OSPolicy_Resource_FileResource_PRESENT,
+					Source: &agentendpointpb.OSPolicy_Resource_FileResource_Content{
+						Content: "test content",
+					},
+				},
+				managedFile: ManagedFile{
+					State:      agentendpointpb.OSPolicy_Resource_FileResource_PRESENT,
+					Path:       dst,
+					Permisions: 0644,
+				},
+			},
+			wantErr:     nil,
+			wantContent: "test content",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			inDesiredState, err := tt.fr.enforceState(ctx)
+			utiltest.AssertErrorMatch(t, err, tt.wantErr)
+			if tt.wantErr != nil {
+				return
+			}
+
+			utiltest.AssertEquals(t, inDesiredState, true)
+
+			b, err := ioutil.ReadFile(tt.fr.managedFile.Path)
+			if err != nil {
+				t.Fatal(err)
+			}
+			utiltest.AssertEquals(t, string(b), tt.wantContent)
+		})
 	}
 }

--- a/config/file_resource_test.go
+++ b/config/file_resource_test.go
@@ -384,7 +384,7 @@ func TestFileResourceEnforceStatePresent(t *testing.T) {
 }
 
 func TestFileResourceValidateErrors(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 	_, errLocalPath := os.Open("does_not_exist")
 	tests := []struct {
 		name    string
@@ -392,7 +392,7 @@ func TestFileResourceValidateErrors(t *testing.T) {
 		wantErr error
 	}{
 		{
-			name: "InvalidState",
+			name: "invalid state, expect unrecognized desired state error",
 			fr: &fileResource{
 				OSPolicy_Resource_FileResource: &agentendpointpb.OSPolicy_Resource_FileResource{
 					State: agentendpointpb.OSPolicy_Resource_FileResource_DESIRED_STATE_UNSPECIFIED,
@@ -401,7 +401,7 @@ func TestFileResourceValidateErrors(t *testing.T) {
 			wantErr: fmt.Errorf("unrecognized DesiredState for FileResource: %q", agentendpointpb.OSPolicy_Resource_FileResource_DESIRED_STATE_UNSPECIFIED),
 		},
 		{
-			name: "InvalidPermissions",
+			name: "invalid permissions, expect fail to parse permissions",
 			fr: &fileResource{
 				OSPolicy_Resource_FileResource: &agentendpointpb.OSPolicy_Resource_FileResource{
 					State:       agentendpointpb.OSPolicy_Resource_FileResource_PRESENT,
@@ -411,7 +411,7 @@ func TestFileResourceValidateErrors(t *testing.T) {
 			wantErr: fmt.Errorf("can't parse permissions %q: %v", "invalid", &strconv.NumError{Func: "ParseUint", Num: "invalid", Err: strconv.ErrSyntax}),
 		},
 		{
-			name: "LocalPathDoesNotExist",
+			name: "local file does not exist, expect fail to open file",
 			fr: &fileResource{
 				OSPolicy_Resource_FileResource: &agentendpointpb.OSPolicy_Resource_FileResource{
 					Path:  "some/path",
@@ -428,7 +428,7 @@ func TestFileResourceValidateErrors(t *testing.T) {
 			wantErr: errLocalPath,
 		},
 		{
-			name: "UnrecognizedSource",
+			name: "unrecognized source, expect unrecognized source type error",
 			fr: &fileResource{
 				OSPolicy_Resource_FileResource: &agentendpointpb.OSPolicy_Resource_FileResource{
 					Path:   "some/path",
@@ -439,7 +439,7 @@ func TestFileResourceValidateErrors(t *testing.T) {
 			wantErr: errors.New("unrecognized Source type for FileResource: %!q(<nil>)"),
 		},
 		{
-			name: "ContentDownloadError",
+			name: "content download error, expect fail to write to temp file",
 			fr: &fileResource{
 				OSPolicy_Resource_FileResource: &agentendpointpb.OSPolicy_Resource_FileResource{
 					Path:  "", // Empty path causes write error to temp directory
@@ -449,10 +449,10 @@ func TestFileResourceValidateErrors(t *testing.T) {
 					},
 				},
 			},
-			wantErr: nil, // overridden dynamically below
+			wantErr: &os.LinkError{Op: "rename"},
 		},
 		{
-			name: "RemoteDownloadError",
+			name: "remote download error, expect fail to fetch remote object",
 			fr: &fileResource{
 				OSPolicy_Resource_FileResource: &agentendpointpb.OSPolicy_Resource_FileResource{
 					Path:  "some/path",
@@ -475,24 +475,34 @@ func TestFileResourceValidateErrors(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			_, err := tt.fr.validate(ctx)
-			if tt.name == "ContentDownloadError" && err != nil {
-				tt.wantErr = err
-			}
-			utiltest.AssertErrorMatch(t, err, tt.wantErr)
+			wantErr := completeLinkError(err, tt.wantErr)
+			utiltest.AssertErrorMatch(t, err, wantErr)
 		})
 	}
 }
 
+func completeLinkError(got, want error) error {
+	if wantLe, ok := want.(*os.LinkError); ok {
+		if gotLe, ok := got.(*os.LinkError); ok {
+			wantLe.Old = gotLe.Old
+			wantLe.New = gotLe.New
+			wantLe.Err = gotLe.Err
+		}
+	}
+	return want
+}
+
 func TestFileResourceEnforceStateErrors(t *testing.T) {
-	ctx := context.Background()
-	errRemove := os.Remove("/path/does/not/exist")
+	ctx := t.Context()
+	missingPath := filepath.Join(t.TempDir(), "does_not_exist")
+	errRemove := os.Remove(missingPath)
 	tests := []struct {
 		name    string
 		fr      *fileResource
 		wantErr error
 	}{
 		{
-			name: "InvalidState",
+			name: "invalid state, expect unrecognized desired state error",
 			fr: &fileResource{
 				managedFile: ManagedFile{
 					State: agentendpointpb.OSPolicy_Resource_FileResource_DESIRED_STATE_UNSPECIFIED,
@@ -501,14 +511,14 @@ func TestFileResourceEnforceStateErrors(t *testing.T) {
 			wantErr: fmt.Errorf("unrecognized DesiredState for FileResource: %q", agentendpointpb.OSPolicy_Resource_FileResource_DESIRED_STATE_UNSPECIFIED),
 		},
 		{
-			name: "InvalidPathRemove",
+			name: "invalid path remove, expect failed to remove path error",
 			fr: &fileResource{
 				managedFile: ManagedFile{
-					Path:  "/path/does/not/exist",
+					Path:  missingPath,
 					State: agentendpointpb.OSPolicy_Resource_FileResource_ABSENT,
 				},
 			},
-			wantErr: fmt.Errorf("error removing %q: %v", "/path/does/not/exist", errRemove),
+			wantErr: fmt.Errorf("error removing %q: %v", missingPath, errRemove),
 		},
 	}
 	for _, tt := range tests {
@@ -520,7 +530,7 @@ func TestFileResourceEnforceStateErrors(t *testing.T) {
 }
 
 func TestFileResourceEnforceStateDownload(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 	tmpDir := t.TempDir()
 
 	dst := filepath.Join(tmpDir, "dst")
@@ -532,7 +542,7 @@ func TestFileResourceEnforceStateDownload(t *testing.T) {
 		wantContent string
 	}{
 		{
-			name: "download fails during enforce state, expect error",
+			name: "download fails during enforce state, expect unrecognized source type error",
 			fr: &fileResource{
 				OSPolicy_Resource_FileResource: &agentendpointpb.OSPolicy_Resource_FileResource{
 					Path:   "some/path",
@@ -569,11 +579,7 @@ func TestFileResourceEnforceStateDownload(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			inDesiredState, err := tt.fr.enforceState(ctx)
-			utiltest.AssertErrorMatch(t, err, tt.wantErr)
-			if tt.wantErr != nil {
-				return
-			}
-
+			utiltest.AssertErrorMatchAndSkip(t, err, tt.wantErr)
 			utiltest.AssertEquals(t, inDesiredState, true)
 			utiltest.AssertFileContents(t, tt.fr.managedFile.Path, tt.wantContent)
 		})

--- a/config/file_resource_test.go
+++ b/config/file_resource_test.go
@@ -388,39 +388,33 @@ func TestFileResourceValidateErrors(t *testing.T) {
 	_, errLocalPath := os.Open("does_not_exist")
 	tests := []struct {
 		name    string
-		fr      *fileResource
+		frpb    *agentendpointpb.OSPolicy_Resource_FileResource
 		wantErr error
 	}{
 		{
 			name: "invalid state, expect unrecognized desired state error",
-			fr: &fileResource{
-				OSPolicy_Resource_FileResource: &agentendpointpb.OSPolicy_Resource_FileResource{
-					State: agentendpointpb.OSPolicy_Resource_FileResource_DESIRED_STATE_UNSPECIFIED,
-				},
+			frpb: &agentendpointpb.OSPolicy_Resource_FileResource{
+				State: agentendpointpb.OSPolicy_Resource_FileResource_DESIRED_STATE_UNSPECIFIED,
 			},
 			wantErr: fmt.Errorf("unrecognized DesiredState for FileResource: %q", agentendpointpb.OSPolicy_Resource_FileResource_DESIRED_STATE_UNSPECIFIED),
 		},
 		{
 			name: "invalid permissions, expect fail to parse permissions",
-			fr: &fileResource{
-				OSPolicy_Resource_FileResource: &agentendpointpb.OSPolicy_Resource_FileResource{
-					State:       agentendpointpb.OSPolicy_Resource_FileResource_PRESENT,
-					Permissions: "invalid",
-				},
+			frpb: &agentendpointpb.OSPolicy_Resource_FileResource{
+				State:       agentendpointpb.OSPolicy_Resource_FileResource_PRESENT,
+				Permissions: "invalid",
 			},
 			wantErr: fmt.Errorf("can't parse permissions %q: %v", "invalid", &strconv.NumError{Func: "ParseUint", Num: "invalid", Err: strconv.ErrSyntax}),
 		},
 		{
 			name: "local file does not exist, expect fail to open file",
-			fr: &fileResource{
-				OSPolicy_Resource_FileResource: &agentendpointpb.OSPolicy_Resource_FileResource{
-					Path:  "some/path",
-					State: agentendpointpb.OSPolicy_Resource_FileResource_PRESENT,
-					Source: &agentendpointpb.OSPolicy_Resource_FileResource_File{
-						File: &agentendpointpb.OSPolicy_Resource_File{
-							Type: &agentendpointpb.OSPolicy_Resource_File_LocalPath{
-								LocalPath: "does_not_exist",
-							},
+			frpb: &agentendpointpb.OSPolicy_Resource_FileResource{
+				Path:  "some/path",
+				State: agentendpointpb.OSPolicy_Resource_FileResource_PRESENT,
+				Source: &agentendpointpb.OSPolicy_Resource_FileResource_File{
+					File: &agentendpointpb.OSPolicy_Resource_File{
+						Type: &agentendpointpb.OSPolicy_Resource_File_LocalPath{
+							LocalPath: "does_not_exist",
 						},
 					},
 				},
@@ -429,40 +423,23 @@ func TestFileResourceValidateErrors(t *testing.T) {
 		},
 		{
 			name: "unrecognized source, expect unrecognized source type error",
-			fr: &fileResource{
-				OSPolicy_Resource_FileResource: &agentendpointpb.OSPolicy_Resource_FileResource{
-					Path:   "some/path",
-					State:  agentendpointpb.OSPolicy_Resource_FileResource_CONTENTS_MATCH,
-					Source: nil,
-				},
+			frpb: &agentendpointpb.OSPolicy_Resource_FileResource{
+				Path:   "some/path",
+				State:  agentendpointpb.OSPolicy_Resource_FileResource_CONTENTS_MATCH,
+				Source: nil,
 			},
 			wantErr: errors.New("unrecognized Source type for FileResource: %!q(<nil>)"),
 		},
 		{
-			name: "content download error, expect fail to write to temp file",
-			fr: &fileResource{
-				OSPolicy_Resource_FileResource: &agentendpointpb.OSPolicy_Resource_FileResource{
-					Path:  "", // Empty path causes write error to temp directory
-					State: agentendpointpb.OSPolicy_Resource_FileResource_CONTENTS_MATCH,
-					Source: &agentendpointpb.OSPolicy_Resource_FileResource_Content{
-						Content: "test content",
-					},
-				},
-			},
-			wantErr: &os.LinkError{Op: "rename"},
-		},
-		{
 			name: "remote download error, expect fail to fetch remote object",
-			fr: &fileResource{
-				OSPolicy_Resource_FileResource: &agentendpointpb.OSPolicy_Resource_FileResource{
-					Path:  "some/path",
-					State: agentendpointpb.OSPolicy_Resource_FileResource_CONTENTS_MATCH,
-					Source: &agentendpointpb.OSPolicy_Resource_FileResource_File{
-						File: &agentendpointpb.OSPolicy_Resource_File{
-							Type: &agentendpointpb.OSPolicy_Resource_File_Remote_{
-								Remote: &agentendpointpb.OSPolicy_Resource_File_Remote{
-									Uri: "doesnot/exist",
-								},
+			frpb: &agentendpointpb.OSPolicy_Resource_FileResource{
+				Path:  "some/path",
+				State: agentendpointpb.OSPolicy_Resource_FileResource_CONTENTS_MATCH,
+				Source: &agentendpointpb.OSPolicy_Resource_FileResource_File{
+					File: &agentendpointpb.OSPolicy_Resource_File{
+						Type: &agentendpointpb.OSPolicy_Resource_File_Remote_{
+							Remote: &agentendpointpb.OSPolicy_Resource_File_Remote{
+								Uri: "doesnot/exist",
 							},
 						},
 					},
@@ -474,22 +451,15 @@ func TestFileResourceValidateErrors(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			_, err := tt.fr.validate(ctx)
-			wantErr := completeLinkError(err, tt.wantErr)
-			utiltest.AssertErrorMatch(t, err, wantErr)
+			pr := &OSPolicyResource{
+				OSPolicy_Resource: &agentendpointpb.OSPolicy_Resource{
+					ResourceType: &agentendpointpb.OSPolicy_Resource_File_{File: tt.frpb},
+				},
+			}
+			gotErr := pr.Validate(ctx)
+			utiltest.AssertErrorMatch(t, gotErr, tt.wantErr)
 		})
 	}
-}
-
-func completeLinkError(got, want error) error {
-	if wantLe, ok := want.(*os.LinkError); ok {
-		if gotLe, ok := got.(*os.LinkError); ok {
-			wantLe.Old = gotLe.Old
-			wantLe.New = gotLe.New
-			wantLe.Err = gotLe.Err
-		}
-	}
-	return want
 }
 
 func TestFileResourceEnforceStateErrors(t *testing.T) {
@@ -498,33 +468,52 @@ func TestFileResourceEnforceStateErrors(t *testing.T) {
 	errRemove := os.Remove(missingPath)
 	tests := []struct {
 		name    string
-		fr      *fileResource
+		setup   func(t *testing.T) *OSPolicyResource
 		wantErr error
 	}{
 		{
 			name: "invalid state, expect unrecognized desired state error",
-			fr: &fileResource{
-				managedFile: ManagedFile{
-					State: agentendpointpb.OSPolicy_Resource_FileResource_DESIRED_STATE_UNSPECIFIED,
-				},
+			setup: func(t *testing.T) *OSPolicyResource {
+				pr := &OSPolicyResource{
+					OSPolicy_Resource: &agentendpointpb.OSPolicy_Resource{
+						ResourceType: &agentendpointpb.OSPolicy_Resource_File_{
+							File: &agentendpointpb.OSPolicy_Resource_FileResource{
+								State: agentendpointpb.OSPolicy_Resource_FileResource_DESIRED_STATE_UNSPECIFIED,
+							},
+						},
+					},
+				}
+				t.Cleanup(func() { pr.Cleanup(ctx) })
+				_ = pr.Validate(ctx)
+				return pr
 			},
 			wantErr: fmt.Errorf("unrecognized DesiredState for FileResource: %q", agentendpointpb.OSPolicy_Resource_FileResource_DESIRED_STATE_UNSPECIFIED),
 		},
 		{
 			name: "invalid path remove, expect failed to remove path error",
-			fr: &fileResource{
-				managedFile: ManagedFile{
-					Path:  missingPath,
-					State: agentendpointpb.OSPolicy_Resource_FileResource_ABSENT,
-				},
+			setup: func(t *testing.T) *OSPolicyResource {
+				pr := &OSPolicyResource{
+					OSPolicy_Resource: &agentendpointpb.OSPolicy_Resource{
+						ResourceType: &agentendpointpb.OSPolicy_Resource_File_{
+							File: &agentendpointpb.OSPolicy_Resource_FileResource{
+								Path:  missingPath,
+								State: agentendpointpb.OSPolicy_Resource_FileResource_ABSENT,
+							},
+						},
+					},
+				}
+				t.Cleanup(func() { pr.Cleanup(ctx) })
+				_ = pr.Validate(ctx)
+				return pr
 			},
 			wantErr: fmt.Errorf("error removing %q: %v", missingPath, errRemove),
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			_, err := tt.fr.enforceState(ctx)
-			utiltest.AssertErrorMatch(t, err, tt.wantErr)
+			pr := tt.setup(t)
+			gotErr := pr.EnforceState(ctx)
+			utiltest.AssertErrorMatch(t, gotErr, tt.wantErr)
 		})
 	}
 }
@@ -537,39 +526,58 @@ func TestFileResourceEnforceStateDownload(t *testing.T) {
 
 	tests := []struct {
 		name        string
-		fr          *fileResource
+		setup       func(t *testing.T) (*OSPolicyResource, string)
 		wantErr     error
 		wantContent string
 	}{
 		{
 			name: "download fails during enforce state, expect unrecognized source type error",
-			fr: &fileResource{
-				OSPolicy_Resource_FileResource: &agentendpointpb.OSPolicy_Resource_FileResource{
-					Path:   "some/path",
-					State:  agentendpointpb.OSPolicy_Resource_FileResource_PRESENT,
-					Source: nil,
-				},
-				managedFile: ManagedFile{
-					State: agentendpointpb.OSPolicy_Resource_FileResource_PRESENT,
-				},
+			setup: func(t *testing.T) (*OSPolicyResource, string) {
+				path := filepath.Join(tmpDir, "some_path")
+				// Create file so Validate skips download and leaves it for EnforceState.
+				if err := os.WriteFile(path, nil, 0644); err != nil {
+					t.Fatal(err)
+				}
+				pr := &OSPolicyResource{
+					OSPolicy_Resource: &agentendpointpb.OSPolicy_Resource{
+						ResourceType: &agentendpointpb.OSPolicy_Resource_File_{
+							File: &agentendpointpb.OSPolicy_Resource_FileResource{
+								Path:   path,
+								State:  agentendpointpb.OSPolicy_Resource_FileResource_PRESENT,
+								Source: nil,
+							},
+						},
+					},
+				}
+				t.Cleanup(func() { pr.Cleanup(ctx) })
+				_ = pr.Validate(ctx)
+				return pr, path
 			},
 			wantErr: errors.New("unrecognized Source type for FileResource: %!q(<nil>)"),
 		},
 		{
 			name: "download succeeds during enforce state, expect success",
-			fr: &fileResource{
-				OSPolicy_Resource_FileResource: &agentendpointpb.OSPolicy_Resource_FileResource{
-					Path:  dst,
-					State: agentendpointpb.OSPolicy_Resource_FileResource_PRESENT,
-					Source: &agentendpointpb.OSPolicy_Resource_FileResource_Content{
-						Content: "test content",
+			setup: func(t *testing.T) (*OSPolicyResource, string) {
+				// Create dst so Validate skips download and leaves it for EnforceState.
+				if err := os.WriteFile(dst, nil, 0644); err != nil {
+					t.Fatal(err)
+				}
+				pr := &OSPolicyResource{
+					OSPolicy_Resource: &agentendpointpb.OSPolicy_Resource{
+						ResourceType: &agentendpointpb.OSPolicy_Resource_File_{
+							File: &agentendpointpb.OSPolicy_Resource_FileResource{
+								Path:  dst,
+								State: agentendpointpb.OSPolicy_Resource_FileResource_PRESENT,
+								Source: &agentendpointpb.OSPolicy_Resource_FileResource_Content{
+									Content: "test content",
+								},
+							},
+						},
 					},
-				},
-				managedFile: ManagedFile{
-					State:      agentendpointpb.OSPolicy_Resource_FileResource_PRESENT,
-					Path:       dst,
-					Permisions: 0644,
-				},
+				}
+				t.Cleanup(func() { pr.Cleanup(ctx) })
+				_ = pr.Validate(ctx)
+				return pr, dst
 			},
 			wantErr:     nil,
 			wantContent: "test content",
@@ -578,10 +586,12 @@ func TestFileResourceEnforceStateDownload(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			inDesiredState, err := tt.fr.enforceState(ctx)
-			utiltest.AssertErrorMatchAndSkip(t, err, tt.wantErr)
-			utiltest.AssertEquals(t, inDesiredState, true)
-			utiltest.AssertFileContents(t, tt.fr.managedFile.Path, tt.wantContent)
+			pr, path := tt.setup(t)
+			gotErr := pr.EnforceState(ctx)
+
+			utiltest.AssertErrorMatchAndSkip(t, gotErr, tt.wantErr)
+			utiltest.AssertEquals(t, pr.InDesiredState(), true)
+			utiltest.AssertFileContents(t, path, tt.wantContent)
 		})
 	}
 }

--- a/config/file_resource_test.go
+++ b/config/file_resource_test.go
@@ -44,37 +44,42 @@ func TestFileResourceValidate(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	_, errLocalPath := os.Open("does_not_exist")
+
 	var tests = []struct {
-		name   string
-		frpb   *agentendpointpb.OSPolicy_Resource_FileResource
-		wantMR ManagedFile
+		name    string
+		frpb    *agentendpointpb.OSPolicy_Resource_FileResource
+		wantMR  ManagedFile
+		wantErr error
 	}{
 		{
-			"Absent",
-			&agentendpointpb.OSPolicy_Resource_FileResource{
+			name: "state absent, want absent managed file",
+			frpb: &agentendpointpb.OSPolicy_Resource_FileResource{
 				Path:  tmpFile,
 				State: agentendpointpb.OSPolicy_Resource_FileResource_ABSENT,
 			},
-			ManagedFile{
+			wantMR: ManagedFile{
 				Path:  tmpFile,
 				State: agentendpointpb.OSPolicy_Resource_FileResource_ABSENT,
 			},
+			wantErr: nil,
 		},
 		{
-			"Present",
-			&agentendpointpb.OSPolicy_Resource_FileResource{
+			name: "state present, want present managed file",
+			frpb: &agentendpointpb.OSPolicy_Resource_FileResource{
 				Path:  tmpFile,
 				State: agentendpointpb.OSPolicy_Resource_FileResource_PRESENT,
 			},
-			ManagedFile{
+			wantMR: ManagedFile{
 				Path:       tmpFile,
 				State:      agentendpointpb.OSPolicy_Resource_FileResource_PRESENT,
 				Permisions: defaultFilePerms,
 			},
+			wantErr: nil,
 		},
 		{
-			"ContentsMatch",
-			&agentendpointpb.OSPolicy_Resource_FileResource{
+			name: "state contents match and local path source, want contents match managed file with checksum",
+			frpb: &agentendpointpb.OSPolicy_Resource_FileResource{
 				Path: tmpFile,
 				Source: &agentendpointpb.OSPolicy_Resource_FileResource_File{
 					File: &agentendpointpb.OSPolicy_Resource_File{
@@ -85,30 +90,32 @@ func TestFileResourceValidate(t *testing.T) {
 				},
 				State: agentendpointpb.OSPolicy_Resource_FileResource_CONTENTS_MATCH,
 			},
-			ManagedFile{
+			wantMR: ManagedFile{
 				Path:       tmpFile,
 				source:     tmpFile,
 				checksum:   "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
 				State:      agentendpointpb.OSPolicy_Resource_FileResource_CONTENTS_MATCH,
 				Permisions: defaultFilePerms,
 			},
+			wantErr: nil,
 		},
 		{
-			"Permissions",
-			&agentendpointpb.OSPolicy_Resource_FileResource{
+			name: "state present and custom permissions, want present managed file with custom permissions",
+			frpb: &agentendpointpb.OSPolicy_Resource_FileResource{
 				Path:        tmpFile,
 				State:       agentendpointpb.OSPolicy_Resource_FileResource_PRESENT,
 				Permissions: "0777",
 			},
-			ManagedFile{
+			wantMR: ManagedFile{
 				Path:       tmpFile,
 				State:      agentendpointpb.OSPolicy_Resource_FileResource_PRESENT,
 				Permisions: 0777,
 			},
+			wantErr: nil,
 		},
 		{
-			"LocalPath",
-			&agentendpointpb.OSPolicy_Resource_FileResource{
+			name: "state present and local path source, want present managed file with checksum",
+			frpb: &agentendpointpb.OSPolicy_Resource_FileResource{
 				Path: tmpFile,
 				Source: &agentendpointpb.OSPolicy_Resource_FileResource_File{
 					File: &agentendpointpb.OSPolicy_Resource_File{
@@ -119,13 +126,70 @@ func TestFileResourceValidate(t *testing.T) {
 				},
 				State: agentendpointpb.OSPolicy_Resource_FileResource_PRESENT,
 			},
-			ManagedFile{
+			wantMR: ManagedFile{
 				Path:       tmpFile,
 				State:      agentendpointpb.OSPolicy_Resource_FileResource_PRESENT,
 				Permisions: defaultFilePerms,
 				checksum:   "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
 				source:     tmpFile,
 			},
+			wantErr: nil,
+		},
+		{
+			name: "invalid state, expect unrecognized desired state error",
+			frpb: &agentendpointpb.OSPolicy_Resource_FileResource{
+				State: agentendpointpb.OSPolicy_Resource_FileResource_DESIRED_STATE_UNSPECIFIED,
+			},
+			wantErr: fmt.Errorf("unrecognized DesiredState for FileResource: %q", agentendpointpb.OSPolicy_Resource_FileResource_DESIRED_STATE_UNSPECIFIED),
+		},
+		{
+			name: "invalid permissions, expect fail to parse permissions",
+			frpb: &agentendpointpb.OSPolicy_Resource_FileResource{
+				State:       agentendpointpb.OSPolicy_Resource_FileResource_PRESENT,
+				Permissions: "invalid",
+			},
+			wantErr: fmt.Errorf("can't parse permissions %q: %v", "invalid", &strconv.NumError{Func: "ParseUint", Num: "invalid", Err: strconv.ErrSyntax}),
+		},
+		{
+			name: "local file does not exist, expect fail to open file",
+			frpb: &agentendpointpb.OSPolicy_Resource_FileResource{
+				Path:  "some/path",
+				State: agentendpointpb.OSPolicy_Resource_FileResource_PRESENT,
+				Source: &agentendpointpb.OSPolicy_Resource_FileResource_File{
+					File: &agentendpointpb.OSPolicy_Resource_File{
+						Type: &agentendpointpb.OSPolicy_Resource_File_LocalPath{
+							LocalPath: "does_not_exist",
+						},
+					},
+				},
+			},
+			wantErr: errLocalPath,
+		},
+		{
+			name: "unrecognized source, expect unrecognized source type error",
+			frpb: &agentendpointpb.OSPolicy_Resource_FileResource{
+				Path:   "some/path",
+				State:  agentendpointpb.OSPolicy_Resource_FileResource_CONTENTS_MATCH,
+				Source: nil,
+			},
+			wantErr: errors.New("unrecognized Source type for FileResource: %!q(<nil>)"),
+		},
+		{
+			name: "remote download error, expect fail to fetch remote object",
+			frpb: &agentendpointpb.OSPolicy_Resource_FileResource{
+				Path:  "some/path",
+				State: agentendpointpb.OSPolicy_Resource_FileResource_CONTENTS_MATCH,
+				Source: &agentendpointpb.OSPolicy_Resource_FileResource_File{
+					File: &agentendpointpb.OSPolicy_Resource_File{
+						Type: &agentendpointpb.OSPolicy_Resource_File_Remote_{
+							Remote: &agentendpointpb.OSPolicy_Resource_File_Remote{
+								Uri: "doesnot/exist",
+							},
+						},
+					},
+				},
+			},
+			wantErr: &url.Error{Op: "Get", URL: "doesnot/exist", Err: errors.New("unsupported protocol scheme \"\"")},
 		},
 	}
 	for _, tt := range tests {
@@ -137,9 +201,8 @@ func TestFileResourceValidate(t *testing.T) {
 					},
 				},
 			}
-			if err := pr.Validate(ctx); err != nil {
-				t.Fatalf("Unexpected error: %v", err)
-			}
+			gotErr := pr.Validate(ctx)
+			utiltest.AssertErrorMatchAndSkip(t, gotErr, tt.wantErr)
 
 			if diff := cmp.Diff(pr.ManagedResources(), &ManagedResources{Files: []ManagedFile{tt.wantMR}}, cmp.AllowUnexported(ManagedFile{})); diff != "" {
 				t.Errorf("OSPolicyResource does not match expectation: (-got +want)\n%s", diff)
@@ -383,85 +446,6 @@ func TestFileResourceEnforceStatePresent(t *testing.T) {
 	}
 }
 
-func TestFileResourceValidateErrors(t *testing.T) {
-	ctx := t.Context()
-	_, errLocalPath := os.Open("does_not_exist")
-	tests := []struct {
-		name    string
-		frpb    *agentendpointpb.OSPolicy_Resource_FileResource
-		wantErr error
-	}{
-		{
-			name: "invalid state, expect unrecognized desired state error",
-			frpb: &agentendpointpb.OSPolicy_Resource_FileResource{
-				State: agentendpointpb.OSPolicy_Resource_FileResource_DESIRED_STATE_UNSPECIFIED,
-			},
-			wantErr: fmt.Errorf("unrecognized DesiredState for FileResource: %q", agentendpointpb.OSPolicy_Resource_FileResource_DESIRED_STATE_UNSPECIFIED),
-		},
-		{
-			name: "invalid permissions, expect fail to parse permissions",
-			frpb: &agentendpointpb.OSPolicy_Resource_FileResource{
-				State:       agentendpointpb.OSPolicy_Resource_FileResource_PRESENT,
-				Permissions: "invalid",
-			},
-			wantErr: fmt.Errorf("can't parse permissions %q: %v", "invalid", &strconv.NumError{Func: "ParseUint", Num: "invalid", Err: strconv.ErrSyntax}),
-		},
-		{
-			name: "local file does not exist, expect fail to open file",
-			frpb: &agentendpointpb.OSPolicy_Resource_FileResource{
-				Path:  "some/path",
-				State: agentendpointpb.OSPolicy_Resource_FileResource_PRESENT,
-				Source: &agentendpointpb.OSPolicy_Resource_FileResource_File{
-					File: &agentendpointpb.OSPolicy_Resource_File{
-						Type: &agentendpointpb.OSPolicy_Resource_File_LocalPath{
-							LocalPath: "does_not_exist",
-						},
-					},
-				},
-			},
-			wantErr: errLocalPath,
-		},
-		{
-			name: "unrecognized source, expect unrecognized source type error",
-			frpb: &agentendpointpb.OSPolicy_Resource_FileResource{
-				Path:   "some/path",
-				State:  agentendpointpb.OSPolicy_Resource_FileResource_CONTENTS_MATCH,
-				Source: nil,
-			},
-			wantErr: errors.New("unrecognized Source type for FileResource: %!q(<nil>)"),
-		},
-		{
-			name: "remote download error, expect fail to fetch remote object",
-			frpb: &agentendpointpb.OSPolicy_Resource_FileResource{
-				Path:  "some/path",
-				State: agentendpointpb.OSPolicy_Resource_FileResource_CONTENTS_MATCH,
-				Source: &agentendpointpb.OSPolicy_Resource_FileResource_File{
-					File: &agentendpointpb.OSPolicy_Resource_File{
-						Type: &agentendpointpb.OSPolicy_Resource_File_Remote_{
-							Remote: &agentendpointpb.OSPolicy_Resource_File_Remote{
-								Uri: "doesnot/exist",
-							},
-						},
-					},
-				},
-			},
-			wantErr: &url.Error{Op: "Get", URL: "doesnot/exist", Err: errors.New("unsupported protocol scheme \"\"")},
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			pr := &OSPolicyResource{
-				OSPolicy_Resource: &agentendpointpb.OSPolicy_Resource{
-					ResourceType: &agentendpointpb.OSPolicy_Resource_File_{File: tt.frpb},
-				},
-			}
-			gotErr := pr.Validate(ctx)
-			utiltest.AssertErrorMatch(t, gotErr, tt.wantErr)
-		})
-	}
-}
-
 func TestFileResourceEnforceStateErrors(t *testing.T) {
 	ctx := t.Context()
 	missingPath := filepath.Join(t.TempDir(), "does_not_exist")
@@ -474,37 +458,46 @@ func TestFileResourceEnforceStateErrors(t *testing.T) {
 		{
 			name: "invalid state, expect unrecognized desired state error",
 			setup: func(t *testing.T) *OSPolicyResource {
-				pr := &OSPolicyResource{
+				frpb := &agentendpointpb.OSPolicy_Resource_FileResource{
+					State: agentendpointpb.OSPolicy_Resource_FileResource_DESIRED_STATE_UNSPECIFIED,
+				}
+				return &OSPolicyResource{
 					OSPolicy_Resource: &agentendpointpb.OSPolicy_Resource{
 						ResourceType: &agentendpointpb.OSPolicy_Resource_File_{
-							File: &agentendpointpb.OSPolicy_Resource_FileResource{
-								State: agentendpointpb.OSPolicy_Resource_FileResource_DESIRED_STATE_UNSPECIFIED,
-							},
+							File: frpb,
+						},
+					},
+					resource: &fileResource{
+						OSPolicy_Resource_FileResource: frpb,
+						managedFile: ManagedFile{
+							State: frpb.GetState(),
 						},
 					},
 				}
-				t.Cleanup(func() { pr.Cleanup(ctx) })
-				_ = pr.Validate(ctx)
-				return pr
 			},
 			wantErr: fmt.Errorf("unrecognized DesiredState for FileResource: %q", agentendpointpb.OSPolicy_Resource_FileResource_DESIRED_STATE_UNSPECIFIED),
 		},
 		{
 			name: "invalid path remove, expect failed to remove path error",
 			setup: func(t *testing.T) *OSPolicyResource {
-				pr := &OSPolicyResource{
+				frpb := &agentendpointpb.OSPolicy_Resource_FileResource{
+					Path:  missingPath,
+					State: agentendpointpb.OSPolicy_Resource_FileResource_ABSENT,
+				}
+				return &OSPolicyResource{
 					OSPolicy_Resource: &agentendpointpb.OSPolicy_Resource{
 						ResourceType: &agentendpointpb.OSPolicy_Resource_File_{
-							File: &agentendpointpb.OSPolicy_Resource_FileResource{
-								Path:  missingPath,
-								State: agentendpointpb.OSPolicy_Resource_FileResource_ABSENT,
-							},
+							File: frpb,
+						},
+					},
+					resource: &fileResource{
+						OSPolicy_Resource_FileResource: frpb,
+						managedFile: ManagedFile{
+							Path:  frpb.GetPath(),
+							State: frpb.GetState(),
 						},
 					},
 				}
-				t.Cleanup(func() { pr.Cleanup(ctx) })
-				_ = pr.Validate(ctx)
-				return pr
 			},
 			wantErr: fmt.Errorf("error removing %q: %v", missingPath, errRemove),
 		},
@@ -534,23 +527,27 @@ func TestFileResourceEnforceStateDownload(t *testing.T) {
 			name: "download fails during enforce state, expect unrecognized source type error",
 			setup: func(t *testing.T) (*OSPolicyResource, string) {
 				path := filepath.Join(tmpDir, "some_path")
-				// Create file so Validate skips download and leaves it for EnforceState.
-				if err := os.WriteFile(path, nil, 0644); err != nil {
-					t.Fatal(err)
+				frpb := &agentendpointpb.OSPolicy_Resource_FileResource{
+					Path:   path,
+					State:  agentendpointpb.OSPolicy_Resource_FileResource_PRESENT,
+					Source: nil,
 				}
 				pr := &OSPolicyResource{
 					OSPolicy_Resource: &agentendpointpb.OSPolicy_Resource{
 						ResourceType: &agentendpointpb.OSPolicy_Resource_File_{
-							File: &agentendpointpb.OSPolicy_Resource_FileResource{
-								Path:   path,
-								State:  agentendpointpb.OSPolicy_Resource_FileResource_PRESENT,
-								Source: nil,
-							},
+							File: frpb,
+						},
+					},
+					resource: &fileResource{
+						OSPolicy_Resource_FileResource: frpb,
+						managedFile: ManagedFile{
+							Path:       frpb.GetPath(),
+							State:      frpb.GetState(),
+							Permisions: defaultFilePerms,
 						},
 					},
 				}
 				t.Cleanup(func() { pr.Cleanup(ctx) })
-				_ = pr.Validate(ctx)
 				return pr, path
 			},
 			wantErr: errors.New("unrecognized Source type for FileResource: %!q(<nil>)"),
@@ -558,25 +555,29 @@ func TestFileResourceEnforceStateDownload(t *testing.T) {
 		{
 			name: "download succeeds during enforce state, expect success",
 			setup: func(t *testing.T) (*OSPolicyResource, string) {
-				// Create dst so Validate skips download and leaves it for EnforceState.
-				if err := os.WriteFile(dst, nil, 0644); err != nil {
-					t.Fatal(err)
+				frpb := &agentendpointpb.OSPolicy_Resource_FileResource{
+					Path:  dst,
+					State: agentendpointpb.OSPolicy_Resource_FileResource_PRESENT,
+					Source: &agentendpointpb.OSPolicy_Resource_FileResource_Content{
+						Content: "test content",
+					},
 				}
 				pr := &OSPolicyResource{
 					OSPolicy_Resource: &agentendpointpb.OSPolicy_Resource{
 						ResourceType: &agentendpointpb.OSPolicy_Resource_File_{
-							File: &agentendpointpb.OSPolicy_Resource_FileResource{
-								Path:  dst,
-								State: agentendpointpb.OSPolicy_Resource_FileResource_PRESENT,
-								Source: &agentendpointpb.OSPolicy_Resource_FileResource_Content{
-									Content: "test content",
-								},
-							},
+							File: frpb,
+						},
+					},
+					resource: &fileResource{
+						OSPolicy_Resource_FileResource: frpb,
+						managedFile: ManagedFile{
+							Path:       frpb.GetPath(),
+							State:      frpb.GetState(),
+							Permisions: defaultFilePerms,
 						},
 					},
 				}
 				t.Cleanup(func() { pr.Cleanup(ctx) })
-				_ = pr.Validate(ctx)
 				return pr, dst
 			},
 			wantErr:     nil,

--- a/config/file_resource_test.go
+++ b/config/file_resource_test.go
@@ -47,18 +47,18 @@ func TestFileResourceValidate(t *testing.T) {
 	_, errLocalPath := os.Open("does_not_exist")
 
 	var tests = []struct {
-		name    string
-		frpb    *agentendpointpb.OSPolicy_Resource_FileResource
-		wantMR  ManagedFile
-		wantErr error
+		name            string
+		fileResourcePB  *agentendpointpb.OSPolicy_Resource_FileResource
+		wantManagedFile ManagedFile
+		wantErr         error
 	}{
 		{
 			name: "state absent, want absent managed file",
-			frpb: &agentendpointpb.OSPolicy_Resource_FileResource{
+			fileResourcePB: &agentendpointpb.OSPolicy_Resource_FileResource{
 				Path:  tmpFile,
 				State: agentendpointpb.OSPolicy_Resource_FileResource_ABSENT,
 			},
-			wantMR: ManagedFile{
+			wantManagedFile: ManagedFile{
 				Path:  tmpFile,
 				State: agentendpointpb.OSPolicy_Resource_FileResource_ABSENT,
 			},
@@ -66,11 +66,11 @@ func TestFileResourceValidate(t *testing.T) {
 		},
 		{
 			name: "state present, want present managed file",
-			frpb: &agentendpointpb.OSPolicy_Resource_FileResource{
+			fileResourcePB: &agentendpointpb.OSPolicy_Resource_FileResource{
 				Path:  tmpFile,
 				State: agentendpointpb.OSPolicy_Resource_FileResource_PRESENT,
 			},
-			wantMR: ManagedFile{
+			wantManagedFile: ManagedFile{
 				Path:       tmpFile,
 				State:      agentendpointpb.OSPolicy_Resource_FileResource_PRESENT,
 				Permisions: defaultFilePerms,
@@ -79,7 +79,7 @@ func TestFileResourceValidate(t *testing.T) {
 		},
 		{
 			name: "state contents match and local path source, want contents match managed file with checksum",
-			frpb: &agentendpointpb.OSPolicy_Resource_FileResource{
+			fileResourcePB: &agentendpointpb.OSPolicy_Resource_FileResource{
 				Path: tmpFile,
 				Source: &agentendpointpb.OSPolicy_Resource_FileResource_File{
 					File: &agentendpointpb.OSPolicy_Resource_File{
@@ -90,7 +90,7 @@ func TestFileResourceValidate(t *testing.T) {
 				},
 				State: agentendpointpb.OSPolicy_Resource_FileResource_CONTENTS_MATCH,
 			},
-			wantMR: ManagedFile{
+			wantManagedFile: ManagedFile{
 				Path:       tmpFile,
 				source:     tmpFile,
 				checksum:   "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
@@ -101,12 +101,12 @@ func TestFileResourceValidate(t *testing.T) {
 		},
 		{
 			name: "state present and custom permissions, want present managed file with custom permissions",
-			frpb: &agentendpointpb.OSPolicy_Resource_FileResource{
+			fileResourcePB: &agentendpointpb.OSPolicy_Resource_FileResource{
 				Path:        tmpFile,
 				State:       agentendpointpb.OSPolicy_Resource_FileResource_PRESENT,
 				Permissions: "0777",
 			},
-			wantMR: ManagedFile{
+			wantManagedFile: ManagedFile{
 				Path:       tmpFile,
 				State:      agentendpointpb.OSPolicy_Resource_FileResource_PRESENT,
 				Permisions: 0777,
@@ -115,7 +115,7 @@ func TestFileResourceValidate(t *testing.T) {
 		},
 		{
 			name: "state present and local path source, want present managed file with checksum",
-			frpb: &agentendpointpb.OSPolicy_Resource_FileResource{
+			fileResourcePB: &agentendpointpb.OSPolicy_Resource_FileResource{
 				Path: tmpFile,
 				Source: &agentendpointpb.OSPolicy_Resource_FileResource_File{
 					File: &agentendpointpb.OSPolicy_Resource_File{
@@ -126,7 +126,7 @@ func TestFileResourceValidate(t *testing.T) {
 				},
 				State: agentendpointpb.OSPolicy_Resource_FileResource_PRESENT,
 			},
-			wantMR: ManagedFile{
+			wantManagedFile: ManagedFile{
 				Path:       tmpFile,
 				State:      agentendpointpb.OSPolicy_Resource_FileResource_PRESENT,
 				Permisions: defaultFilePerms,
@@ -137,14 +137,14 @@ func TestFileResourceValidate(t *testing.T) {
 		},
 		{
 			name: "invalid state, expect unrecognized desired state error",
-			frpb: &agentendpointpb.OSPolicy_Resource_FileResource{
+			fileResourcePB: &agentendpointpb.OSPolicy_Resource_FileResource{
 				State: agentendpointpb.OSPolicy_Resource_FileResource_DESIRED_STATE_UNSPECIFIED,
 			},
 			wantErr: fmt.Errorf("unrecognized DesiredState for FileResource: %q", agentendpointpb.OSPolicy_Resource_FileResource_DESIRED_STATE_UNSPECIFIED),
 		},
 		{
 			name: "invalid permissions, expect fail to parse permissions",
-			frpb: &agentendpointpb.OSPolicy_Resource_FileResource{
+			fileResourcePB: &agentendpointpb.OSPolicy_Resource_FileResource{
 				State:       agentendpointpb.OSPolicy_Resource_FileResource_PRESENT,
 				Permissions: "invalid",
 			},
@@ -152,7 +152,7 @@ func TestFileResourceValidate(t *testing.T) {
 		},
 		{
 			name: "local file does not exist, expect fail to open file",
-			frpb: &agentendpointpb.OSPolicy_Resource_FileResource{
+			fileResourcePB: &agentendpointpb.OSPolicy_Resource_FileResource{
 				Path:  "some/path",
 				State: agentendpointpb.OSPolicy_Resource_FileResource_PRESENT,
 				Source: &agentendpointpb.OSPolicy_Resource_FileResource_File{
@@ -167,7 +167,7 @@ func TestFileResourceValidate(t *testing.T) {
 		},
 		{
 			name: "unrecognized source, expect unrecognized source type error",
-			frpb: &agentendpointpb.OSPolicy_Resource_FileResource{
+			fileResourcePB: &agentendpointpb.OSPolicy_Resource_FileResource{
 				Path:   "some/path",
 				State:  agentendpointpb.OSPolicy_Resource_FileResource_CONTENTS_MATCH,
 				Source: nil,
@@ -176,7 +176,7 @@ func TestFileResourceValidate(t *testing.T) {
 		},
 		{
 			name: "remote download error, expect fail to fetch remote object",
-			frpb: &agentendpointpb.OSPolicy_Resource_FileResource{
+			fileResourcePB: &agentendpointpb.OSPolicy_Resource_FileResource{
 				Path:  "some/path",
 				State: agentendpointpb.OSPolicy_Resource_FileResource_CONTENTS_MATCH,
 				Source: &agentendpointpb.OSPolicy_Resource_FileResource_File{
@@ -197,17 +197,17 @@ func TestFileResourceValidate(t *testing.T) {
 			pr := &OSPolicyResource{
 				OSPolicy_Resource: &agentendpointpb.OSPolicy_Resource{
 					ResourceType: &agentendpointpb.OSPolicy_Resource_File_{
-						File: tt.frpb,
+						File: tt.fileResourcePB,
 					},
 				},
 			}
 			gotErr := pr.Validate(ctx)
 			utiltest.AssertErrorMatchAndSkip(t, gotErr, tt.wantErr)
 
-			if diff := cmp.Diff(pr.ManagedResources(), &ManagedResources{Files: []ManagedFile{tt.wantMR}}, cmp.AllowUnexported(ManagedFile{})); diff != "" {
+			if diff := cmp.Diff(pr.ManagedResources(), &ManagedResources{Files: []ManagedFile{tt.wantManagedFile}}, cmp.AllowUnexported(ManagedFile{})); diff != "" {
 				t.Errorf("OSPolicyResource does not match expectation: (-got +want)\n%s", diff)
 			}
-			if diff := cmp.Diff(pr.resource.(*fileResource).managedFile, tt.wantMR, cmp.AllowUnexported(ManagedFile{})); diff != "" {
+			if diff := cmp.Diff(pr.resource.(*fileResource).managedFile, tt.wantManagedFile, cmp.AllowUnexported(ManagedFile{})); diff != "" {
 				t.Errorf("fileResource does not match expectation: (-got +want)\n%s", diff)
 			}
 		})
@@ -232,7 +232,7 @@ func TestFileResourceCheckState(t *testing.T) {
 
 	var tests = []struct {
 		name               string
-		frpb               *agentendpointpb.OSPolicy_Resource_FileResource
+		fileResourcePB     *agentendpointpb.OSPolicy_Resource_FileResource
 		wantInDesiredState bool
 	}{
 		{
@@ -347,7 +347,7 @@ func TestFileResourceCheckState(t *testing.T) {
 			pr := &OSPolicyResource{
 				OSPolicy_Resource: &agentendpointpb.OSPolicy_Resource{
 					ResourceType: &agentendpointpb.OSPolicy_Resource_File_{
-						File: tt.frpb,
+						File: tt.fileResourcePB,
 					},
 				},
 			}
@@ -378,13 +378,13 @@ func TestFileResourceEnforceStateAbsent(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	frpb := &agentendpointpb.OSPolicy_Resource_FileResource{
+	fileResourcePB := &agentendpointpb.OSPolicy_Resource_FileResource{
 		Path:  tmpFile,
 		State: agentendpointpb.OSPolicy_Resource_FileResource_ABSENT,
 	}
 	pr := &OSPolicyResource{
 		OSPolicy_Resource: &agentendpointpb.OSPolicy_Resource{
-			ResourceType: &agentendpointpb.OSPolicy_Resource_File_{File: frpb},
+			ResourceType: &agentendpointpb.OSPolicy_Resource_File_{File: fileResourcePB},
 		},
 	}
 	if err := pr.Validate(ctx); err != nil {
@@ -413,7 +413,7 @@ func TestFileResourceEnforceStatePresent(t *testing.T) {
 	}
 	wantFile := filepath.Join(tmpDir, "bar")
 
-	frpb := &agentendpointpb.OSPolicy_Resource_FileResource{
+	fileResourcePB := &agentendpointpb.OSPolicy_Resource_FileResource{
 		Path: wantFile,
 		Source: &agentendpointpb.OSPolicy_Resource_FileResource_File{
 			File: &agentendpointpb.OSPolicy_Resource_File{
@@ -426,7 +426,7 @@ func TestFileResourceEnforceStatePresent(t *testing.T) {
 	}
 	pr := &OSPolicyResource{
 		OSPolicy_Resource: &agentendpointpb.OSPolicy_Resource{
-			ResourceType: &agentendpointpb.OSPolicy_Resource_File_{File: frpb},
+			ResourceType: &agentendpointpb.OSPolicy_Resource_File_{File: fileResourcePB},
 		},
 	}
 	if err := pr.Validate(ctx); err != nil {
@@ -458,19 +458,19 @@ func TestFileResourceEnforceStateErrors(t *testing.T) {
 		{
 			name: "invalid state, expect unrecognized desired state error",
 			setup: func(t *testing.T) *OSPolicyResource {
-				frpb := &agentendpointpb.OSPolicy_Resource_FileResource{
+				fileResourcePB := &agentendpointpb.OSPolicy_Resource_FileResource{
 					State: agentendpointpb.OSPolicy_Resource_FileResource_DESIRED_STATE_UNSPECIFIED,
 				}
 				return &OSPolicyResource{
 					OSPolicy_Resource: &agentendpointpb.OSPolicy_Resource{
 						ResourceType: &agentendpointpb.OSPolicy_Resource_File_{
-							File: frpb,
+							File: fileResourcePB,
 						},
 					},
 					resource: &fileResource{
-						OSPolicy_Resource_FileResource: frpb,
+						OSPolicy_Resource_FileResource: fileResourcePB,
 						managedFile: ManagedFile{
-							State: frpb.GetState(),
+							State: fileResourcePB.GetState(),
 						},
 					},
 				}
@@ -480,21 +480,21 @@ func TestFileResourceEnforceStateErrors(t *testing.T) {
 		{
 			name: "invalid path remove, expect failed to remove path error",
 			setup: func(t *testing.T) *OSPolicyResource {
-				frpb := &agentendpointpb.OSPolicy_Resource_FileResource{
+				fileResourcePB := &agentendpointpb.OSPolicy_Resource_FileResource{
 					Path:  missingPath,
 					State: agentendpointpb.OSPolicy_Resource_FileResource_ABSENT,
 				}
 				return &OSPolicyResource{
 					OSPolicy_Resource: &agentendpointpb.OSPolicy_Resource{
 						ResourceType: &agentendpointpb.OSPolicy_Resource_File_{
-							File: frpb,
+							File: fileResourcePB,
 						},
 					},
 					resource: &fileResource{
-						OSPolicy_Resource_FileResource: frpb,
+						OSPolicy_Resource_FileResource: fileResourcePB,
 						managedFile: ManagedFile{
-							Path:  frpb.GetPath(),
-							State: frpb.GetState(),
+							Path:  fileResourcePB.GetPath(),
+							State: fileResourcePB.GetState(),
 						},
 					},
 				}
@@ -527,7 +527,7 @@ func TestFileResourceEnforceStateDownload(t *testing.T) {
 			name: "download fails during enforce state, expect unrecognized source type error",
 			setup: func(t *testing.T) (*OSPolicyResource, string) {
 				path := filepath.Join(tmpDir, "some_path")
-				frpb := &agentendpointpb.OSPolicy_Resource_FileResource{
+				fileResourcePB := &agentendpointpb.OSPolicy_Resource_FileResource{
 					Path:   path,
 					State:  agentendpointpb.OSPolicy_Resource_FileResource_PRESENT,
 					Source: nil,
@@ -535,14 +535,14 @@ func TestFileResourceEnforceStateDownload(t *testing.T) {
 				pr := &OSPolicyResource{
 					OSPolicy_Resource: &agentendpointpb.OSPolicy_Resource{
 						ResourceType: &agentendpointpb.OSPolicy_Resource_File_{
-							File: frpb,
+							File: fileResourcePB,
 						},
 					},
 					resource: &fileResource{
-						OSPolicy_Resource_FileResource: frpb,
+						OSPolicy_Resource_FileResource: fileResourcePB,
 						managedFile: ManagedFile{
-							Path:       frpb.GetPath(),
-							State:      frpb.GetState(),
+							Path:       fileResourcePB.GetPath(),
+							State:      fileResourcePB.GetState(),
 							Permisions: defaultFilePerms,
 						},
 					},
@@ -555,7 +555,7 @@ func TestFileResourceEnforceStateDownload(t *testing.T) {
 		{
 			name: "download succeeds during enforce state, expect success",
 			setup: func(t *testing.T) (*OSPolicyResource, string) {
-				frpb := &agentendpointpb.OSPolicy_Resource_FileResource{
+				fileResourcePB := &agentendpointpb.OSPolicy_Resource_FileResource{
 					Path:  dst,
 					State: agentendpointpb.OSPolicy_Resource_FileResource_PRESENT,
 					Source: &agentendpointpb.OSPolicy_Resource_FileResource_Content{
@@ -565,14 +565,14 @@ func TestFileResourceEnforceStateDownload(t *testing.T) {
 				pr := &OSPolicyResource{
 					OSPolicy_Resource: &agentendpointpb.OSPolicy_Resource{
 						ResourceType: &agentendpointpb.OSPolicy_Resource_File_{
-							File: frpb,
+							File: fileResourcePB,
 						},
 					},
 					resource: &fileResource{
-						OSPolicy_Resource_FileResource: frpb,
+						OSPolicy_Resource_FileResource: fileResourcePB,
 						managedFile: ManagedFile{
-							Path:       frpb.GetPath(),
-							State:      frpb.GetState(),
+							Path:       fileResourcePB.GetPath(),
+							State:      fileResourcePB.GetState(),
 							Permisions: defaultFilePerms,
 						},
 					},


### PR DESCRIPTION
This PR contains unit tests for file_resource.go
Initial coverage: 67.1%, current coverage 86.6%