### PR TITLE
Add unit tests for policies/policies.go PART 2

### DIFF
--- a/policies/policies.go
+++ b/policies/policies.go
@@ -38,6 +38,15 @@ import (
 	"cloud.google.com/go/osconfig/agentendpoint/apiv1beta/agentendpointpb"
 )
 
+var (
+	googetRepoFilePath = agentconfig.GooGetRepoFilePath
+	aptRepoFilePath    = agentconfig.AptRepoFilePath
+	yumRepoFilePath    = agentconfig.YumRepoFilePath
+	zypperRepoFilePath = agentconfig.ZypperRepoFilePath
+
+	retry = retryutil.RetryFunc
+)
+
 func run(ctx context.Context) {
 	var resp *agentendpointpb.EffectiveGuestPolicy
 
@@ -59,8 +68,9 @@ func run(ctx context.Context) {
 
 	effective := mergeConfigs(local, resp)
 
-	// We don't check the error from setConfig as all errors are already logged.
-	setConfig(ctx, effective)
+	if err := setConfig(ctx, effective); err != nil {
+		clog.Errorf(ctx, "%v", err)
+	}
 	if err := installRecipes(ctx, effective); err != nil {
 		clog.Errorf(ctx, "%v", err)
 	}
@@ -84,6 +94,19 @@ func (e installRecipesError) Error() string {
 	return fmt.Sprintf("unable to install recipes:\n%s", strings.Join(results, ",\n"))
 }
 
+type setConfigError struct {
+	errors []error
+}
+
+func (e setConfigError) Error() string {
+	results := make([]string, len(e.errors))
+	for i, err := range e.errors {
+		results[i] = err.Error()
+	}
+
+	return fmt.Sprintf("error applying config:\n%s", strings.Join(results, ",\n"))
+}
+
 func installRecipes(ctx context.Context, egp *agentendpointpb.EffectiveGuestPolicy) error {
 	var errors []error
 	for _, recipe := range egp.GetSoftwareRecipes() {
@@ -99,7 +122,7 @@ func installRecipes(ctx context.Context, egp *agentendpointpb.EffectiveGuestPoli
 	return nil
 }
 
-func setConfig(ctx context.Context, egp *agentendpointpb.EffectiveGuestPolicy) {
+func setConfig(ctx context.Context, egp *agentendpointpb.EffectiveGuestPolicy) error {
 	var aptRepos []*agentendpointpb.AptRepository
 	var yumRepos []*agentendpointpb.YumRepository
 	var zypperRepos []*agentendpointpb.ZypperRepository
@@ -187,49 +210,63 @@ func setConfig(ctx context.Context, egp *agentendpointpb.EffectiveGuestPolicy) {
 		}
 	}
 
+	var errs []error
 	if packages.GooGetExists {
-		if err := googetRepositories(ctx, gooRepos, agentconfig.GooGetRepoFilePath()); err != nil {
+		if err := googetRepositories(ctx, gooRepos, googetRepoFilePath()); err != nil {
+			errs = append(errs, fmt.Errorf("Error writing googet repo file: %v", err))
 			clog.Errorf(ctx, "Error writing googet repo file: %v", err)
 		}
-		if err := retryutil.RetryFunc(ctx, 1*time.Minute, "Applying googet changes", func() error {
+		if err := retry(ctx, 1*time.Minute, "Applying googet changes", func() error {
 			return googetChanges(ctx, gooInstallPkgs, gooRemovePkgs, gooUpdatePkgs)
 		}); err != nil {
+			errs = append(errs, fmt.Errorf("Error performing googet changes: %v", err))
 			clog.Errorf(ctx, "Error performing googet changes: %v", err)
 		}
 	}
 
 	if packages.AptExists {
-		if err := aptRepositories(ctx, aptRepos, agentconfig.AptRepoFilePath()); err != nil {
+		if err := aptRepositories(ctx, aptRepos, aptRepoFilePath()); err != nil {
+			errs = append(errs, fmt.Errorf("Error writing apt repo file: %v", err))
 			clog.Errorf(ctx, "Error writing apt repo file: %v", err)
 		}
-		if err := retryutil.RetryFunc(ctx, 1*time.Minute, "Applying apt changes", func() error {
+		if err := retry(ctx, 1*time.Minute, "Applying apt changes", func() error {
 			return aptChanges(ctx, aptInstallPkgs, aptRemovePkgs, aptUpdatePkgs)
 		}); err != nil {
+			errs = append(errs, fmt.Errorf("Error performing apt changes: %v", err))
 			clog.Errorf(ctx, "Error performing apt changes: %v", err)
 		}
 	}
 
 	if packages.YumExists {
-		if err := yumRepositories(ctx, yumRepos, agentconfig.YumRepoFilePath()); err != nil {
+		if err := yumRepositories(ctx, yumRepos, yumRepoFilePath()); err != nil {
+			errs = append(errs, fmt.Errorf("Error writing yum repo file: %v", err))
 			clog.Errorf(ctx, "Error writing yum repo file: %v", err)
 		}
-		if err := retryutil.RetryFunc(ctx, 1*time.Minute, "Applying yum changes", func() error {
+		if err := retry(ctx, 1*time.Minute, "Applying yum changes", func() error {
 			return yumChanges(ctx, yumInstallPkgs, yumRemovePkgs, yumUpdatePkgs)
 		}); err != nil {
+			errs = append(errs, fmt.Errorf("Error performing yum changes: %v", err))
 			clog.Errorf(ctx, "Error performing yum changes: %v", err)
 		}
 	}
 
 	if packages.ZypperExists {
-		if err := zypperRepositories(ctx, zypperRepos, agentconfig.ZypperRepoFilePath()); err != nil {
+		if err := zypperRepositories(ctx, zypperRepos, zypperRepoFilePath()); err != nil {
+			errs = append(errs, fmt.Errorf("Error writing zypper repo file: %v", err))
 			clog.Errorf(ctx, "Error writing zypper repo file: %v", err)
 		}
-		if err := retryutil.RetryFunc(ctx, 1*time.Minute, "Applying zypper changes.", func() error {
+		if err := retry(ctx, 1*time.Minute, "Applying zypper changes.", func() error {
 			return zypperChanges(ctx, zypperInstallPkgs, zypperRemovePkgs, zypperUpdatePkgs)
 		}); err != nil {
+			errs = append(errs, fmt.Errorf("Error performing zypper changes: %v", err))
 			clog.Errorf(ctx, "Error performing zypper changes: %v", err)
 		}
 	}
+
+	if len(errs) > 0 {
+		return setConfigError{errors: errs}
+	}
+	return nil
 }
 
 func checksum(r io.Reader) hash.Hash {

--- a/policies/policies_test.go
+++ b/policies/policies_test.go
@@ -222,10 +222,17 @@ func TestSetConfigApt(t *testing.T) {
 	t.Cleanup(func() { mockCtrl.Finish() })
 
 	mockCommandRunner := utilmocks.NewMockCommandRunner(mockCtrl)
+	setupSetConfigTest(t, mockCommandRunner)
 
 	dpkgQueryArgs := []string{"-W", "-f", "\\{\"architecture\":\"${Architecture}\",\"package\":\"${Package}\",\"source_name\":\"${source:Package}\",\"source_version\":\"${source:Version}\",\"status\":\"${db:Status-Status}\",\"version\":\"${Version}\"\\}\n"}
 	aptUpgradableArgs := []string{"--just-print", "-qq", "dist-upgrade"}
 	aptEnv := []string{"DEBIAN_FRONTEND=noninteractive"}
+
+	setupAptEnv := func(t *testing.T, aptExists bool) {
+		utiltest.OverrideVariable(t, &packages.AptExists, aptExists)
+		tmpDir := t.TempDir()
+		utiltest.OverrideVariable(t, &aptRepoFilePath, func() string { return filepath.Join(tmpDir, "apt.list") })
+	}
 
 	tests := []struct {
 		name             string
@@ -370,9 +377,9 @@ func TestSetConfigApt(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			setupSetConfigTest(t, tt.aptExists, false, false, false, mockCommandRunner)
-
+			setupAptEnv(t, tt.aptExists)
 			utiltest.SetExpectedCommands(ctx, mockCommandRunner, tt.expectedCommands)
+
 			err := setConfig(context.Background(), tt.egp)
 			utiltest.AssertErrorMatch(t, err, tt.wantErr)
 		})
@@ -388,21 +395,10 @@ func (s policiesStubOsInfoProvider) GetOSInfo(ctx context.Context) (osinfo.OSInf
 }
 
 // setupSetConfigTest sets up the environment for SetConfig tests by mocking the command runner.
-func setupSetConfigTest(t *testing.T, apt, yum, zypper, googet bool, runner *utilmocks.MockCommandRunner) {
-	utiltest.OverrideVariable(t, &packages.AptExists, apt)
-	utiltest.OverrideVariable(t, &packages.YumExists, yum)
-	utiltest.OverrideVariable(t, &packages.ZypperExists, zypper)
-	utiltest.OverrideVariable(t, &packages.GooGetExists, googet)
+func setupSetConfigTest(t *testing.T, runner *utilmocks.MockCommandRunner) {
 	utiltest.OverrideVariable(t, &osInfoProvider, (osinfo.Provider)(policiesStubOsInfoProvider{
 		osinfo: osinfo.OSInfo{ShortName: "debian", Version: "11"},
 	}))
-
-	tmpDir := t.TempDir()
-	utiltest.OverrideVariable(t, &googetRepoFilePath, func() string { return filepath.Join(tmpDir, "googet.repo") })
-	utiltest.OverrideVariable(t, &aptRepoFilePath, func() string { return filepath.Join(tmpDir, "apt.list") })
-	utiltest.OverrideVariable(t, &yumRepoFilePath, func() string { return filepath.Join(tmpDir, "yum.repo") })
-	utiltest.OverrideVariable(t, &zypperRepoFilePath, func() string { return filepath.Join(tmpDir, "zypper.repo") })
-
 	utiltest.OverrideVariable(t, &retry, func(ctx context.Context, timeout time.Duration, desc string, f func() error) error {
 		return f()
 	})

--- a/policies/policies_test.go
+++ b/policies/policies_test.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"syscall"
 	"testing"
 	"time"
@@ -217,19 +218,20 @@ func TestInstallRecipesHandlesInputs(t *testing.T) {
 func TestSetConfig(t *testing.T) {
 	ctx := context.Background()
 
+	mockCtrl := gomock.NewController(t)
+	t.Cleanup(func() { mockCtrl.Finish() })
+
+	mockCommandRunner := utilmocks.NewMockCommandRunner(mockCtrl)
+
 	dpkgQueryArgs := []string{"-W", "-f", "\\{\"architecture\":\"${Architecture}\",\"package\":\"${Package}\",\"source_name\":\"${source:Package}\",\"source_version\":\"${source:Version}\",\"status\":\"${db:Status-Status}\",\"version\":\"${Version}\"\\}\n"}
 	rpmQueryArgs := []string{"--queryformat", "\\{\"architecture\":\"%{ARCH}\",\"package\":\"%{NAME}\",\"source_name\":\"%{SOURCERPM}\",\"version\":\"%|EPOCH?{%{EPOCH}:}:{}|%{VERSION}-%{RELEASE}\"\\}\n", "-a"}
 	aptUpgradableArgs := []string{"--just-print", "-qq", "dist-upgrade"}
 	yumCheckUpdateArgs := []string{"check-update", "--assumeyes"}
 	yumListUpdatesArgs := []string{"update", "--assumeno", "--color=never"}
 	zypperListUpdatesArgs := []string{"--gpg-auto-import-keys", "-q", "list-updates"}
+	aptEnv := []string{"DEBIAN_FRONTEND=noninteractive"}
 
 	yumCheckUpdateErr := exec.Command("/bin/bash", "-c", "exit 100").Run()
-
-	mockCtrl := gomock.NewController(t)
-	t.Cleanup(func() { mockCtrl.Finish() })
-
-	mockCommandRunner := utilmocks.NewMockCommandRunner(mockCtrl)
 
 	tests := []struct {
 		name             string
@@ -239,13 +241,15 @@ func TestSetConfig(t *testing.T) {
 		zypperExists     bool
 		googetExists     bool
 		expectedCommands []utiltest.ExpectedCommand
+		wantErr          error
 	}{
 		{
-			name: "empty policy",
-			egp:  &agentendpointpb.EffectiveGuestPolicy{},
+			name:    "empty policy, want nil error",
+			egp:     &agentendpointpb.EffectiveGuestPolicy{},
+			wantErr: nil,
 		},
 		{
-			name: "apt install",
+			name: "apt install package p1, want nil error",
 			egp: &agentendpointpb.EffectiveGuestPolicy{
 				Packages: []*agentendpointpb.EffectiveGuestPolicy_SourcedPackage{
 					{Package: &agentendpointpb.Package{Name: "p1", DesiredState: agentendpointpb.DesiredState_INSTALLED, Manager: agentendpointpb.Package_APT}},
@@ -257,21 +261,29 @@ func TestSetConfig(t *testing.T) {
 					Cmd:    exec.Command("/usr/bin/dpkg-query", dpkgQueryArgs...),
 					Stdout: []byte(""),
 				},
-				{Cmd: exec.Command("/usr/bin/apt-get", "update")},
-				{Cmd: exec.Command("/usr/bin/apt-get", "install", "-y", "p1")},
+				{
+					Cmd:  exec.Command("/usr/bin/apt-get", "update"),
+					Envs: aptEnv,
+				},
+				{
+					Cmd:  exec.Command("/usr/bin/apt-get", "install", "-y", "p1"),
+					Envs: aptEnv,
+				},
 			},
+			wantErr: nil,
 		},
 		{
-			name: "apt install manager not found",
+			name: "apt install manager not found, want nil error",
 			egp: &agentendpointpb.EffectiveGuestPolicy{
 				Packages: []*agentendpointpb.EffectiveGuestPolicy_SourcedPackage{
 					{Package: &agentendpointpb.Package{Name: "p1", DesiredState: agentendpointpb.DesiredState_INSTALLED, Manager: agentendpointpb.Package_APT}},
 				},
 			},
 			aptExists: false,
+			wantErr:   nil,
 		},
 		{
-			name: "apt update",
+			name: "apt update package p1, want nil error",
 			egp: &agentendpointpb.EffectiveGuestPolicy{
 				Packages: []*agentendpointpb.EffectiveGuestPolicy_SourcedPackage{
 					{Package: &agentendpointpb.Package{Name: "p1", DesiredState: agentendpointpb.DesiredState_UPDATED, Manager: agentendpointpb.Package_APT}},
@@ -283,16 +295,24 @@ func TestSetConfig(t *testing.T) {
 					Cmd:    exec.Command("/usr/bin/dpkg-query", dpkgQueryArgs...),
 					Stdout: []byte(`{"package":"p1","status":"installed"}`),
 				},
-				{Cmd: exec.Command("/usr/bin/apt-get", "update")},
+				{
+					Cmd:  exec.Command("/usr/bin/apt-get", "update"),
+					Envs: aptEnv,
+				},
 				{
 					Cmd:    exec.Command("/usr/bin/apt-get", aptUpgradableArgs...),
 					Stdout: []byte("Inst p1 [1.0] (2.0 repo [amd64])\n"),
+					Envs:   aptEnv,
 				},
-				{Cmd: exec.Command("/usr/bin/apt-get", "install", "-y", "p1")},
+				{
+					Cmd:  exec.Command("/usr/bin/apt-get", "install", "-y", "p1"),
+					Envs: aptEnv,
+				},
 			},
+			wantErr: nil,
 		},
 		{
-			name: "apt remove",
+			name: "apt remove package p1, want nil error",
 			egp: &agentendpointpb.EffectiveGuestPolicy{
 				Packages: []*agentendpointpb.EffectiveGuestPolicy_SourcedPackage{
 					{Package: &agentendpointpb.Package{Name: "p1", DesiredState: agentendpointpb.DesiredState_REMOVED, Manager: agentendpointpb.Package_APT}},
@@ -304,11 +324,15 @@ func TestSetConfig(t *testing.T) {
 					Cmd:    exec.Command("/usr/bin/dpkg-query", dpkgQueryArgs...),
 					Stdout: []byte(`{"package":"p1","status":"installed"}`),
 				},
-				{Cmd: exec.Command("/usr/bin/apt-get", "remove", "-y", "p1")},
+				{
+					Cmd:  exec.Command("/usr/bin/apt-get", "remove", "-y", "p1"),
+					Envs: aptEnv,
+				},
 			},
+			wantErr: nil,
 		},
 		{
-			name: "yum install",
+			name: "yum install package p1, want nil error",
 			egp: &agentendpointpb.EffectiveGuestPolicy{
 				Packages: []*agentendpointpb.EffectiveGuestPolicy_SourcedPackage{
 					{Package: &agentendpointpb.Package{Name: "p1", DesiredState: agentendpointpb.DesiredState_INSTALLED, Manager: agentendpointpb.Package_YUM}},
@@ -320,11 +344,14 @@ func TestSetConfig(t *testing.T) {
 					Cmd:    exec.Command("/usr/bin/rpmquery", rpmQueryArgs...),
 					Stdout: []byte(""),
 				},
-				{Cmd: exec.Command("/usr/bin/yum", "install", "--assumeyes", "p1")},
+				{
+					Cmd: exec.Command("/usr/bin/yum", "install", "--assumeyes", "p1"),
+				},
 			},
+			wantErr: nil,
 		},
 		{
-			name: "yum update",
+			name: "yum update package p1, want nil error",
 			egp: &agentendpointpb.EffectiveGuestPolicy{
 				Packages: []*agentendpointpb.EffectiveGuestPolicy_SourcedPackage{
 					{Package: &agentendpointpb.Package{Name: "p1", DesiredState: agentendpointpb.DesiredState_UPDATED, Manager: agentendpointpb.Package_YUM}},
@@ -344,11 +371,14 @@ func TestSetConfig(t *testing.T) {
 					Cmd:    exec.Command("/usr/bin/yum", yumListUpdatesArgs...),
 					Stdout: []byte("Updating:\n p1 x86_64 2.0 updates 100 k\n"),
 				},
-				{Cmd: exec.Command("/usr/bin/yum", "install", "--assumeyes", "p1")},
+				{
+					Cmd: exec.Command("/usr/bin/yum", "install", "--assumeyes", "p1"),
+				},
 			},
+			wantErr: nil,
 		},
 		{
-			name: "yum remove",
+			name: "yum remove package p1, want nil error",
 			egp: &agentendpointpb.EffectiveGuestPolicy{
 				Packages: []*agentendpointpb.EffectiveGuestPolicy_SourcedPackage{
 					{Package: &agentendpointpb.Package{Name: "p1", DesiredState: agentendpointpb.DesiredState_REMOVED, Manager: agentendpointpb.Package_YUM}},
@@ -360,11 +390,14 @@ func TestSetConfig(t *testing.T) {
 					Cmd:    exec.Command("/usr/bin/rpmquery", rpmQueryArgs...),
 					Stdout: []byte(`{"package":"p1","status":"installed"}`),
 				},
-				{Cmd: exec.Command("/usr/bin/yum", "remove", "--assumeyes", "p1")},
+				{
+					Cmd: exec.Command("/usr/bin/yum", "remove", "--assumeyes", "p1"),
+				},
 			},
+			wantErr: nil,
 		},
 		{
-			name: "zypper install",
+			name: "zypper install package p1, want nil error",
 			egp: &agentendpointpb.EffectiveGuestPolicy{
 				Packages: []*agentendpointpb.EffectiveGuestPolicy_SourcedPackage{
 					{Package: &agentendpointpb.Package{Name: "p1", DesiredState: agentendpointpb.DesiredState_INSTALLED, Manager: agentendpointpb.Package_ZYPPER}},
@@ -376,11 +409,14 @@ func TestSetConfig(t *testing.T) {
 					Cmd:    exec.Command("/usr/bin/rpmquery", rpmQueryArgs...),
 					Stdout: []byte(""),
 				},
-				{Cmd: exec.Command("/usr/bin/zypper", "--gpg-auto-import-keys", "--non-interactive", "install", "--auto-agree-with-licenses", "p1")},
+				{
+					Cmd: exec.Command("/usr/bin/zypper", "--gpg-auto-import-keys", "--non-interactive", "install", "--auto-agree-with-licenses", "p1"),
+				},
 			},
+			wantErr: nil,
 		},
 		{
-			name: "zypper update",
+			name: "zypper update package p1, want nil error",
 			egp: &agentendpointpb.EffectiveGuestPolicy{
 				Packages: []*agentendpointpb.EffectiveGuestPolicy_SourcedPackage{
 					{Package: &agentendpointpb.Package{Name: "p1", DesiredState: agentendpointpb.DesiredState_UPDATED, Manager: agentendpointpb.Package_ZYPPER}},
@@ -396,11 +432,14 @@ func TestSetConfig(t *testing.T) {
 					Cmd:    exec.Command("/usr/bin/zypper", zypperListUpdatesArgs...),
 					Stdout: []byte("v | Repo | p1 | 1.0 | 2.0 | x86_64\n"),
 				},
-				{Cmd: exec.Command("/usr/bin/zypper", "--gpg-auto-import-keys", "--non-interactive", "install", "--auto-agree-with-licenses", "p1")},
+				{
+					Cmd: exec.Command("/usr/bin/zypper", "--gpg-auto-import-keys", "--non-interactive", "install", "--auto-agree-with-licenses", "p1"),
+				},
 			},
+			wantErr: nil,
 		},
 		{
-			name: "zypper remove",
+			name: "zypper remove package p1, want nil error",
 			egp: &agentendpointpb.EffectiveGuestPolicy{
 				Packages: []*agentendpointpb.EffectiveGuestPolicy_SourcedPackage{
 					{Package: &agentendpointpb.Package{Name: "p1", DesiredState: agentendpointpb.DesiredState_REMOVED, Manager: agentendpointpb.Package_ZYPPER}},
@@ -412,11 +451,14 @@ func TestSetConfig(t *testing.T) {
 					Cmd:    exec.Command("/usr/bin/rpmquery", rpmQueryArgs...),
 					Stdout: []byte(`{"package":"p1","status":"installed"}`),
 				},
-				{Cmd: exec.Command("/usr/bin/zypper", "--non-interactive", "remove", "p1")},
+				{
+					Cmd: exec.Command("/usr/bin/zypper", "--non-interactive", "remove", "p1"),
+				},
 			},
+			wantErr: nil,
 		},
 		{
-			name: "googet install",
+			name: "googet install package p1, want nil error",
 			egp: &agentendpointpb.EffectiveGuestPolicy{
 				Packages: []*agentendpointpb.EffectiveGuestPolicy_SourcedPackage{
 					{Package: &agentendpointpb.Package{Name: "p1", DesiredState: agentendpointpb.DesiredState_INSTALLED, Manager: agentendpointpb.Package_GOO}},
@@ -428,11 +470,14 @@ func TestSetConfig(t *testing.T) {
 					Cmd:    exec.Command("googet.exe", "installed"),
 					Stdout: []byte(""),
 				},
-				{Cmd: exec.Command("googet.exe", "-noconfirm", "install", "p1")},
+				{
+					Cmd: exec.Command("googet.exe", "-noconfirm", "install", "p1"),
+				},
 			},
+			wantErr: nil,
 		},
 		{
-			name: "googet update",
+			name: "googet update package p1, want nil error",
 			egp: &agentendpointpb.EffectiveGuestPolicy{
 				Packages: []*agentendpointpb.EffectiveGuestPolicy_SourcedPackage{
 					{Package: &agentendpointpb.Package{Name: "p1", DesiredState: agentendpointpb.DesiredState_UPDATED, Manager: agentendpointpb.Package_GOO}},
@@ -448,11 +493,14 @@ func TestSetConfig(t *testing.T) {
 					Cmd:    exec.Command("googet.exe", "update"),
 					Stdout: []byte("p1.noarch, 1.0 --> 2.0 from repo\n"),
 				},
-				{Cmd: exec.Command("googet.exe", "-noconfirm", "install", "p1")},
+				{
+					Cmd: exec.Command("googet.exe", "-noconfirm", "install", "p1"),
+				},
 			},
+			wantErr: nil,
 		},
 		{
-			name: "googet remove",
+			name: "googet remove package p1, want nil error",
 			egp: &agentendpointpb.EffectiveGuestPolicy{
 				Packages: []*agentendpointpb.EffectiveGuestPolicy_SourcedPackage{
 					{Package: &agentendpointpb.Package{Name: "p1", DesiredState: agentendpointpb.DesiredState_REMOVED, Manager: agentendpointpb.Package_GOO}},
@@ -464,11 +512,14 @@ func TestSetConfig(t *testing.T) {
 					Cmd:    exec.Command("googet.exe", "installed"),
 					Stdout: []byte("p1.x86_64 1.0\n"),
 				},
-				{Cmd: exec.Command("googet.exe", "-noconfirm", "remove", "p1")},
+				{
+					Cmd: exec.Command("googet.exe", "-noconfirm", "remove", "p1"),
+				},
 			},
+			wantErr: nil,
 		},
 		{
-			name: "package ANY install",
+			name: "package ANY install p1, want nil error",
 			egp: &agentendpointpb.EffectiveGuestPolicy{
 				Packages: []*agentendpointpb.EffectiveGuestPolicy_SourcedPackage{
 					{Package: &agentendpointpb.Package{Name: "p1", DesiredState: agentendpointpb.DesiredState_INSTALLED, Manager: agentendpointpb.Package_ANY}},
@@ -480,17 +531,26 @@ func TestSetConfig(t *testing.T) {
 					Cmd:    exec.Command("/usr/bin/dpkg-query", dpkgQueryArgs...),
 					Stdout: []byte(""),
 				},
-				{Cmd: exec.Command("/usr/bin/apt-get", "update")},
-				{Cmd: exec.Command("/usr/bin/apt-get", "install", "-y", "p1")},
+				{
+					Cmd:  exec.Command("/usr/bin/apt-get", "update"),
+					Envs: aptEnv,
+				},
+				{
+					Cmd:  exec.Command("/usr/bin/apt-get", "install", "-y", "p1"),
+					Envs: aptEnv,
+				},
 				{
 					Cmd:    exec.Command("/usr/bin/rpmquery", rpmQueryArgs...),
 					Stdout: []byte(""),
 				},
-				{Cmd: exec.Command("/usr/bin/yum", "install", "--assumeyes", "p1")},
+				{
+					Cmd: exec.Command("/usr/bin/yum", "install", "--assumeyes", "p1"),
+				},
 			},
+			wantErr: nil,
 		},
 		{
-			name: "all repositories",
+			name: "all repositories configured, want nil error",
 			egp: &agentendpointpb.EffectiveGuestPolicy{
 				PackageRepositories: []*agentendpointpb.EffectiveGuestPolicy_SourcedPackageRepository{
 					{PackageRepository: &agentendpointpb.PackageRepository{Repository: &agentendpointpb.PackageRepository_Apt{Apt: &agentendpointpb.AptRepository{Uri: "http://repo"}}}},
@@ -500,6 +560,195 @@ func TestSetConfig(t *testing.T) {
 				},
 			},
 			aptExists: true, yumExists: true, zypperExists: true, googetExists: true,
+			wantErr: nil,
+		},
+		{
+			name: "apt install p1 with failure, want installing error",
+			egp: &agentendpointpb.EffectiveGuestPolicy{
+				Packages: []*agentendpointpb.EffectiveGuestPolicy_SourcedPackage{
+					{Package: &agentendpointpb.Package{Name: "p1", DesiredState: agentendpointpb.DesiredState_INSTALLED, Manager: agentendpointpb.Package_APT}},
+				},
+			},
+			aptExists: true,
+			expectedCommands: []utiltest.ExpectedCommand{
+				{
+					Cmd:    exec.Command("/usr/bin/dpkg-query", dpkgQueryArgs...),
+					Stdout: []byte(""),
+				},
+				{
+					Cmd:  exec.Command("/usr/bin/apt-get", "update"),
+					Envs: aptEnv,
+				},
+				{
+					Cmd:  exec.Command("/usr/bin/apt-get", "install", "-y", "p1"),
+					Envs: aptEnv,
+					Err:  fmt.Errorf("individual install error"),
+				},
+				{
+					Cmd:  exec.Command("/usr/bin/apt-get", "install", "-y", "p1"),
+					Envs: aptEnv,
+					Err:  fmt.Errorf("individual install error"),
+				},
+			},
+			wantErr: setConfigError{
+				errors: []error{
+					fmt.Errorf("Error performing apt changes: error installing apt packages: Error installing apt package: p1. Error details: error running /usr/bin/apt-get with args [\"install\" \"-y\" \"p1\"]: individual install error, stdout: \"\", stderr: \"\""),
+				},
+			},
+		},
+		{
+			name: "yum install p1 with failure, want installing error",
+			egp: &agentendpointpb.EffectiveGuestPolicy{
+				Packages: []*agentendpointpb.EffectiveGuestPolicy_SourcedPackage{
+					{Package: &agentendpointpb.Package{Name: "p1", DesiredState: agentendpointpb.DesiredState_INSTALLED, Manager: agentendpointpb.Package_YUM}},
+				},
+			},
+			yumExists: true,
+			expectedCommands: []utiltest.ExpectedCommand{
+				{
+					Cmd:    exec.Command("/usr/bin/rpmquery", rpmQueryArgs...),
+					Stdout: []byte(""),
+				},
+				{
+					Cmd: exec.Command("/usr/bin/yum", "install", "--assumeyes", "p1"),
+					Err: fmt.Errorf("yum error"),
+				},
+			},
+			wantErr: setConfigError{
+				errors: []error{
+					fmt.Errorf("Error performing yum changes: error installing yum packages: error running /usr/bin/yum with args [\"install\" \"--assumeyes\" \"p1\"]: yum error, stdout: \"\", stderr: \"\""),
+				},
+			},
+		},
+		{
+			name: "zypper install p1 with failure, want installing error",
+			egp: &agentendpointpb.EffectiveGuestPolicy{
+				Packages: []*agentendpointpb.EffectiveGuestPolicy_SourcedPackage{
+					{Package: &agentendpointpb.Package{Name: "p1", DesiredState: agentendpointpb.DesiredState_INSTALLED, Manager: agentendpointpb.Package_ZYPPER}},
+				},
+			},
+			zypperExists: true,
+			expectedCommands: []utiltest.ExpectedCommand{
+				{
+					Cmd:    exec.Command("/usr/bin/rpmquery", rpmQueryArgs...),
+					Stdout: []byte(""),
+				},
+				{
+					Cmd: exec.Command("/usr/bin/zypper", "--gpg-auto-import-keys", "--non-interactive", "install", "--auto-agree-with-licenses", "p1"),
+					Err: fmt.Errorf("zypper error"),
+				},
+			},
+			wantErr: setConfigError{
+				errors: []error{
+					fmt.Errorf("Error performing zypper changes: error installing zypper packages: error running /usr/bin/zypper with args [\"--gpg-auto-import-keys\" \"--non-interactive\" \"install\" \"--auto-agree-with-licenses\" \"p1\"]: zypper error, stdout: \"\", stderr: \"\""),
+				},
+			},
+		},
+		{
+			name: "googet install p1 with failure, want installing  error",
+			egp: &agentendpointpb.EffectiveGuestPolicy{
+				Packages: []*agentendpointpb.EffectiveGuestPolicy_SourcedPackage{
+					{Package: &agentendpointpb.Package{Name: "p1", DesiredState: agentendpointpb.DesiredState_INSTALLED, Manager: agentendpointpb.Package_GOO}},
+				},
+			},
+			googetExists: true,
+			expectedCommands: []utiltest.ExpectedCommand{
+				{
+					Cmd:    exec.Command("googet.exe", "installed"),
+					Stdout: []byte(""),
+				},
+				{
+					Cmd: exec.Command("googet.exe", "-noconfirm", "install", "p1"),
+					Err: fmt.Errorf("googet error"),
+				},
+			},
+			wantErr: setConfigError{
+				errors: []error{
+					fmt.Errorf("Error performing googet changes: error installing googet packages: error running googet.exe with args [\"-noconfirm\" \"install\" \"p1\"]: googet error, stdout: \"\", stderr: \"\""),
+				},
+			},
+		},
+		{
+			name: "package ANY removed and unspecified manager/state, want nil error",
+			egp: &agentendpointpb.EffectiveGuestPolicy{
+				Packages: []*agentendpointpb.EffectiveGuestPolicy_SourcedPackage{
+					{
+						Package: &agentendpointpb.Package{
+							Name:         "p1",
+							DesiredState: agentendpointpb.DesiredState_REMOVED,
+							Manager:      agentendpointpb.Package_ANY,
+						},
+					},
+					{
+						Package: &agentendpointpb.Package{
+							Name:         "p2",
+							DesiredState: agentendpointpb.DesiredState_DESIRED_STATE_UNSPECIFIED,
+							Manager:      agentendpointpb.Package_MANAGER_UNSPECIFIED,
+						},
+					},
+					{
+						Package: &agentendpointpb.Package{
+							Name:         "p3",
+							DesiredState: agentendpointpb.DesiredState_UPDATED,
+							Manager:      agentendpointpb.Package_ANY,
+						},
+					},
+				},
+			},
+			aptExists: true, yumExists: true,
+			expectedCommands: []utiltest.ExpectedCommand{
+				{
+					Cmd:    exec.Command("/usr/bin/dpkg-query", dpkgQueryArgs...),
+					Stdout: []byte(`{"package":"p1","status":"installed"}`),
+				},
+				{
+					Cmd:  exec.Command("/usr/bin/apt-get", "update"),
+					Envs: aptEnv,
+				},
+				{
+					Cmd:    exec.Command("/usr/bin/apt-get", aptUpgradableArgs...),
+					Stdout: []byte("Inst p3 [1.0] (2.0 repo [amd64])\n"),
+					Envs:   aptEnv,
+				},
+				{
+					Cmd:  exec.Command("/usr/bin/apt-get", "update"),
+					Envs: aptEnv,
+				},
+				{
+					Cmd:  exec.Command("/usr/bin/apt-get", "install", "-y", "p2"),
+					Envs: aptEnv,
+				},
+				{
+					Cmd:  exec.Command("/usr/bin/apt-get", "install", "-y", "p3"),
+					Envs: aptEnv,
+				},
+				{
+					Cmd:  exec.Command("/usr/bin/apt-get", "remove", "-y", "p1"),
+					Envs: aptEnv,
+				},
+				{
+					Cmd:    exec.Command("/usr/bin/rpmquery", rpmQueryArgs...),
+					Stdout: []byte(`{"package":"p1","status":"installed"}`),
+				},
+				{
+					Cmd: exec.Command("/usr/bin/yum", yumCheckUpdateArgs...),
+					Err: yumCheckUpdateErr,
+				},
+				{
+					Cmd:    exec.Command("/usr/bin/yum", yumListUpdatesArgs...),
+					Stdout: []byte("Updating:\n p3 x86_64 2.0 updates 100 k\n"),
+				},
+				{
+					Cmd: exec.Command("/usr/bin/yum", "install", "--assumeyes", "p2"),
+				},
+				{
+					Cmd: exec.Command("/usr/bin/yum", "install", "--assumeyes", "p3"),
+				},
+				{
+					Cmd: exec.Command("/usr/bin/yum", "remove", "--assumeyes", "p1"),
+				},
+			},
+			wantErr: nil,
 		},
 	}
 
@@ -508,7 +757,8 @@ func TestSetConfig(t *testing.T) {
 			setupSetConfigTest(t, tt.aptExists, tt.yumExists, tt.zypperExists, tt.googetExists, mockCommandRunner)
 
 			utiltest.SetExpectedCommands(ctx, mockCommandRunner, tt.expectedCommands)
-			setConfig(context.Background(), tt.egp)
+			err := setConfig(context.Background(), tt.egp)
+			utiltest.AssertErrorMatch(t, err, tt.wantErr)
 		})
 	}
 }
@@ -530,6 +780,16 @@ func setupSetConfigTest(t *testing.T, apt, yum, zypper, googet bool, runner *uti
 	utiltest.OverrideVariable(t, &osInfoProvider, (osinfo.Provider)(policiesStubOsInfoProvider{
 		osinfo: osinfo.OSInfo{ShortName: "debian", Version: "11"},
 	}))
+
+	tmpDir := t.TempDir()
+	utiltest.OverrideVariable(t, &googetRepoFilePath, func() string { return filepath.Join(tmpDir, "googet.repo") })
+	utiltest.OverrideVariable(t, &aptRepoFilePath, func() string { return filepath.Join(tmpDir, "apt.list") })
+	utiltest.OverrideVariable(t, &yumRepoFilePath, func() string { return filepath.Join(tmpDir, "yum.repo") })
+	utiltest.OverrideVariable(t, &zypperRepoFilePath, func() string { return filepath.Join(tmpDir, "zypper.repo") })
+
+	utiltest.OverrideVariable(t, &retry, func(ctx context.Context, timeout time.Duration, desc string, f func() error) error {
+		return f()
+	})
 
 	packages.SetCommandRunner(runner)
 	packages.SetPtyCommandRunner(runner)

--- a/policies/policies_test.go
+++ b/policies/policies_test.go
@@ -214,8 +214,8 @@ func TestInstallRecipesHandlesInputs(t *testing.T) {
 	}
 }
 
-// TestSetConfig verifies that setConfig handles different package managers and their configurations.
-func TestSetConfig(t *testing.T) {
+// TestSetConfigApt verifies that setConfig handles apt package manager and its configurations.
+func TestSetConfigApt(t *testing.T) {
 	ctx := context.Background()
 
 	mockCtrl := gomock.NewController(t)
@@ -224,22 +224,13 @@ func TestSetConfig(t *testing.T) {
 	mockCommandRunner := utilmocks.NewMockCommandRunner(mockCtrl)
 
 	dpkgQueryArgs := []string{"-W", "-f", "\\{\"architecture\":\"${Architecture}\",\"package\":\"${Package}\",\"source_name\":\"${source:Package}\",\"source_version\":\"${source:Version}\",\"status\":\"${db:Status-Status}\",\"version\":\"${Version}\"\\}\n"}
-	rpmQueryArgs := []string{"--queryformat", "\\{\"architecture\":\"%{ARCH}\",\"package\":\"%{NAME}\",\"source_name\":\"%{SOURCERPM}\",\"version\":\"%|EPOCH?{%{EPOCH}:}:{}|%{VERSION}-%{RELEASE}\"\\}\n", "-a"}
 	aptUpgradableArgs := []string{"--just-print", "-qq", "dist-upgrade"}
-	yumCheckUpdateArgs := []string{"check-update", "--assumeyes"}
-	yumListUpdatesArgs := []string{"update", "--assumeno", "--color=never"}
-	zypperListUpdatesArgs := []string{"--gpg-auto-import-keys", "-q", "list-updates"}
 	aptEnv := []string{"DEBIAN_FRONTEND=noninteractive"}
-
-	yumCheckUpdateErr := exec.Command("/bin/bash", "-c", "exit 100").Run()
 
 	tests := []struct {
 		name             string
 		egp              *agentendpointpb.EffectiveGuestPolicy
 		aptExists        bool
-		yumExists        bool
-		zypperExists     bool
-		googetExists     bool
 		expectedCommands []utiltest.ExpectedCommand
 		wantErr          error
 	}{
@@ -332,237 +323,6 @@ func TestSetConfig(t *testing.T) {
 			wantErr: nil,
 		},
 		{
-			name: "yum install package p1, want nil error",
-			egp: &agentendpointpb.EffectiveGuestPolicy{
-				Packages: []*agentendpointpb.EffectiveGuestPolicy_SourcedPackage{
-					{Package: &agentendpointpb.Package{Name: "p1", DesiredState: agentendpointpb.DesiredState_INSTALLED, Manager: agentendpointpb.Package_YUM}},
-				},
-			},
-			yumExists: true,
-			expectedCommands: []utiltest.ExpectedCommand{
-				{
-					Cmd:    exec.Command("/usr/bin/rpmquery", rpmQueryArgs...),
-					Stdout: []byte(""),
-				},
-				{
-					Cmd: exec.Command("/usr/bin/yum", "install", "--assumeyes", "p1"),
-				},
-			},
-			wantErr: nil,
-		},
-		{
-			name: "yum update package p1, want nil error",
-			egp: &agentendpointpb.EffectiveGuestPolicy{
-				Packages: []*agentendpointpb.EffectiveGuestPolicy_SourcedPackage{
-					{Package: &agentendpointpb.Package{Name: "p1", DesiredState: agentendpointpb.DesiredState_UPDATED, Manager: agentendpointpb.Package_YUM}},
-				},
-			},
-			yumExists: true,
-			expectedCommands: []utiltest.ExpectedCommand{
-				{
-					Cmd:    exec.Command("/usr/bin/rpmquery", rpmQueryArgs...),
-					Stdout: []byte(`{"package":"p1","status":"installed"}`),
-				},
-				{
-					Cmd: exec.Command("/usr/bin/yum", yumCheckUpdateArgs...),
-					Err: yumCheckUpdateErr,
-				},
-				{
-					Cmd:    exec.Command("/usr/bin/yum", yumListUpdatesArgs...),
-					Stdout: []byte("Updating:\n p1 x86_64 2.0 updates 100 k\n"),
-				},
-				{
-					Cmd: exec.Command("/usr/bin/yum", "install", "--assumeyes", "p1"),
-				},
-			},
-			wantErr: nil,
-		},
-		{
-			name: "yum remove package p1, want nil error",
-			egp: &agentendpointpb.EffectiveGuestPolicy{
-				Packages: []*agentendpointpb.EffectiveGuestPolicy_SourcedPackage{
-					{Package: &agentendpointpb.Package{Name: "p1", DesiredState: agentendpointpb.DesiredState_REMOVED, Manager: agentendpointpb.Package_YUM}},
-				},
-			},
-			yumExists: true,
-			expectedCommands: []utiltest.ExpectedCommand{
-				{
-					Cmd:    exec.Command("/usr/bin/rpmquery", rpmQueryArgs...),
-					Stdout: []byte(`{"package":"p1","status":"installed"}`),
-				},
-				{
-					Cmd: exec.Command("/usr/bin/yum", "remove", "--assumeyes", "p1"),
-				},
-			},
-			wantErr: nil,
-		},
-		{
-			name: "zypper install package p1, want nil error",
-			egp: &agentendpointpb.EffectiveGuestPolicy{
-				Packages: []*agentendpointpb.EffectiveGuestPolicy_SourcedPackage{
-					{Package: &agentendpointpb.Package{Name: "p1", DesiredState: agentendpointpb.DesiredState_INSTALLED, Manager: agentendpointpb.Package_ZYPPER}},
-				},
-			},
-			zypperExists: true,
-			expectedCommands: []utiltest.ExpectedCommand{
-				{
-					Cmd:    exec.Command("/usr/bin/rpmquery", rpmQueryArgs...),
-					Stdout: []byte(""),
-				},
-				{
-					Cmd: exec.Command("/usr/bin/zypper", "--gpg-auto-import-keys", "--non-interactive", "install", "--auto-agree-with-licenses", "p1"),
-				},
-			},
-			wantErr: nil,
-		},
-		{
-			name: "zypper update package p1, want nil error",
-			egp: &agentendpointpb.EffectiveGuestPolicy{
-				Packages: []*agentendpointpb.EffectiveGuestPolicy_SourcedPackage{
-					{Package: &agentendpointpb.Package{Name: "p1", DesiredState: agentendpointpb.DesiredState_UPDATED, Manager: agentendpointpb.Package_ZYPPER}},
-				},
-			},
-			zypperExists: true,
-			expectedCommands: []utiltest.ExpectedCommand{
-				{
-					Cmd:    exec.Command("/usr/bin/rpmquery", rpmQueryArgs...),
-					Stdout: []byte(`{"package":"p1","status":"installed"}`),
-				},
-				{
-					Cmd:    exec.Command("/usr/bin/zypper", zypperListUpdatesArgs...),
-					Stdout: []byte("v | Repo | p1 | 1.0 | 2.0 | x86_64\n"),
-				},
-				{
-					Cmd: exec.Command("/usr/bin/zypper", "--gpg-auto-import-keys", "--non-interactive", "install", "--auto-agree-with-licenses", "p1"),
-				},
-			},
-			wantErr: nil,
-		},
-		{
-			name: "zypper remove package p1, want nil error",
-			egp: &agentendpointpb.EffectiveGuestPolicy{
-				Packages: []*agentendpointpb.EffectiveGuestPolicy_SourcedPackage{
-					{Package: &agentendpointpb.Package{Name: "p1", DesiredState: agentendpointpb.DesiredState_REMOVED, Manager: agentendpointpb.Package_ZYPPER}},
-				},
-			},
-			zypperExists: true,
-			expectedCommands: []utiltest.ExpectedCommand{
-				{
-					Cmd:    exec.Command("/usr/bin/rpmquery", rpmQueryArgs...),
-					Stdout: []byte(`{"package":"p1","status":"installed"}`),
-				},
-				{
-					Cmd: exec.Command("/usr/bin/zypper", "--non-interactive", "remove", "p1"),
-				},
-			},
-			wantErr: nil,
-		},
-		{
-			name: "googet install package p1, want nil error",
-			egp: &agentendpointpb.EffectiveGuestPolicy{
-				Packages: []*agentendpointpb.EffectiveGuestPolicy_SourcedPackage{
-					{Package: &agentendpointpb.Package{Name: "p1", DesiredState: agentendpointpb.DesiredState_INSTALLED, Manager: agentendpointpb.Package_GOO}},
-				},
-			},
-			googetExists: true,
-			expectedCommands: []utiltest.ExpectedCommand{
-				{
-					Cmd:    exec.Command("googet.exe", "installed"),
-					Stdout: []byte(""),
-				},
-				{
-					Cmd: exec.Command("googet.exe", "-noconfirm", "install", "p1"),
-				},
-			},
-			wantErr: nil,
-		},
-		{
-			name: "googet update package p1, want nil error",
-			egp: &agentendpointpb.EffectiveGuestPolicy{
-				Packages: []*agentendpointpb.EffectiveGuestPolicy_SourcedPackage{
-					{Package: &agentendpointpb.Package{Name: "p1", DesiredState: agentendpointpb.DesiredState_UPDATED, Manager: agentendpointpb.Package_GOO}},
-				},
-			},
-			googetExists: true,
-			expectedCommands: []utiltest.ExpectedCommand{
-				{
-					Cmd:    exec.Command("googet.exe", "installed"),
-					Stdout: []byte("p1.x86_64 1.0\n"),
-				},
-				{
-					Cmd:    exec.Command("googet.exe", "update"),
-					Stdout: []byte("p1.noarch, 1.0 --> 2.0 from repo\n"),
-				},
-				{
-					Cmd: exec.Command("googet.exe", "-noconfirm", "install", "p1"),
-				},
-			},
-			wantErr: nil,
-		},
-		{
-			name: "googet remove package p1, want nil error",
-			egp: &agentendpointpb.EffectiveGuestPolicy{
-				Packages: []*agentendpointpb.EffectiveGuestPolicy_SourcedPackage{
-					{Package: &agentendpointpb.Package{Name: "p1", DesiredState: agentendpointpb.DesiredState_REMOVED, Manager: agentendpointpb.Package_GOO}},
-				},
-			},
-			googetExists: true,
-			expectedCommands: []utiltest.ExpectedCommand{
-				{
-					Cmd:    exec.Command("googet.exe", "installed"),
-					Stdout: []byte("p1.x86_64 1.0\n"),
-				},
-				{
-					Cmd: exec.Command("googet.exe", "-noconfirm", "remove", "p1"),
-				},
-			},
-			wantErr: nil,
-		},
-		{
-			name: "package ANY install p1, want nil error",
-			egp: &agentendpointpb.EffectiveGuestPolicy{
-				Packages: []*agentendpointpb.EffectiveGuestPolicy_SourcedPackage{
-					{Package: &agentendpointpb.Package{Name: "p1", DesiredState: agentendpointpb.DesiredState_INSTALLED, Manager: agentendpointpb.Package_ANY}},
-				},
-			},
-			aptExists: true, yumExists: true,
-			expectedCommands: []utiltest.ExpectedCommand{
-				{
-					Cmd:    exec.Command("/usr/bin/dpkg-query", dpkgQueryArgs...),
-					Stdout: []byte(""),
-				},
-				{
-					Cmd:  exec.Command("/usr/bin/apt-get", "update"),
-					Envs: aptEnv,
-				},
-				{
-					Cmd:  exec.Command("/usr/bin/apt-get", "install", "-y", "p1"),
-					Envs: aptEnv,
-				},
-				{
-					Cmd:    exec.Command("/usr/bin/rpmquery", rpmQueryArgs...),
-					Stdout: []byte(""),
-				},
-				{
-					Cmd: exec.Command("/usr/bin/yum", "install", "--assumeyes", "p1"),
-				},
-			},
-			wantErr: nil,
-		},
-		{
-			name: "all repositories configured, want nil error",
-			egp: &agentendpointpb.EffectiveGuestPolicy{
-				PackageRepositories: []*agentendpointpb.EffectiveGuestPolicy_SourcedPackageRepository{
-					{PackageRepository: &agentendpointpb.PackageRepository{Repository: &agentendpointpb.PackageRepository_Apt{Apt: &agentendpointpb.AptRepository{Uri: "http://repo"}}}},
-					{PackageRepository: &agentendpointpb.PackageRepository{Repository: &agentendpointpb.PackageRepository_Yum{Yum: &agentendpointpb.YumRepository{Id: "repo", BaseUrl: "http://repo"}}}},
-					{PackageRepository: &agentendpointpb.PackageRepository{Repository: &agentendpointpb.PackageRepository_Zypper{Zypper: &agentendpointpb.ZypperRepository{Id: "repo", BaseUrl: "http://repo"}}}},
-					{PackageRepository: &agentendpointpb.PackageRepository{Repository: &agentendpointpb.PackageRepository_Goo{Goo: &agentendpointpb.GooRepository{Name: "repo", Url: "http://repo"}}}},
-				},
-			},
-			aptExists: true, yumExists: true, zypperExists: true, googetExists: true,
-			wantErr: nil,
-		},
-		{
 			name: "apt install p1 with failure, want installing error",
 			egp: &agentendpointpb.EffectiveGuestPolicy{
 				Packages: []*agentendpointpb.EffectiveGuestPolicy_SourcedPackage{
@@ -597,164 +357,20 @@ func TestSetConfig(t *testing.T) {
 			},
 		},
 		{
-			name: "yum install p1 with failure, want installing error",
+			name: "apt repository configured, want nil error",
 			egp: &agentendpointpb.EffectiveGuestPolicy{
-				Packages: []*agentendpointpb.EffectiveGuestPolicy_SourcedPackage{
-					{Package: &agentendpointpb.Package{Name: "p1", DesiredState: agentendpointpb.DesiredState_INSTALLED, Manager: agentendpointpb.Package_YUM}},
+				PackageRepositories: []*agentendpointpb.EffectiveGuestPolicy_SourcedPackageRepository{
+					{PackageRepository: &agentendpointpb.PackageRepository{Repository: &agentendpointpb.PackageRepository_Apt{Apt: &agentendpointpb.AptRepository{Uri: "http://repo"}}}},
 				},
 			},
-			yumExists: true,
-			expectedCommands: []utiltest.ExpectedCommand{
-				{
-					Cmd:    exec.Command("/usr/bin/rpmquery", rpmQueryArgs...),
-					Stdout: []byte(""),
-				},
-				{
-					Cmd: exec.Command("/usr/bin/yum", "install", "--assumeyes", "p1"),
-					Err: fmt.Errorf("yum error"),
-				},
-			},
-			wantErr: setConfigError{
-				errors: []error{
-					fmt.Errorf("Error performing yum changes: error installing yum packages: error running /usr/bin/yum with args [\"install\" \"--assumeyes\" \"p1\"]: yum error, stdout: \"\", stderr: \"\""),
-				},
-			},
-		},
-		{
-			name: "zypper install p1 with failure, want installing error",
-			egp: &agentendpointpb.EffectiveGuestPolicy{
-				Packages: []*agentendpointpb.EffectiveGuestPolicy_SourcedPackage{
-					{Package: &agentendpointpb.Package{Name: "p1", DesiredState: agentendpointpb.DesiredState_INSTALLED, Manager: agentendpointpb.Package_ZYPPER}},
-				},
-			},
-			zypperExists: true,
-			expectedCommands: []utiltest.ExpectedCommand{
-				{
-					Cmd:    exec.Command("/usr/bin/rpmquery", rpmQueryArgs...),
-					Stdout: []byte(""),
-				},
-				{
-					Cmd: exec.Command("/usr/bin/zypper", "--gpg-auto-import-keys", "--non-interactive", "install", "--auto-agree-with-licenses", "p1"),
-					Err: fmt.Errorf("zypper error"),
-				},
-			},
-			wantErr: setConfigError{
-				errors: []error{
-					fmt.Errorf("Error performing zypper changes: error installing zypper packages: error running /usr/bin/zypper with args [\"--gpg-auto-import-keys\" \"--non-interactive\" \"install\" \"--auto-agree-with-licenses\" \"p1\"]: zypper error, stdout: \"\", stderr: \"\""),
-				},
-			},
-		},
-		{
-			name: "googet install p1 with failure, want installing  error",
-			egp: &agentendpointpb.EffectiveGuestPolicy{
-				Packages: []*agentendpointpb.EffectiveGuestPolicy_SourcedPackage{
-					{Package: &agentendpointpb.Package{Name: "p1", DesiredState: agentendpointpb.DesiredState_INSTALLED, Manager: agentendpointpb.Package_GOO}},
-				},
-			},
-			googetExists: true,
-			expectedCommands: []utiltest.ExpectedCommand{
-				{
-					Cmd:    exec.Command("googet.exe", "installed"),
-					Stdout: []byte(""),
-				},
-				{
-					Cmd: exec.Command("googet.exe", "-noconfirm", "install", "p1"),
-					Err: fmt.Errorf("googet error"),
-				},
-			},
-			wantErr: setConfigError{
-				errors: []error{
-					fmt.Errorf("Error performing googet changes: error installing googet packages: error running googet.exe with args [\"-noconfirm\" \"install\" \"p1\"]: googet error, stdout: \"\", stderr: \"\""),
-				},
-			},
-		},
-		{
-			name: "package ANY removed and unspecified manager/state, want nil error",
-			egp: &agentendpointpb.EffectiveGuestPolicy{
-				Packages: []*agentendpointpb.EffectiveGuestPolicy_SourcedPackage{
-					{
-						Package: &agentendpointpb.Package{
-							Name:         "p1",
-							DesiredState: agentendpointpb.DesiredState_REMOVED,
-							Manager:      agentendpointpb.Package_ANY,
-						},
-					},
-					{
-						Package: &agentendpointpb.Package{
-							Name:         "p2",
-							DesiredState: agentendpointpb.DesiredState_DESIRED_STATE_UNSPECIFIED,
-							Manager:      agentendpointpb.Package_MANAGER_UNSPECIFIED,
-						},
-					},
-					{
-						Package: &agentendpointpb.Package{
-							Name:         "p3",
-							DesiredState: agentendpointpb.DesiredState_UPDATED,
-							Manager:      agentendpointpb.Package_ANY,
-						},
-					},
-				},
-			},
-			aptExists: true, yumExists: true,
-			expectedCommands: []utiltest.ExpectedCommand{
-				{
-					Cmd:    exec.Command("/usr/bin/dpkg-query", dpkgQueryArgs...),
-					Stdout: []byte(`{"package":"p1","status":"installed"}`),
-				},
-				{
-					Cmd:  exec.Command("/usr/bin/apt-get", "update"),
-					Envs: aptEnv,
-				},
-				{
-					Cmd:    exec.Command("/usr/bin/apt-get", aptUpgradableArgs...),
-					Stdout: []byte("Inst p3 [1.0] (2.0 repo [amd64])\n"),
-					Envs:   aptEnv,
-				},
-				{
-					Cmd:  exec.Command("/usr/bin/apt-get", "update"),
-					Envs: aptEnv,
-				},
-				{
-					Cmd:  exec.Command("/usr/bin/apt-get", "install", "-y", "p2"),
-					Envs: aptEnv,
-				},
-				{
-					Cmd:  exec.Command("/usr/bin/apt-get", "install", "-y", "p3"),
-					Envs: aptEnv,
-				},
-				{
-					Cmd:  exec.Command("/usr/bin/apt-get", "remove", "-y", "p1"),
-					Envs: aptEnv,
-				},
-				{
-					Cmd:    exec.Command("/usr/bin/rpmquery", rpmQueryArgs...),
-					Stdout: []byte(`{"package":"p1","status":"installed"}`),
-				},
-				{
-					Cmd: exec.Command("/usr/bin/yum", yumCheckUpdateArgs...),
-					Err: yumCheckUpdateErr,
-				},
-				{
-					Cmd:    exec.Command("/usr/bin/yum", yumListUpdatesArgs...),
-					Stdout: []byte("Updating:\n p3 x86_64 2.0 updates 100 k\n"),
-				},
-				{
-					Cmd: exec.Command("/usr/bin/yum", "install", "--assumeyes", "p2"),
-				},
-				{
-					Cmd: exec.Command("/usr/bin/yum", "install", "--assumeyes", "p3"),
-				},
-				{
-					Cmd: exec.Command("/usr/bin/yum", "remove", "--assumeyes", "p1"),
-				},
-			},
-			wantErr: nil,
+			aptExists: true,
+			wantErr:   nil,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			setupSetConfigTest(t, tt.aptExists, tt.yumExists, tt.zypperExists, tt.googetExists, mockCommandRunner)
+			setupSetConfigTest(t, tt.aptExists, false, false, false, mockCommandRunner)
 
 			utiltest.SetExpectedCommands(ctx, mockCommandRunner, tt.expectedCommands)
 			err := setConfig(context.Background(), tt.egp)

--- a/policies/policies_test.go
+++ b/policies/policies_test.go
@@ -20,12 +20,17 @@ import (
 	"crypto/sha256"
 	"fmt"
 	"os"
+	"os/exec"
 	"syscall"
 	"testing"
 	"time"
 
 	"cloud.google.com/go/osconfig/agentendpoint/apiv1beta/agentendpointpb"
+	"github.com/GoogleCloudPlatform/osconfig/osinfo"
+	"github.com/GoogleCloudPlatform/osconfig/packages"
+	utilmocks "github.com/GoogleCloudPlatform/osconfig/util/mocks"
 	"github.com/GoogleCloudPlatform/osconfig/util/utiltest"
+	"github.com/golang/mock/gomock"
 )
 
 // TestChecksum verifies that checksum correctly calculates the SHA256 hash of the input reader.
@@ -206,4 +211,326 @@ func TestInstallRecipesHandlesInputs(t *testing.T) {
 			utiltest.AssertErrorMatch(t, err, tt.wantErr)
 		})
 	}
+}
+
+// TestSetConfig verifies that setConfig handles different package managers and their configurations.
+func TestSetConfig(t *testing.T) {
+	ctx := context.Background()
+
+	dpkgQueryArgs := []string{"-W", "-f", "\\{\"architecture\":\"${Architecture}\",\"package\":\"${Package}\",\"source_name\":\"${source:Package}\",\"source_version\":\"${source:Version}\",\"status\":\"${db:Status-Status}\",\"version\":\"${Version}\"\\}\n"}
+	rpmQueryArgs := []string{"--queryformat", "\\{\"architecture\":\"%{ARCH}\",\"package\":\"%{NAME}\",\"source_name\":\"%{SOURCERPM}\",\"version\":\"%|EPOCH?{%{EPOCH}:}:{}|%{VERSION}-%{RELEASE}\"\\}\n", "-a"}
+	aptUpgradableArgs := []string{"--just-print", "-qq", "dist-upgrade"}
+	yumCheckUpdateArgs := []string{"check-update", "--assumeyes"}
+	yumListUpdatesArgs := []string{"update", "--assumeno", "--color=never"}
+	zypperListUpdatesArgs := []string{"--gpg-auto-import-keys", "-q", "list-updates"}
+
+	yumCheckUpdateErr := exec.Command("/bin/bash", "-c", "exit 100").Run()
+
+	mockCtrl := gomock.NewController(t)
+	t.Cleanup(func() { mockCtrl.Finish() })
+
+	mockCommandRunner := utilmocks.NewMockCommandRunner(mockCtrl)
+
+	tests := []struct {
+		name             string
+		egp              *agentendpointpb.EffectiveGuestPolicy
+		aptExists        bool
+		yumExists        bool
+		zypperExists     bool
+		googetExists     bool
+		expectedCommands []utiltest.ExpectedCommand
+	}{
+		{
+			name: "empty policy",
+			egp:  &agentendpointpb.EffectiveGuestPolicy{},
+		},
+		{
+			name: "apt install",
+			egp: &agentendpointpb.EffectiveGuestPolicy{
+				Packages: []*agentendpointpb.EffectiveGuestPolicy_SourcedPackage{
+					{Package: &agentendpointpb.Package{Name: "p1", DesiredState: agentendpointpb.DesiredState_INSTALLED, Manager: agentendpointpb.Package_APT}},
+				},
+			},
+			aptExists: true,
+			expectedCommands: []utiltest.ExpectedCommand{
+				{
+					Cmd:    exec.Command("/usr/bin/dpkg-query", dpkgQueryArgs...),
+					Stdout: []byte(""),
+				},
+				{Cmd: exec.Command("/usr/bin/apt-get", "update")},
+				{Cmd: exec.Command("/usr/bin/apt-get", "install", "-y", "p1")},
+			},
+		},
+		{
+			name: "apt install manager not found",
+			egp: &agentendpointpb.EffectiveGuestPolicy{
+				Packages: []*agentendpointpb.EffectiveGuestPolicy_SourcedPackage{
+					{Package: &agentendpointpb.Package{Name: "p1", DesiredState: agentendpointpb.DesiredState_INSTALLED, Manager: agentendpointpb.Package_APT}},
+				},
+			},
+			aptExists: false,
+		},
+		{
+			name: "apt update",
+			egp: &agentendpointpb.EffectiveGuestPolicy{
+				Packages: []*agentendpointpb.EffectiveGuestPolicy_SourcedPackage{
+					{Package: &agentendpointpb.Package{Name: "p1", DesiredState: agentendpointpb.DesiredState_UPDATED, Manager: agentendpointpb.Package_APT}},
+				},
+			},
+			aptExists: true,
+			expectedCommands: []utiltest.ExpectedCommand{
+				{
+					Cmd:    exec.Command("/usr/bin/dpkg-query", dpkgQueryArgs...),
+					Stdout: []byte(`{"package":"p1","status":"installed"}`),
+				},
+				{Cmd: exec.Command("/usr/bin/apt-get", "update")},
+				{
+					Cmd:    exec.Command("/usr/bin/apt-get", aptUpgradableArgs...),
+					Stdout: []byte("Inst p1 [1.0] (2.0 repo [amd64])\n"),
+				},
+				{Cmd: exec.Command("/usr/bin/apt-get", "install", "-y", "p1")},
+			},
+		},
+		{
+			name: "apt remove",
+			egp: &agentendpointpb.EffectiveGuestPolicy{
+				Packages: []*agentendpointpb.EffectiveGuestPolicy_SourcedPackage{
+					{Package: &agentendpointpb.Package{Name: "p1", DesiredState: agentendpointpb.DesiredState_REMOVED, Manager: agentendpointpb.Package_APT}},
+				},
+			},
+			aptExists: true,
+			expectedCommands: []utiltest.ExpectedCommand{
+				{
+					Cmd:    exec.Command("/usr/bin/dpkg-query", dpkgQueryArgs...),
+					Stdout: []byte(`{"package":"p1","status":"installed"}`),
+				},
+				{Cmd: exec.Command("/usr/bin/apt-get", "remove", "-y", "p1")},
+			},
+		},
+		{
+			name: "yum install",
+			egp: &agentendpointpb.EffectiveGuestPolicy{
+				Packages: []*agentendpointpb.EffectiveGuestPolicy_SourcedPackage{
+					{Package: &agentendpointpb.Package{Name: "p1", DesiredState: agentendpointpb.DesiredState_INSTALLED, Manager: agentendpointpb.Package_YUM}},
+				},
+			},
+			yumExists: true,
+			expectedCommands: []utiltest.ExpectedCommand{
+				{
+					Cmd:    exec.Command("/usr/bin/rpmquery", rpmQueryArgs...),
+					Stdout: []byte(""),
+				},
+				{Cmd: exec.Command("/usr/bin/yum", "install", "--assumeyes", "p1")},
+			},
+		},
+		{
+			name: "yum update",
+			egp: &agentendpointpb.EffectiveGuestPolicy{
+				Packages: []*agentendpointpb.EffectiveGuestPolicy_SourcedPackage{
+					{Package: &agentendpointpb.Package{Name: "p1", DesiredState: agentendpointpb.DesiredState_UPDATED, Manager: agentendpointpb.Package_YUM}},
+				},
+			},
+			yumExists: true,
+			expectedCommands: []utiltest.ExpectedCommand{
+				{
+					Cmd:    exec.Command("/usr/bin/rpmquery", rpmQueryArgs...),
+					Stdout: []byte(`{"package":"p1","status":"installed"}`),
+				},
+				{
+					Cmd: exec.Command("/usr/bin/yum", yumCheckUpdateArgs...),
+					Err: yumCheckUpdateErr,
+				},
+				{
+					Cmd:    exec.Command("/usr/bin/yum", yumListUpdatesArgs...),
+					Stdout: []byte("Updating:\n p1 x86_64 2.0 updates 100 k\n"),
+				},
+				{Cmd: exec.Command("/usr/bin/yum", "install", "--assumeyes", "p1")},
+			},
+		},
+		{
+			name: "yum remove",
+			egp: &agentendpointpb.EffectiveGuestPolicy{
+				Packages: []*agentendpointpb.EffectiveGuestPolicy_SourcedPackage{
+					{Package: &agentendpointpb.Package{Name: "p1", DesiredState: agentendpointpb.DesiredState_REMOVED, Manager: agentendpointpb.Package_YUM}},
+				},
+			},
+			yumExists: true,
+			expectedCommands: []utiltest.ExpectedCommand{
+				{
+					Cmd:    exec.Command("/usr/bin/rpmquery", rpmQueryArgs...),
+					Stdout: []byte(`{"package":"p1","status":"installed"}`),
+				},
+				{Cmd: exec.Command("/usr/bin/yum", "remove", "--assumeyes", "p1")},
+			},
+		},
+		{
+			name: "zypper install",
+			egp: &agentendpointpb.EffectiveGuestPolicy{
+				Packages: []*agentendpointpb.EffectiveGuestPolicy_SourcedPackage{
+					{Package: &agentendpointpb.Package{Name: "p1", DesiredState: agentendpointpb.DesiredState_INSTALLED, Manager: agentendpointpb.Package_ZYPPER}},
+				},
+			},
+			zypperExists: true,
+			expectedCommands: []utiltest.ExpectedCommand{
+				{
+					Cmd:    exec.Command("/usr/bin/rpmquery", rpmQueryArgs...),
+					Stdout: []byte(""),
+				},
+				{Cmd: exec.Command("/usr/bin/zypper", "--gpg-auto-import-keys", "--non-interactive", "install", "--auto-agree-with-licenses", "p1")},
+			},
+		},
+		{
+			name: "zypper update",
+			egp: &agentendpointpb.EffectiveGuestPolicy{
+				Packages: []*agentendpointpb.EffectiveGuestPolicy_SourcedPackage{
+					{Package: &agentendpointpb.Package{Name: "p1", DesiredState: agentendpointpb.DesiredState_UPDATED, Manager: agentendpointpb.Package_ZYPPER}},
+				},
+			},
+			zypperExists: true,
+			expectedCommands: []utiltest.ExpectedCommand{
+				{
+					Cmd:    exec.Command("/usr/bin/rpmquery", rpmQueryArgs...),
+					Stdout: []byte(`{"package":"p1","status":"installed"}`),
+				},
+				{
+					Cmd:    exec.Command("/usr/bin/zypper", zypperListUpdatesArgs...),
+					Stdout: []byte("v | Repo | p1 | 1.0 | 2.0 | x86_64\n"),
+				},
+				{Cmd: exec.Command("/usr/bin/zypper", "--gpg-auto-import-keys", "--non-interactive", "install", "--auto-agree-with-licenses", "p1")},
+			},
+		},
+		{
+			name: "zypper remove",
+			egp: &agentendpointpb.EffectiveGuestPolicy{
+				Packages: []*agentendpointpb.EffectiveGuestPolicy_SourcedPackage{
+					{Package: &agentendpointpb.Package{Name: "p1", DesiredState: agentendpointpb.DesiredState_REMOVED, Manager: agentendpointpb.Package_ZYPPER}},
+				},
+			},
+			zypperExists: true,
+			expectedCommands: []utiltest.ExpectedCommand{
+				{
+					Cmd:    exec.Command("/usr/bin/rpmquery", rpmQueryArgs...),
+					Stdout: []byte(`{"package":"p1","status":"installed"}`),
+				},
+				{Cmd: exec.Command("/usr/bin/zypper", "--non-interactive", "remove", "p1")},
+			},
+		},
+		{
+			name: "googet install",
+			egp: &agentendpointpb.EffectiveGuestPolicy{
+				Packages: []*agentendpointpb.EffectiveGuestPolicy_SourcedPackage{
+					{Package: &agentendpointpb.Package{Name: "p1", DesiredState: agentendpointpb.DesiredState_INSTALLED, Manager: agentendpointpb.Package_GOO}},
+				},
+			},
+			googetExists: true,
+			expectedCommands: []utiltest.ExpectedCommand{
+				{
+					Cmd:    exec.Command("googet.exe", "installed"),
+					Stdout: []byte(""),
+				},
+				{Cmd: exec.Command("googet.exe", "-noconfirm", "install", "p1")},
+			},
+		},
+		{
+			name: "googet update",
+			egp: &agentendpointpb.EffectiveGuestPolicy{
+				Packages: []*agentendpointpb.EffectiveGuestPolicy_SourcedPackage{
+					{Package: &agentendpointpb.Package{Name: "p1", DesiredState: agentendpointpb.DesiredState_UPDATED, Manager: agentendpointpb.Package_GOO}},
+				},
+			},
+			googetExists: true,
+			expectedCommands: []utiltest.ExpectedCommand{
+				{
+					Cmd:    exec.Command("googet.exe", "installed"),
+					Stdout: []byte("p1.x86_64 1.0\n"),
+				},
+				{
+					Cmd:    exec.Command("googet.exe", "update"),
+					Stdout: []byte("p1.noarch, 1.0 --> 2.0 from repo\n"),
+				},
+				{Cmd: exec.Command("googet.exe", "-noconfirm", "install", "p1")},
+			},
+		},
+		{
+			name: "googet remove",
+			egp: &agentendpointpb.EffectiveGuestPolicy{
+				Packages: []*agentendpointpb.EffectiveGuestPolicy_SourcedPackage{
+					{Package: &agentendpointpb.Package{Name: "p1", DesiredState: agentendpointpb.DesiredState_REMOVED, Manager: agentendpointpb.Package_GOO}},
+				},
+			},
+			googetExists: true,
+			expectedCommands: []utiltest.ExpectedCommand{
+				{
+					Cmd:    exec.Command("googet.exe", "installed"),
+					Stdout: []byte("p1.x86_64 1.0\n"),
+				},
+				{Cmd: exec.Command("googet.exe", "-noconfirm", "remove", "p1")},
+			},
+		},
+		{
+			name: "package ANY install",
+			egp: &agentendpointpb.EffectiveGuestPolicy{
+				Packages: []*agentendpointpb.EffectiveGuestPolicy_SourcedPackage{
+					{Package: &agentendpointpb.Package{Name: "p1", DesiredState: agentendpointpb.DesiredState_INSTALLED, Manager: agentendpointpb.Package_ANY}},
+				},
+			},
+			aptExists: true, yumExists: true,
+			expectedCommands: []utiltest.ExpectedCommand{
+				{
+					Cmd:    exec.Command("/usr/bin/dpkg-query", dpkgQueryArgs...),
+					Stdout: []byte(""),
+				},
+				{Cmd: exec.Command("/usr/bin/apt-get", "update")},
+				{Cmd: exec.Command("/usr/bin/apt-get", "install", "-y", "p1")},
+				{
+					Cmd:    exec.Command("/usr/bin/rpmquery", rpmQueryArgs...),
+					Stdout: []byte(""),
+				},
+				{Cmd: exec.Command("/usr/bin/yum", "install", "--assumeyes", "p1")},
+			},
+		},
+		{
+			name: "all repositories",
+			egp: &agentendpointpb.EffectiveGuestPolicy{
+				PackageRepositories: []*agentendpointpb.EffectiveGuestPolicy_SourcedPackageRepository{
+					{PackageRepository: &agentendpointpb.PackageRepository{Repository: &agentendpointpb.PackageRepository_Apt{Apt: &agentendpointpb.AptRepository{Uri: "http://repo"}}}},
+					{PackageRepository: &agentendpointpb.PackageRepository{Repository: &agentendpointpb.PackageRepository_Yum{Yum: &agentendpointpb.YumRepository{Id: "repo", BaseUrl: "http://repo"}}}},
+					{PackageRepository: &agentendpointpb.PackageRepository{Repository: &agentendpointpb.PackageRepository_Zypper{Zypper: &agentendpointpb.ZypperRepository{Id: "repo", BaseUrl: "http://repo"}}}},
+					{PackageRepository: &agentendpointpb.PackageRepository{Repository: &agentendpointpb.PackageRepository_Goo{Goo: &agentendpointpb.GooRepository{Name: "repo", Url: "http://repo"}}}},
+				},
+			},
+			aptExists: true, yumExists: true, zypperExists: true, googetExists: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			setupSetConfigTest(t, tt.aptExists, tt.yumExists, tt.zypperExists, tt.googetExists, mockCommandRunner)
+
+			utiltest.SetExpectedCommands(ctx, mockCommandRunner, tt.expectedCommands)
+			setConfig(context.Background(), tt.egp)
+		})
+	}
+}
+
+type policiesStubOsInfoProvider struct {
+	osinfo osinfo.OSInfo
+}
+
+func (s policiesStubOsInfoProvider) GetOSInfo(ctx context.Context) (osinfo.OSInfo, error) {
+	return s.osinfo, nil
+}
+
+// setupSetConfigTest sets up the environment for SetConfig tests by mocking the command runner.
+func setupSetConfigTest(t *testing.T, apt, yum, zypper, googet bool, runner *utilmocks.MockCommandRunner) {
+	utiltest.OverrideVariable(t, &packages.AptExists, apt)
+	utiltest.OverrideVariable(t, &packages.YumExists, yum)
+	utiltest.OverrideVariable(t, &packages.ZypperExists, zypper)
+	utiltest.OverrideVariable(t, &packages.GooGetExists, googet)
+	utiltest.OverrideVariable(t, &osInfoProvider, (osinfo.Provider)(policiesStubOsInfoProvider{
+		osinfo: osinfo.OSInfo{ShortName: "debian", Version: "11"},
+	}))
+
+	packages.SetCommandRunner(runner)
+	packages.SetPtyCommandRunner(runner)
 }


### PR DESCRIPTION
Second part of unit tests for policies.go: TestSetConfigApt implementation.
Final test coverage: github.com/GoogleCloudPlatform/osconfig/policies/policies.go:125:	setConfig		90.9%