### PR TITLE
Add unit tests for policies/policies.go PART 3

### DIFF
--- a/policies/policies_test.go
+++ b/policies/policies_test.go
@@ -216,11 +216,18 @@ func TestSetConfigYum(t *testing.T) {
 	t.Cleanup(func() { mockCtrl.Finish() })
 
 	mockCommandRunner := utilmocks.NewMockCommandRunner(mockCtrl)
+	setupSetConfigTest(t, mockCommandRunner)
 
 	rpmQueryArgs := []string{"--queryformat", "\\{\"architecture\":\"%{ARCH}\",\"package\":\"%{NAME}\",\"source_name\":\"%{SOURCERPM}\",\"version\":\"%|EPOCH?{%{EPOCH}:}:{}|%{VERSION}-%{RELEASE}\"\\}\n", "-a"}
 	yumCheckUpdateArgs := []string{"check-update", "--assumeyes"}
 	yumListUpdatesArgs := []string{"update", "--assumeno", "--color=never"}
 	yumCheckUpdateErr := exec.Command("/bin/bash", "-c", "exit 100").Run()
+
+	setupYumEnv := func(t *testing.T, yumExists bool) {
+		utiltest.OverrideVariable(t, &packages.YumExists, yumExists)
+		tmpDir := t.TempDir()
+		utiltest.OverrideVariable(t, &yumRepoFilePath, func() string { return filepath.Join(tmpDir, "yum.repo") })
+	}
 
 	tests := []struct {
 		name             string
@@ -351,9 +358,9 @@ func TestSetConfigYum(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			setupSetConfigTest(t, false, tt.yumExists, false, false, mockCommandRunner)
-
+			setupYumEnv(t, tt.yumExists)
 			utiltest.SetExpectedCommands(ctx, mockCommandRunner, tt.expectedCommands)
+
 			err := setConfig(context.Background(), tt.egp)
 			utiltest.AssertErrorMatch(t, err, tt.wantErr)
 		})

--- a/policies/policies_test.go
+++ b/policies/policies_test.go
@@ -230,6 +230,9 @@ func TestSetConfigApt(t *testing.T) {
 
 	setupAptEnv := func(t *testing.T, aptExists bool) {
 		utiltest.OverrideVariable(t, &packages.AptExists, aptExists)
+		utiltest.OverrideVariable(t, &packages.YumExists, false)
+		utiltest.OverrideVariable(t, &packages.ZypperExists, false)
+		utiltest.OverrideVariable(t, &packages.GooGetExists, false)
 		tmpDir := t.TempDir()
 		utiltest.OverrideVariable(t, &aptRepoFilePath, func() string { return filepath.Join(tmpDir, "apt.list") })
 	}
@@ -403,6 +406,9 @@ func TestSetConfigYum(t *testing.T) {
 
 	setupYumEnv := func(t *testing.T, yumExists bool) {
 		utiltest.OverrideVariable(t, &packages.YumExists, yumExists)
+		utiltest.OverrideVariable(t, &packages.AptExists, false)
+		utiltest.OverrideVariable(t, &packages.ZypperExists, false)
+		utiltest.OverrideVariable(t, &packages.GooGetExists, false)
 		tmpDir := t.TempDir()
 		utiltest.OverrideVariable(t, &yumRepoFilePath, func() string { return filepath.Join(tmpDir, "yum.repo") })
 	}

--- a/policies/policies_test.go
+++ b/policies/policies_test.go
@@ -207,3 +207,155 @@ func TestInstallRecipesHandlesInputs(t *testing.T) {
 		})
 	}
 }
+
+// TestSetConfigYum verifies that setConfig handles yum package manager and its configurations.
+func TestSetConfigYum(t *testing.T) {
+	ctx := context.Background()
+
+	mockCtrl := gomock.NewController(t)
+	t.Cleanup(func() { mockCtrl.Finish() })
+
+	mockCommandRunner := utilmocks.NewMockCommandRunner(mockCtrl)
+
+	rpmQueryArgs := []string{"--queryformat", "\\{\"architecture\":\"%{ARCH}\",\"package\":\"%{NAME}\",\"source_name\":\"%{SOURCERPM}\",\"version\":\"%|EPOCH?{%{EPOCH}:}:{}|%{VERSION}-%{RELEASE}\"\\}\n", "-a"}
+	yumCheckUpdateArgs := []string{"check-update", "--assumeyes"}
+	yumListUpdatesArgs := []string{"update", "--assumeno", "--color=never"}
+	yumCheckUpdateErr := exec.Command("/bin/bash", "-c", "exit 100").Run()
+
+	tests := []struct {
+		name             string
+		egp              *agentendpointpb.EffectiveGuestPolicy
+		yumExists        bool
+		expectedCommands []utiltest.ExpectedCommand
+		wantErr          error
+	}{
+		{
+			name: "yum install package p1, want nil error",
+			egp: &agentendpointpb.EffectiveGuestPolicy{
+				Packages: []*agentendpointpb.EffectiveGuestPolicy_SourcedPackage{
+					{Package: &agentendpointpb.Package{Name: "p1", DesiredState: agentendpointpb.DesiredState_INSTALLED, Manager: agentendpointpb.Package_YUM}},
+				},
+			},
+			yumExists: true,
+			expectedCommands: []utiltest.ExpectedCommand{
+				{
+					Cmd:    exec.Command("/usr/bin/rpmquery", rpmQueryArgs...),
+					Stdout: []byte(""),
+				},
+				{
+					Cmd: exec.Command("/usr/bin/yum", "install", "--assumeyes", "p1"),
+				},
+			},
+			wantErr: nil,
+		},
+		{
+			name: "yum update package p1, want nil error",
+			egp: &agentendpointpb.EffectiveGuestPolicy{
+				Packages: []*agentendpointpb.EffectiveGuestPolicy_SourcedPackage{
+					{Package: &agentendpointpb.Package{Name: "p1", DesiredState: agentendpointpb.DesiredState_UPDATED, Manager: agentendpointpb.Package_YUM}},
+				},
+			},
+			yumExists: true,
+			expectedCommands: []utiltest.ExpectedCommand{
+				{
+					Cmd:    exec.Command("/usr/bin/rpmquery", rpmQueryArgs...),
+					Stdout: []byte(`{"package":"p1","status":"installed"}`),
+				},
+				{
+					Cmd: exec.Command("/usr/bin/yum", yumCheckUpdateArgs...),
+					Err: yumCheckUpdateErr,
+				},
+				{
+					Cmd:    exec.Command("/usr/bin/yum", yumListUpdatesArgs...),
+					Stdout: []byte("Updating:\n p1 x86_64 2.0 updates 100 k\n"),
+				},
+				{
+					Cmd: exec.Command("/usr/bin/yum", "install", "--assumeyes", "p1"),
+				},
+			},
+			wantErr: nil,
+		},
+		{
+			name: "yum remove package p1, want nil error",
+			egp: &agentendpointpb.EffectiveGuestPolicy{
+				Packages: []*agentendpointpb.EffectiveGuestPolicy_SourcedPackage{
+					{Package: &agentendpointpb.Package{Name: "p1", DesiredState: agentendpointpb.DesiredState_REMOVED, Manager: agentendpointpb.Package_YUM}},
+				},
+			},
+			yumExists: true,
+			expectedCommands: []utiltest.ExpectedCommand{
+				{
+					Cmd:    exec.Command("/usr/bin/rpmquery", rpmQueryArgs...),
+					Stdout: []byte(`{"package":"p1","status":"installed"}`),
+				},
+				{
+					Cmd: exec.Command("/usr/bin/yum", "remove", "--assumeyes", "p1"),
+				},
+			},
+			wantErr: nil,
+		},
+		{
+			name: "yum install p1 with failure, want installing error",
+			egp: &agentendpointpb.EffectiveGuestPolicy{
+				Packages: []*agentendpointpb.EffectiveGuestPolicy_SourcedPackage{
+					{Package: &agentendpointpb.Package{Name: "p1", DesiredState: agentendpointpb.DesiredState_INSTALLED, Manager: agentendpointpb.Package_YUM}},
+				},
+			},
+			yumExists: true,
+			expectedCommands: []utiltest.ExpectedCommand{
+				{
+					Cmd:    exec.Command("/usr/bin/rpmquery", rpmQueryArgs...),
+					Stdout: []byte(""),
+				},
+				{
+					Cmd: exec.Command("/usr/bin/yum", "install", "--assumeyes", "p1"),
+					Err: fmt.Errorf("yum error"),
+				},
+			},
+			wantErr: setConfigError{
+				errors: []error{
+					fmt.Errorf("Error performing yum changes: error installing yum packages: error running /usr/bin/yum with args [\"install\" \"--assumeyes\" \"p1\"]: yum error, stdout: \"\", stderr: \"\""),
+				},
+			},
+		},
+		{
+			name: "yum repository configured, want nil error",
+			egp: &agentendpointpb.EffectiveGuestPolicy{
+				PackageRepositories: []*agentendpointpb.EffectiveGuestPolicy_SourcedPackageRepository{
+					{PackageRepository: &agentendpointpb.PackageRepository{Repository: &agentendpointpb.PackageRepository_Yum{Yum: &agentendpointpb.YumRepository{Id: "repo", BaseUrl: "http://repo"}}}},
+				},
+			},
+			yumExists: true,
+			wantErr:   nil,
+		},
+		{
+			name: "package ANY install p1, want nil error",
+			egp: &agentendpointpb.EffectiveGuestPolicy{
+				Packages: []*agentendpointpb.EffectiveGuestPolicy_SourcedPackage{
+					{Package: &agentendpointpb.Package{Name: "p1", DesiredState: agentendpointpb.DesiredState_INSTALLED, Manager: agentendpointpb.Package_ANY}},
+				},
+			},
+			yumExists: true,
+			expectedCommands: []utiltest.ExpectedCommand{
+				{
+					Cmd:    exec.Command("/usr/bin/rpmquery", rpmQueryArgs...),
+					Stdout: []byte(""),
+				},
+				{
+					Cmd: exec.Command("/usr/bin/yum", "install", "--assumeyes", "p1"),
+				},
+			},
+			wantErr: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			setupSetConfigTest(t, false, tt.yumExists, false, false, mockCommandRunner)
+
+			utiltest.SetExpectedCommands(ctx, mockCommandRunner, tt.expectedCommands)
+			err := setConfig(context.Background(), tt.egp)
+			utiltest.AssertErrorMatch(t, err, tt.wantErr)
+		})
+	}
+}

--- a/policies/policies_test.go
+++ b/policies/policies_test.go
@@ -383,8 +383,8 @@ func TestSetConfigApt(t *testing.T) {
 			setupAptEnv(t, tt.aptExists)
 			utiltest.SetExpectedCommands(ctx, mockCommandRunner, tt.expectedCommands)
 
-			err := setConfig(context.Background(), tt.egp)
-			utiltest.AssertErrorMatch(t, err, tt.wantErr)
+			gotErr := setConfig(context.Background(), tt.egp)
+			utiltest.AssertErrorMatch(t, gotErr, tt.wantErr)
 		})
 	}
 }
@@ -545,8 +545,8 @@ func TestSetConfigYum(t *testing.T) {
 			setupYumEnv(t, tt.yumExists)
 			utiltest.SetExpectedCommands(ctx, mockCommandRunner, tt.expectedCommands)
 
-			err := setConfig(context.Background(), tt.egp)
-			utiltest.AssertErrorMatch(t, err, tt.wantErr)
+			gotErr := setConfig(context.Background(), tt.egp)
+			utiltest.AssertErrorMatch(t, gotErr, tt.wantErr)
 		})
 	}
 }

--- a/policies/policies_test.go
+++ b/policies/policies_test.go
@@ -20,12 +20,18 @@ import (
 	"crypto/sha256"
 	"fmt"
 	"os"
+	"os/exec"
+	"path/filepath"
 	"syscall"
 	"testing"
 	"time"
 
 	"cloud.google.com/go/osconfig/agentendpoint/apiv1beta/agentendpointpb"
+	"github.com/GoogleCloudPlatform/osconfig/osinfo"
+	"github.com/GoogleCloudPlatform/osconfig/packages"
+	utilmocks "github.com/GoogleCloudPlatform/osconfig/util/mocks"
 	"github.com/GoogleCloudPlatform/osconfig/util/utiltest"
+	"github.com/golang/mock/gomock"
 )
 
 // TestChecksum verifies that checksum correctly calculates the SHA256 hash of the input reader.
@@ -208,6 +214,178 @@ func TestInstallRecipesHandlesInputs(t *testing.T) {
 	}
 }
 
+// TestSetConfigApt verifies that setConfig handles apt package manager and its configurations.
+func TestSetConfigApt(t *testing.T) {
+	ctx := context.Background()
+
+	mockCtrl := gomock.NewController(t)
+	t.Cleanup(func() { mockCtrl.Finish() })
+
+	mockCommandRunner := utilmocks.NewMockCommandRunner(mockCtrl)
+	setupSetConfigTest(t, mockCommandRunner)
+
+	dpkgQueryArgs := []string{"-W", "-f", "\\{\"architecture\":\"${Architecture}\",\"package\":\"${Package}\",\"source_name\":\"${source:Package}\",\"source_version\":\"${source:Version}\",\"status\":\"${db:Status-Status}\",\"version\":\"${Version}\"\\}\n"}
+	aptUpgradableArgs := []string{"--just-print", "-qq", "dist-upgrade"}
+	aptEnv := []string{"DEBIAN_FRONTEND=noninteractive"}
+
+	setupAptEnv := func(t *testing.T, aptExists bool) {
+		utiltest.OverrideVariable(t, &packages.AptExists, aptExists)
+		tmpDir := t.TempDir()
+		utiltest.OverrideVariable(t, &aptRepoFilePath, func() string { return filepath.Join(tmpDir, "apt.list") })
+	}
+
+	tests := []struct {
+		name             string
+		egp              *agentendpointpb.EffectiveGuestPolicy
+		aptExists        bool
+		expectedCommands []utiltest.ExpectedCommand
+		wantErr          error
+	}{
+		{
+			name:    "empty policy, want nil error",
+			egp:     &agentendpointpb.EffectiveGuestPolicy{},
+			wantErr: nil,
+		},
+		{
+			name: "apt install package p1, want nil error",
+			egp: &agentendpointpb.EffectiveGuestPolicy{
+				Packages: []*agentendpointpb.EffectiveGuestPolicy_SourcedPackage{
+					{Package: &agentendpointpb.Package{Name: "p1", DesiredState: agentendpointpb.DesiredState_INSTALLED, Manager: agentendpointpb.Package_APT}},
+				},
+			},
+			aptExists: true,
+			expectedCommands: []utiltest.ExpectedCommand{
+				{
+					Cmd:    exec.Command("/usr/bin/dpkg-query", dpkgQueryArgs...),
+					Stdout: []byte(""),
+				},
+				{
+					Cmd:  exec.Command("/usr/bin/apt-get", "update"),
+					Envs: aptEnv,
+				},
+				{
+					Cmd:  exec.Command("/usr/bin/apt-get", "install", "-y", "p1"),
+					Envs: aptEnv,
+				},
+			},
+			wantErr: nil,
+		},
+		{
+			name: "apt install manager not found, want nil error",
+			egp: &agentendpointpb.EffectiveGuestPolicy{
+				Packages: []*agentendpointpb.EffectiveGuestPolicy_SourcedPackage{
+					{Package: &agentendpointpb.Package{Name: "p1", DesiredState: agentendpointpb.DesiredState_INSTALLED, Manager: agentendpointpb.Package_APT}},
+				},
+			},
+			aptExists: false,
+			wantErr:   nil,
+		},
+		{
+			name: "apt update package p1, want nil error",
+			egp: &agentendpointpb.EffectiveGuestPolicy{
+				Packages: []*agentendpointpb.EffectiveGuestPolicy_SourcedPackage{
+					{Package: &agentendpointpb.Package{Name: "p1", DesiredState: agentendpointpb.DesiredState_UPDATED, Manager: agentendpointpb.Package_APT}},
+				},
+			},
+			aptExists: true,
+			expectedCommands: []utiltest.ExpectedCommand{
+				{
+					Cmd:    exec.Command("/usr/bin/dpkg-query", dpkgQueryArgs...),
+					Stdout: []byte(`{"package":"p1","status":"installed"}`),
+				},
+				{
+					Cmd:  exec.Command("/usr/bin/apt-get", "update"),
+					Envs: aptEnv,
+				},
+				{
+					Cmd:    exec.Command("/usr/bin/apt-get", aptUpgradableArgs...),
+					Stdout: []byte("Inst p1 [1.0] (2.0 repo [amd64])\n"),
+					Envs:   aptEnv,
+				},
+				{
+					Cmd:  exec.Command("/usr/bin/apt-get", "install", "-y", "p1"),
+					Envs: aptEnv,
+				},
+			},
+			wantErr: nil,
+		},
+		{
+			name: "apt remove package p1, want nil error",
+			egp: &agentendpointpb.EffectiveGuestPolicy{
+				Packages: []*agentendpointpb.EffectiveGuestPolicy_SourcedPackage{
+					{Package: &agentendpointpb.Package{Name: "p1", DesiredState: agentendpointpb.DesiredState_REMOVED, Manager: agentendpointpb.Package_APT}},
+				},
+			},
+			aptExists: true,
+			expectedCommands: []utiltest.ExpectedCommand{
+				{
+					Cmd:    exec.Command("/usr/bin/dpkg-query", dpkgQueryArgs...),
+					Stdout: []byte(`{"package":"p1","status":"installed"}`),
+				},
+				{
+					Cmd:  exec.Command("/usr/bin/apt-get", "remove", "-y", "p1"),
+					Envs: aptEnv,
+				},
+			},
+			wantErr: nil,
+		},
+		{
+			name: "apt install p1 with failure, want installing error",
+			egp: &agentendpointpb.EffectiveGuestPolicy{
+				Packages: []*agentendpointpb.EffectiveGuestPolicy_SourcedPackage{
+					{Package: &agentendpointpb.Package{Name: "p1", DesiredState: agentendpointpb.DesiredState_INSTALLED, Manager: agentendpointpb.Package_APT}},
+				},
+			},
+			aptExists: true,
+			expectedCommands: []utiltest.ExpectedCommand{
+				{
+					Cmd:    exec.Command("/usr/bin/dpkg-query", dpkgQueryArgs...),
+					Stdout: []byte(""),
+				},
+				{
+					Cmd:  exec.Command("/usr/bin/apt-get", "update"),
+					Envs: aptEnv,
+				},
+				{
+					Cmd:  exec.Command("/usr/bin/apt-get", "install", "-y", "p1"),
+					Envs: aptEnv,
+					Err:  fmt.Errorf("individual install error"),
+				},
+				{
+					Cmd:  exec.Command("/usr/bin/apt-get", "install", "-y", "p1"),
+					Envs: aptEnv,
+					Err:  fmt.Errorf("individual install error"),
+				},
+			},
+			wantErr: setConfigError{
+				errors: []error{
+					fmt.Errorf("Error performing apt changes: error installing apt packages: Error installing apt package: p1. Error details: error running /usr/bin/apt-get with args [\"install\" \"-y\" \"p1\"]: individual install error, stdout: \"\", stderr: \"\""),
+				},
+			},
+		},
+		{
+			name: "apt repository configured, want nil error",
+			egp: &agentendpointpb.EffectiveGuestPolicy{
+				PackageRepositories: []*agentendpointpb.EffectiveGuestPolicy_SourcedPackageRepository{
+					{PackageRepository: &agentendpointpb.PackageRepository{Repository: &agentendpointpb.PackageRepository_Apt{Apt: &agentendpointpb.AptRepository{Uri: "http://repo"}}}},
+				},
+			},
+			aptExists: true,
+			wantErr:   nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			setupAptEnv(t, tt.aptExists)
+			utiltest.SetExpectedCommands(ctx, mockCommandRunner, tt.expectedCommands)
+
+			err := setConfig(context.Background(), tt.egp)
+			utiltest.AssertErrorMatch(t, err, tt.wantErr)
+		})
+	}
+}
+
 // TestSetConfigYum verifies that setConfig handles yum package manager and its configurations.
 func TestSetConfigYum(t *testing.T) {
 	ctx := context.Background()
@@ -365,4 +543,25 @@ func TestSetConfigYum(t *testing.T) {
 			utiltest.AssertErrorMatch(t, err, tt.wantErr)
 		})
 	}
+}
+
+type policiesStubOsInfoProvider struct {
+	osinfo osinfo.OSInfo
+}
+
+func (s policiesStubOsInfoProvider) GetOSInfo(ctx context.Context) (osinfo.OSInfo, error) {
+	return s.osinfo, nil
+}
+
+// setupSetConfigTest sets up the environment for SetConfig tests by mocking the command runner.
+func setupSetConfigTest(t *testing.T, runner *utilmocks.MockCommandRunner) {
+	utiltest.OverrideVariable(t, &osInfoProvider, (osinfo.Provider)(policiesStubOsInfoProvider{
+		osinfo: osinfo.OSInfo{ShortName: "debian", Version: "11"},
+	}))
+	utiltest.OverrideVariable(t, &retry, func(ctx context.Context, timeout time.Duration, desc string, f func() error) error {
+		return f()
+	})
+
+	packages.SetCommandRunner(runner)
+	packages.SetPtyCommandRunner(runner)
 }


### PR DESCRIPTION
Third part of unit tests for policies.go: TestSetConfigYum implementation.
Final test coverage: github.com/GoogleCloudPlatform/osconfig/policies/policies.go:125:	setConfig		90.9%