### PR TITLE
Add Configuration for SCALIBR

### DIFF
--- a/agentconfig/agentconfig.go
+++ b/agentconfig/agentconfig.go
@@ -62,12 +62,11 @@ const (
 
 	prodEndpoint = "{zone}-osconfig.googleapis.com.:443"
 
-	osInventoryEnabledDefault                  = false
-	guestPoliciesEnabledDefault                = false
-	taskNotificationEnabledDefault             = false
-	debugEnabledDefault                        = false
-	extendedInventoryEnabledDefault            = false
-	extendedInventoryCollectionIntervalDefault = 10
+	osInventoryEnabledDefault       = false
+	guestPoliciesEnabledDefault     = false
+	taskNotificationEnabledDefault  = false
+	debugEnabledDefault             = false
+	extendedInventoryEnabledDefault = false
 
 	oldConfigDirLinux = "/etc/osconfig"
 	cacheDirLinux     = "/var/lib/google_osconfig_agent"
@@ -124,28 +123,27 @@ var (
 )
 
 type config struct {
-	aptRepoFilePath                     string
-	instanceName                        string
-	instanceZone                        string
-	projectID                           string
-	svcEndpoint                         string
-	googetRepoFilePath                  string
-	zypperRepoFilePath                  string
-	yumRepoFilePath                     string
-	instanceID                          string
-	universeDomain                      string
-	numericProjectID                    int64
-	osConfigPollInterval                int
-	debugEnabled                        bool
-	taskNotificationEnabled             bool
-	guestPoliciesEnabled                bool
-	osInventoryEnabled                  bool
-	scalibrLinuxEnabled                 bool
-	guestAttributesEnabled              bool
-	traceGetInventory                   bool
-	extendedInventoryEnabled            bool
-	extendedInventoryCollectionInterval int
-	extendedInventoryExtractorsAllowed  []string
+	aptRepoFilePath                    string
+	instanceName                       string
+	instanceZone                       string
+	projectID                          string
+	svcEndpoint                        string
+	googetRepoFilePath                 string
+	zypperRepoFilePath                 string
+	yumRepoFilePath                    string
+	instanceID                         string
+	universeDomain                     string
+	numericProjectID                   int64
+	osConfigPollInterval               int
+	debugEnabled                       bool
+	taskNotificationEnabled            bool
+	guestPoliciesEnabled               bool
+	osInventoryEnabled                 bool
+	scalibrLinuxEnabled                bool
+	guestAttributesEnabled             bool
+	traceGetInventory                  bool
+	extendedInventoryEnabled           bool
+	extendedInventoryExtractorsAllowed []string
 }
 
 func (c *config) parseFeatures(features string, enabled bool) {
@@ -236,37 +234,35 @@ type universeJSON struct {
 }
 
 type attributesJSON struct {
-	PollIntervalOld                     *json.Number `json:"os-config-poll-interval"`
-	PollInterval                        *json.Number `json:"osconfig-poll-interval"`
-	InventoryEnabledOld                 string       `json:"os-inventory-enabled"`
-	InventoryEnabled                    string       `json:"enable-os-inventory"`
-	PreReleaseFeaturesOld               string       `json:"os-config-enabled-prerelease-features"`
-	PreReleaseFeatures                  string       `json:"osconfig-enabled-prerelease-features"`
-	DebugEnabledOld                     string       `json:"enable-os-config-debug"`
-	LogLevel                            string       `json:"osconfig-log-level"`
-	OSConfigEndpointOld                 string       `json:"os-config-endpoint"`
-	OSConfigEndpoint                    string       `json:"osconfig-endpoint"`
-	OSConfigEnabled                     string       `json:"enable-osconfig"`
-	DisabledFeatures                    string       `json:"osconfig-disabled-features"`
-	EnableGuestAttributes               string       `json:"enable-guest-attributes"`
-	TraceGetInventory                   string       `json:"trace-get-inventory"`
-	ScalibrLinuxEnabled                 string       `json:"enable-scalibr-linux"`
-	ExtendedInventoryEnabled            string       `json:"osconfig-extended-inventory-enabled"`
-	ExtendedInventoryCollectionInterval *json.Number `json:"osconfig-extended-inventory-collection-interval"`
-	ExtendedInventoryExtractorsAllowed  string       `json:"osconfig-extended-inventory-extractors-allowed"`
+	PollIntervalOld                    *json.Number `json:"os-config-poll-interval"`
+	PollInterval                       *json.Number `json:"osconfig-poll-interval"`
+	InventoryEnabledOld                string       `json:"os-inventory-enabled"`
+	InventoryEnabled                   string       `json:"enable-os-inventory"`
+	PreReleaseFeaturesOld              string       `json:"os-config-enabled-prerelease-features"`
+	PreReleaseFeatures                 string       `json:"osconfig-enabled-prerelease-features"`
+	DebugEnabledOld                    string       `json:"enable-os-config-debug"`
+	LogLevel                           string       `json:"osconfig-log-level"`
+	OSConfigEndpointOld                string       `json:"os-config-endpoint"`
+	OSConfigEndpoint                   string       `json:"osconfig-endpoint"`
+	OSConfigEnabled                    string       `json:"enable-osconfig"`
+	DisabledFeatures                   string       `json:"osconfig-disabled-features"`
+	EnableGuestAttributes              string       `json:"enable-guest-attributes"`
+	TraceGetInventory                  string       `json:"trace-get-inventory"`
+	ScalibrLinuxEnabled                string       `json:"enable-scalibr-linux"`
+	ExtendedInventoryEnabled           string       `json:"osconfig-extended-inventory-enabled"`
+	ExtendedInventoryExtractorsAllowed string       `json:"osconfig-extended-inventory-extractors-allowed"`
 }
 
 func createConfigFromMetadata(md metadataJSON) *config {
 	old := getAgentConfig()
 	c := &config{
-		osInventoryEnabled:                  osInventoryEnabledDefault,
-		guestPoliciesEnabled:                guestPoliciesEnabledDefault,
-		taskNotificationEnabled:             taskNotificationEnabledDefault,
-		debugEnabled:                        debugEnabledDefault,
-		svcEndpoint:                         prodEndpoint,
-		osConfigPollInterval:                osConfigPollIntervalDefault,
-		extendedInventoryEnabled:            extendedInventoryEnabledDefault,
-		extendedInventoryCollectionInterval: extendedInventoryCollectionIntervalDefault,
+		osInventoryEnabled:       osInventoryEnabledDefault,
+		guestPoliciesEnabled:     guestPoliciesEnabledDefault,
+		taskNotificationEnabled:  taskNotificationEnabledDefault,
+		debugEnabled:             debugEnabledDefault,
+		svcEndpoint:              prodEndpoint,
+		osConfigPollInterval:     osConfigPollIntervalDefault,
+		extendedInventoryEnabled: extendedInventoryEnabledDefault,
 
 		googetRepoFilePath: googetRepoFilePath,
 		zypperRepoFilePath: zypperRepoFilePath,
@@ -409,17 +405,6 @@ func setExtendedInventory(md metadataJSON, c *config) {
 	}
 	if instanceSettings.ExtendedInventoryEnabled != "" {
 		c.extendedInventoryEnabled = parseBool(instanceSettings.ExtendedInventoryEnabled)
-	}
-
-	if projectSettings.ExtendedInventoryCollectionInterval != nil {
-		if val, err := projectSettings.ExtendedInventoryCollectionInterval.Int64(); err == nil {
-			c.extendedInventoryCollectionInterval = int(val)
-		}
-	}
-	if instanceSettings.ExtendedInventoryCollectionInterval != nil {
-		if val, err := instanceSettings.ExtendedInventoryCollectionInterval.Int64(); err == nil {
-			c.extendedInventoryCollectionInterval = int(val)
-		}
 	}
 
 	if projectSettings.ExtendedInventoryExtractorsAllowed != "" {
@@ -656,11 +641,6 @@ func TraceGetInventory() bool {
 // ExtendedInventoryEnabled indicates whether extended inventory collection should be enabled.
 func ExtendedInventoryEnabled() bool {
 	return getAgentConfig().extendedInventoryEnabled
-}
-
-// ExtendedInventoryCollectionInterval returns the frequency for extended inventory collection.
-func ExtendedInventoryCollectionInterval() time.Duration {
-	return time.Duration(getAgentConfig().extendedInventoryCollectionInterval) * time.Minute
 }
 
 // ExtendedInventoryExtractorsAllowed returns the allowed extractors for extended inventory.

--- a/agentconfig/agentconfig.go
+++ b/agentconfig/agentconfig.go
@@ -62,10 +62,12 @@ const (
 
 	prodEndpoint = "{zone}-osconfig.googleapis.com.:443"
 
-	osInventoryEnabledDefault      = false
-	guestPoliciesEnabledDefault    = false
-	taskNotificationEnabledDefault = false
-	debugEnabledDefault            = false
+	osInventoryEnabledDefault                  = false
+	guestPoliciesEnabledDefault                = false
+	taskNotificationEnabledDefault             = false
+	debugEnabledDefault                        = false
+	extendedInventoryEnabledDefault            = false
+	extendedInventoryCollectionIntervalDefault = 10
 
 	oldConfigDirLinux = "/etc/osconfig"
 	cacheDirLinux     = "/var/lib/google_osconfig_agent"
@@ -122,25 +124,28 @@ var (
 )
 
 type config struct {
-	aptRepoFilePath         string
-	instanceName            string
-	instanceZone            string
-	projectID               string
-	svcEndpoint             string
-	googetRepoFilePath      string
-	zypperRepoFilePath      string
-	yumRepoFilePath         string
-	instanceID              string
-	universeDomain          string
-	numericProjectID        int64
-	osConfigPollInterval    int
-	debugEnabled            bool
-	taskNotificationEnabled bool
-	guestPoliciesEnabled    bool
-	osInventoryEnabled      bool
-	scalibrLinuxEnabled     bool
-	guestAttributesEnabled  bool
-	traceGetInventory       bool
+	aptRepoFilePath                     string
+	instanceName                        string
+	instanceZone                        string
+	projectID                           string
+	svcEndpoint                         string
+	googetRepoFilePath                  string
+	zypperRepoFilePath                  string
+	yumRepoFilePath                     string
+	instanceID                          string
+	universeDomain                      string
+	numericProjectID                    int64
+	osConfigPollInterval                int
+	debugEnabled                        bool
+	taskNotificationEnabled             bool
+	guestPoliciesEnabled                bool
+	osInventoryEnabled                  bool
+	scalibrLinuxEnabled                 bool
+	guestAttributesEnabled              bool
+	traceGetInventory                   bool
+	extendedInventoryEnabled            bool
+	extendedInventoryCollectionInterval int
+	extendedInventoryExtractorsAllowed  []string
 }
 
 func (c *config) parseFeatures(features string, enabled bool) {
@@ -196,6 +201,17 @@ func parseBool(s string) bool {
 	return enabled
 }
 
+func parseSlice(s string) []string {
+	var slice []string
+	for _, item := range strings.Split(s, ",") {
+		item = strings.TrimSpace(item)
+		if item != "" {
+			slice = append(slice, item)
+		}
+	}
+	return slice
+}
+
 type metadataJSON struct {
 	Instance instanceJSON
 	Project  projectJSON
@@ -220,32 +236,37 @@ type universeJSON struct {
 }
 
 type attributesJSON struct {
-	PollIntervalOld       *json.Number `json:"os-config-poll-interval"`
-	PollInterval          *json.Number `json:"osconfig-poll-interval"`
-	InventoryEnabledOld   string       `json:"os-inventory-enabled"`
-	InventoryEnabled      string       `json:"enable-os-inventory"`
-	PreReleaseFeaturesOld string       `json:"os-config-enabled-prerelease-features"`
-	PreReleaseFeatures    string       `json:"osconfig-enabled-prerelease-features"`
-	DebugEnabledOld       string       `json:"enable-os-config-debug"`
-	LogLevel              string       `json:"osconfig-log-level"`
-	OSConfigEndpointOld   string       `json:"os-config-endpoint"`
-	OSConfigEndpoint      string       `json:"osconfig-endpoint"`
-	OSConfigEnabled       string       `json:"enable-osconfig"`
-	DisabledFeatures      string       `json:"osconfig-disabled-features"`
-	EnableGuestAttributes string       `json:"enable-guest-attributes"`
-	TraceGetInventory     string       `json:"trace-get-inventory"`
-	ScalibrLinuxEnabled   string       `json:"enable-scalibr-linux"`
+	PollIntervalOld                     *json.Number `json:"os-config-poll-interval"`
+	PollInterval                        *json.Number `json:"osconfig-poll-interval"`
+	InventoryEnabledOld                 string       `json:"os-inventory-enabled"`
+	InventoryEnabled                    string       `json:"enable-os-inventory"`
+	PreReleaseFeaturesOld               string       `json:"os-config-enabled-prerelease-features"`
+	PreReleaseFeatures                  string       `json:"osconfig-enabled-prerelease-features"`
+	DebugEnabledOld                     string       `json:"enable-os-config-debug"`
+	LogLevel                            string       `json:"osconfig-log-level"`
+	OSConfigEndpointOld                 string       `json:"os-config-endpoint"`
+	OSConfigEndpoint                    string       `json:"osconfig-endpoint"`
+	OSConfigEnabled                     string       `json:"enable-osconfig"`
+	DisabledFeatures                    string       `json:"osconfig-disabled-features"`
+	EnableGuestAttributes               string       `json:"enable-guest-attributes"`
+	TraceGetInventory                   string       `json:"trace-get-inventory"`
+	ScalibrLinuxEnabled                 string       `json:"enable-scalibr-linux"`
+	ExtendedInventoryEnabled            string       `json:"osconfig-extended-inventory-enabled"`
+	ExtendedInventoryCollectionInterval *json.Number `json:"osconfig-extended-inventory-collection-interval"`
+	ExtendedInventoryExtractorsAllowed  string       `json:"osconfig-extended-inventory-extractors-allowed"`
 }
 
 func createConfigFromMetadata(md metadataJSON) *config {
 	old := getAgentConfig()
 	c := &config{
-		osInventoryEnabled:      osInventoryEnabledDefault,
-		guestPoliciesEnabled:    guestPoliciesEnabledDefault,
-		taskNotificationEnabled: taskNotificationEnabledDefault,
-		debugEnabled:            debugEnabledDefault,
-		svcEndpoint:             prodEndpoint,
-		osConfigPollInterval:    osConfigPollIntervalDefault,
+		osInventoryEnabled:                  osInventoryEnabledDefault,
+		guestPoliciesEnabled:                guestPoliciesEnabledDefault,
+		taskNotificationEnabled:             taskNotificationEnabledDefault,
+		debugEnabled:                        debugEnabledDefault,
+		svcEndpoint:                         prodEndpoint,
+		osConfigPollInterval:                osConfigPollIntervalDefault,
+		extendedInventoryEnabled:            extendedInventoryEnabledDefault,
+		extendedInventoryCollectionInterval: extendedInventoryCollectionIntervalDefault,
 
 		googetRepoFilePath: googetRepoFilePath,
 		zypperRepoFilePath: zypperRepoFilePath,
@@ -374,8 +395,39 @@ func createConfigFromMetadata(md metadataJSON) *config {
 	setScalibrEnablement(md, c)
 	setSVCEndpoint(md, c)
 	setTraceGetInventory(md, c)
+	setExtendedInventory(md, c)
 
 	return c
+}
+
+func setExtendedInventory(md metadataJSON, c *config) {
+	projectSettings := md.Project.Attributes
+	instanceSettings := md.Instance.Attributes
+
+	if projectSettings.ExtendedInventoryEnabled != "" {
+		c.extendedInventoryEnabled = parseBool(projectSettings.ExtendedInventoryEnabled)
+	}
+	if instanceSettings.ExtendedInventoryEnabled != "" {
+		c.extendedInventoryEnabled = parseBool(instanceSettings.ExtendedInventoryEnabled)
+	}
+
+	if projectSettings.ExtendedInventoryCollectionInterval != nil {
+		if val, err := projectSettings.ExtendedInventoryCollectionInterval.Int64(); err == nil {
+			c.extendedInventoryCollectionInterval = int(val)
+		}
+	}
+	if instanceSettings.ExtendedInventoryCollectionInterval != nil {
+		if val, err := instanceSettings.ExtendedInventoryCollectionInterval.Int64(); err == nil {
+			c.extendedInventoryCollectionInterval = int(val)
+		}
+	}
+
+	if projectSettings.ExtendedInventoryExtractorsAllowed != "" {
+		c.extendedInventoryExtractorsAllowed = parseSlice(projectSettings.ExtendedInventoryExtractorsAllowed)
+	}
+	if instanceSettings.ExtendedInventoryExtractorsAllowed != "" {
+		c.extendedInventoryExtractorsAllowed = parseSlice(instanceSettings.ExtendedInventoryExtractorsAllowed)
+	}
 }
 
 func setScalibrEnablement(md metadataJSON, c *config) {
@@ -599,6 +651,21 @@ func SvcEndpoint() string {
 // TraceGetInventory turns on memory tracing while gathering inventory.
 func TraceGetInventory() bool {
 	return getAgentConfig().traceGetInventory
+}
+
+// ExtendedInventoryEnabled indicates whether extended inventory collection should be enabled.
+func ExtendedInventoryEnabled() bool {
+	return getAgentConfig().extendedInventoryEnabled
+}
+
+// ExtendedInventoryCollectionInterval returns the frequency for extended inventory collection.
+func ExtendedInventoryCollectionInterval() time.Duration {
+	return time.Duration(getAgentConfig().extendedInventoryCollectionInterval) * time.Minute
+}
+
+// ExtendedInventoryExtractorsAllowed returns the allowed extractors for extended inventory.
+func ExtendedInventoryExtractorsAllowed() []string {
+	return getAgentConfig().extendedInventoryExtractorsAllowed
 }
 
 // ZypperRepoDir is the location of the zypper repo files.

--- a/agentconfig/agentconfig_test.go
+++ b/agentconfig/agentconfig_test.go
@@ -335,12 +335,100 @@ func TestSetConfigDefaultValues(t *testing.T) {
 			op:   asAny(SvcEndpoint),
 			want: "fake-zone-osconfig.googleapis.com.:443",
 		},
+		{
+			name: "extended inventory enabled is requested, returns default boolean",
+			op:   asAny(ExtendedInventoryEnabled),
+			want: extendedInventoryEnabledDefault,
+		},
+		{
+			name: "extended inventory collection interval is requested, returns default duration",
+			op:   asAny(ExtendedInventoryCollectionInterval),
+			want: time.Duration(extendedInventoryCollectionIntervalDefault) * time.Minute,
+		},
+		{
+			name: "extended inventory extractors allowed is requested, returns default slice",
+			op:   asAny(ExtendedInventoryExtractorsAllowed),
+			want: []string(nil),
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			utiltest.AssertEquals(t, tt.op(), tt.want)
 		})
 	}
+}
+
+func TestSetExtendedInventory(t *testing.T) {
+	tests := []struct {
+		name           string
+		md             metadataJSON
+		wantEnabled    bool
+		wantInterval   time.Duration
+		wantExtractors []string
+	}{
+		{
+			name:           "project and instance values are empty, returns defaults",
+			md:             metadataJSON{},
+			wantEnabled:    false,
+			wantInterval:   10 * time.Minute,
+			wantExtractors: nil,
+		},
+		{
+			name: "project sets extended inventory values, returns project config",
+			md: metadataJSON{
+				Project: projectJSON{
+					Attributes: attributesJSON{
+						ExtendedInventoryEnabled:            "true",
+						ExtendedInventoryCollectionInterval: jsonNumberPtr("15"),
+						ExtendedInventoryExtractorsAllowed:  "pkg, os",
+					},
+				},
+			},
+			wantEnabled:    true,
+			wantInterval:   15 * time.Minute,
+			wantExtractors: []string{"pkg", "os"},
+		},
+		{
+			name: "instance overrides project extended inventory values, returns instance config",
+			md: metadataJSON{
+				Project: projectJSON{
+					Attributes: attributesJSON{
+						ExtendedInventoryEnabled:            "true",
+						ExtendedInventoryCollectionInterval: jsonNumberPtr("15"),
+						ExtendedInventoryExtractorsAllowed:  "pkg, os",
+					},
+				},
+				Instance: instanceJSON{
+					Attributes: attributesJSON{
+						ExtendedInventoryEnabled:            "false",
+						ExtendedInventoryCollectionInterval: jsonNumberPtr("30"),
+						ExtendedInventoryExtractorsAllowed:  "pkg",
+					},
+				},
+			},
+			wantEnabled:    false,
+			wantInterval:   30 * time.Minute,
+			wantExtractors: []string{"pkg"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := createConfigFromMetadata(tt.md)
+			agentConfigMx.Lock()
+			agentConfig = c
+			agentConfigMx.Unlock()
+
+			utiltest.AssertEquals(t, ExtendedInventoryEnabled(), tt.wantEnabled)
+			utiltest.AssertEquals(t, ExtendedInventoryCollectionInterval(), tt.wantInterval)
+			utiltest.AssertEquals(t, ExtendedInventoryExtractorsAllowed(), tt.wantExtractors)
+		})
+	}
+}
+
+func jsonNumberPtr(s string) *json.Number {
+	n := json.Number(s)
+	return &n
 }
 
 // TestWatchConfigUnchangedConfigTimeout ignores unchanged metadata until timeout.
@@ -365,7 +453,7 @@ func TestWatchConfigUnchangedConfigTimeout(t *testing.T) {
 	err := WatchConfig(ctx)
 	utiltest.AssertErrorMatch(t, err, nil)
 	utiltest.AssertErrorMatch(t, ctx.Err(), nil)
-	if got := getAgentConfig(); got != before {
+	if got := getAgentConfig(); !reflect.DeepEqual(got, before) {
 		t.Errorf("Agent config changed after unchanged metadata: got %+v, want %+v", got, before)
 	}
 	if count <= 1 {
@@ -792,17 +880,19 @@ func TestCreateConfigFromMetadata(t *testing.T) {
 			name: "metadata is empty, returns config defaults",
 			md:   metadataJSON{},
 			want: &config{
-				osInventoryEnabled:      osInventoryEnabledDefault,
-				guestPoliciesEnabled:    guestPoliciesEnabledDefault,
-				taskNotificationEnabled: taskNotificationEnabledDefault,
-				debugEnabled:            debugEnabledDefault,
-				svcEndpoint:             strings.ReplaceAll(prodEndpoint, "{zone}", ""),
-				osConfigPollInterval:    osConfigPollIntervalDefault,
-				googetRepoFilePath:      googetRepoFilePath,
-				zypperRepoFilePath:      zypperRepoFilePath,
-				yumRepoFilePath:         yumRepoFilePath,
-				aptRepoFilePath:         aptRepoFilePath,
-				universeDomain:          universeDomainDefault,
+				osInventoryEnabled:                  osInventoryEnabledDefault,
+				guestPoliciesEnabled:                guestPoliciesEnabledDefault,
+				taskNotificationEnabled:             taskNotificationEnabledDefault,
+				debugEnabled:                        debugEnabledDefault,
+				extendedInventoryEnabled:            extendedInventoryEnabledDefault,
+				extendedInventoryCollectionInterval: extendedInventoryCollectionIntervalDefault,
+				svcEndpoint:                         strings.ReplaceAll(prodEndpoint, "{zone}", ""),
+				osConfigPollInterval:                osConfigPollIntervalDefault,
+				googetRepoFilePath:                  googetRepoFilePath,
+				zypperRepoFilePath:                  zypperRepoFilePath,
+				yumRepoFilePath:                     yumRepoFilePath,
+				aptRepoFilePath:                     aptRepoFilePath,
+				universeDomain:                      universeDomainDefault,
 			},
 		},
 		{
@@ -818,18 +908,20 @@ func TestCreateConfigFromMetadata(t *testing.T) {
 				},
 			},
 			want: &config{
-				projectID:               "proj-1",
-				osInventoryEnabled:      true,
-				guestPoliciesEnabled:    true,
-				taskNotificationEnabled: true,
-				debugEnabled:            true,
-				svcEndpoint:             strings.ReplaceAll(prodEndpoint, "{zone}", ""),
-				osConfigPollInterval:    15,
-				googetRepoFilePath:      googetRepoFilePath,
-				zypperRepoFilePath:      zypperRepoFilePath,
-				yumRepoFilePath:         yumRepoFilePath,
-				aptRepoFilePath:         aptRepoFilePath,
-				universeDomain:          universeDomainDefault,
+				projectID:                           "proj-1",
+				osInventoryEnabled:                  true,
+				guestPoliciesEnabled:                true,
+				taskNotificationEnabled:             true,
+				debugEnabled:                        true,
+				extendedInventoryEnabled:            extendedInventoryEnabledDefault,
+				extendedInventoryCollectionInterval: extendedInventoryCollectionIntervalDefault,
+				svcEndpoint:                         strings.ReplaceAll(prodEndpoint, "{zone}", ""),
+				osConfigPollInterval:                15,
+				googetRepoFilePath:                  googetRepoFilePath,
+				zypperRepoFilePath:                  zypperRepoFilePath,
+				yumRepoFilePath:                     yumRepoFilePath,
+				aptRepoFilePath:                     aptRepoFilePath,
+				universeDomain:                      universeDomainDefault,
 			},
 		},
 		{
@@ -852,18 +944,20 @@ func TestCreateConfigFromMetadata(t *testing.T) {
 				},
 			},
 			want: &config{
-				projectID:               "proj-1",
-				osInventoryEnabled:      false,
-				guestPoliciesEnabled:    false,
-				taskNotificationEnabled: false,
-				debugEnabled:            true,
-				svcEndpoint:             strings.ReplaceAll(prodEndpoint, "{zone}", ""),
-				osConfigPollInterval:    20,
-				googetRepoFilePath:      googetRepoFilePath,
-				zypperRepoFilePath:      zypperRepoFilePath,
-				yumRepoFilePath:         yumRepoFilePath,
-				aptRepoFilePath:         aptRepoFilePath,
-				universeDomain:          universeDomainDefault,
+				projectID:                           "proj-1",
+				osInventoryEnabled:                  false,
+				guestPoliciesEnabled:                false,
+				taskNotificationEnabled:             false,
+				debugEnabled:                        true,
+				extendedInventoryEnabled:            extendedInventoryEnabledDefault,
+				extendedInventoryCollectionInterval: extendedInventoryCollectionIntervalDefault,
+				svcEndpoint:                         strings.ReplaceAll(prodEndpoint, "{zone}", ""),
+				osConfigPollInterval:                20,
+				googetRepoFilePath:                  googetRepoFilePath,
+				zypperRepoFilePath:                  zypperRepoFilePath,
+				yumRepoFilePath:                     yumRepoFilePath,
+				aptRepoFilePath:                     aptRepoFilePath,
+				universeDomain:                      universeDomainDefault,
 			},
 		},
 		{
@@ -883,18 +977,20 @@ func TestCreateConfigFromMetadata(t *testing.T) {
 				},
 			},
 			want: &config{
-				instanceID:              "98765",
-				osInventoryEnabled:      false,
-				guestPoliciesEnabled:    false,
-				taskNotificationEnabled: true,
-				debugEnabled:            debugEnabledDefault,
-				svcEndpoint:             strings.ReplaceAll(prodEndpoint, "{zone}", ""),
-				osConfigPollInterval:    15,
-				googetRepoFilePath:      googetRepoFilePath,
-				zypperRepoFilePath:      zypperRepoFilePath,
-				yumRepoFilePath:         yumRepoFilePath,
-				aptRepoFilePath:         aptRepoFilePath,
-				universeDomain:          universeDomainDefault,
+				instanceID:                          "98765",
+				osInventoryEnabled:                  false,
+				guestPoliciesEnabled:                false,
+				taskNotificationEnabled:             true,
+				debugEnabled:                        debugEnabledDefault,
+				extendedInventoryEnabled:            extendedInventoryEnabledDefault,
+				extendedInventoryCollectionInterval: extendedInventoryCollectionIntervalDefault,
+				svcEndpoint:                         strings.ReplaceAll(prodEndpoint, "{zone}", ""),
+				osConfigPollInterval:                15,
+				googetRepoFilePath:                  googetRepoFilePath,
+				zypperRepoFilePath:                  zypperRepoFilePath,
+				yumRepoFilePath:                     yumRepoFilePath,
+				aptRepoFilePath:                     aptRepoFilePath,
+				universeDomain:                      universeDomainDefault,
 			},
 		},
 		{
@@ -908,17 +1004,19 @@ func TestCreateConfigFromMetadata(t *testing.T) {
 			},
 			setDebugFlag: true,
 			want: &config{
-				osInventoryEnabled:      osInventoryEnabledDefault,
-				guestPoliciesEnabled:    guestPoliciesEnabledDefault,
-				taskNotificationEnabled: taskNotificationEnabledDefault,
-				debugEnabled:            true,
-				svcEndpoint:             strings.ReplaceAll(prodEndpoint, "{zone}", ""),
-				osConfigPollInterval:    osConfigPollIntervalDefault,
-				googetRepoFilePath:      googetRepoFilePath,
-				zypperRepoFilePath:      zypperRepoFilePath,
-				yumRepoFilePath:         yumRepoFilePath,
-				aptRepoFilePath:         aptRepoFilePath,
-				universeDomain:          universeDomainDefault,
+				osInventoryEnabled:                  osInventoryEnabledDefault,
+				guestPoliciesEnabled:                guestPoliciesEnabledDefault,
+				taskNotificationEnabled:             taskNotificationEnabledDefault,
+				debugEnabled:                        true,
+				extendedInventoryEnabled:            extendedInventoryEnabledDefault,
+				extendedInventoryCollectionInterval: extendedInventoryCollectionIntervalDefault,
+				svcEndpoint:                         strings.ReplaceAll(prodEndpoint, "{zone}", ""),
+				osConfigPollInterval:                osConfigPollIntervalDefault,
+				googetRepoFilePath:                  googetRepoFilePath,
+				zypperRepoFilePath:                  zypperRepoFilePath,
+				yumRepoFilePath:                     yumRepoFilePath,
+				aptRepoFilePath:                     aptRepoFilePath,
+				universeDomain:                      universeDomainDefault,
 			},
 		},
 	}

--- a/agentconfig/agentconfig_test.go
+++ b/agentconfig/agentconfig_test.go
@@ -341,11 +341,6 @@ func TestSetConfigDefaultValues(t *testing.T) {
 			want: extendedInventoryEnabledDefault,
 		},
 		{
-			name: "extended inventory collection interval is requested, returns default duration",
-			op:   asAny(ExtendedInventoryCollectionInterval),
-			want: time.Duration(extendedInventoryCollectionIntervalDefault) * time.Minute,
-		},
-		{
 			name: "extended inventory extractors allowed is requested, returns default slice",
 			op:   asAny(ExtendedInventoryExtractorsAllowed),
 			want: []string(nil),
@@ -363,14 +358,12 @@ func TestSetExtendedInventory(t *testing.T) {
 		name           string
 		md             metadataJSON
 		wantEnabled    bool
-		wantInterval   time.Duration
 		wantExtractors []string
 	}{
 		{
 			name:           "project and instance values are empty, returns defaults",
 			md:             metadataJSON{},
 			wantEnabled:    false,
-			wantInterval:   10 * time.Minute,
 			wantExtractors: nil,
 		},
 		{
@@ -378,14 +371,12 @@ func TestSetExtendedInventory(t *testing.T) {
 			md: metadataJSON{
 				Project: projectJSON{
 					Attributes: attributesJSON{
-						ExtendedInventoryEnabled:            "true",
-						ExtendedInventoryCollectionInterval: jsonNumberPtr("15"),
-						ExtendedInventoryExtractorsAllowed:  "pkg, os",
+						ExtendedInventoryEnabled:           "true",
+						ExtendedInventoryExtractorsAllowed: "pkg, os",
 					},
 				},
 			},
 			wantEnabled:    true,
-			wantInterval:   15 * time.Minute,
 			wantExtractors: []string{"pkg", "os"},
 		},
 		{
@@ -393,21 +384,18 @@ func TestSetExtendedInventory(t *testing.T) {
 			md: metadataJSON{
 				Project: projectJSON{
 					Attributes: attributesJSON{
-						ExtendedInventoryEnabled:            "true",
-						ExtendedInventoryCollectionInterval: jsonNumberPtr("15"),
-						ExtendedInventoryExtractorsAllowed:  "pkg, os",
+						ExtendedInventoryEnabled:           "true",
+						ExtendedInventoryExtractorsAllowed: "pkg, os",
 					},
 				},
 				Instance: instanceJSON{
 					Attributes: attributesJSON{
-						ExtendedInventoryEnabled:            "false",
-						ExtendedInventoryCollectionInterval: jsonNumberPtr("30"),
-						ExtendedInventoryExtractorsAllowed:  "pkg",
+						ExtendedInventoryEnabled:           "false",
+						ExtendedInventoryExtractorsAllowed: "pkg",
 					},
 				},
 			},
 			wantEnabled:    false,
-			wantInterval:   30 * time.Minute,
 			wantExtractors: []string{"pkg"},
 		},
 	}
@@ -420,15 +408,9 @@ func TestSetExtendedInventory(t *testing.T) {
 			agentConfigMx.Unlock()
 
 			utiltest.AssertEquals(t, ExtendedInventoryEnabled(), tt.wantEnabled)
-			utiltest.AssertEquals(t, ExtendedInventoryCollectionInterval(), tt.wantInterval)
 			utiltest.AssertEquals(t, ExtendedInventoryExtractorsAllowed(), tt.wantExtractors)
 		})
 	}
-}
-
-func jsonNumberPtr(s string) *json.Number {
-	n := json.Number(s)
-	return &n
 }
 
 // TestWatchConfigUnchangedConfigTimeout ignores unchanged metadata until timeout.
@@ -880,19 +862,18 @@ func TestCreateConfigFromMetadata(t *testing.T) {
 			name: "metadata is empty, returns config defaults",
 			md:   metadataJSON{},
 			want: &config{
-				osInventoryEnabled:                  osInventoryEnabledDefault,
-				guestPoliciesEnabled:                guestPoliciesEnabledDefault,
-				taskNotificationEnabled:             taskNotificationEnabledDefault,
-				debugEnabled:                        debugEnabledDefault,
-				extendedInventoryEnabled:            extendedInventoryEnabledDefault,
-				extendedInventoryCollectionInterval: extendedInventoryCollectionIntervalDefault,
-				svcEndpoint:                         strings.ReplaceAll(prodEndpoint, "{zone}", ""),
-				osConfigPollInterval:                osConfigPollIntervalDefault,
-				googetRepoFilePath:                  googetRepoFilePath,
-				zypperRepoFilePath:                  zypperRepoFilePath,
-				yumRepoFilePath:                     yumRepoFilePath,
-				aptRepoFilePath:                     aptRepoFilePath,
-				universeDomain:                      universeDomainDefault,
+				osInventoryEnabled:       osInventoryEnabledDefault,
+				guestPoliciesEnabled:     guestPoliciesEnabledDefault,
+				taskNotificationEnabled:  taskNotificationEnabledDefault,
+				debugEnabled:             debugEnabledDefault,
+				extendedInventoryEnabled: extendedInventoryEnabledDefault,
+				svcEndpoint:              strings.ReplaceAll(prodEndpoint, "{zone}", ""),
+				osConfigPollInterval:     osConfigPollIntervalDefault,
+				googetRepoFilePath:       googetRepoFilePath,
+				zypperRepoFilePath:       zypperRepoFilePath,
+				yumRepoFilePath:          yumRepoFilePath,
+				aptRepoFilePath:          aptRepoFilePath,
+				universeDomain:           universeDomainDefault,
 			},
 		},
 		{
@@ -908,20 +889,19 @@ func TestCreateConfigFromMetadata(t *testing.T) {
 				},
 			},
 			want: &config{
-				projectID:                           "proj-1",
-				osInventoryEnabled:                  true,
-				guestPoliciesEnabled:                true,
-				taskNotificationEnabled:             true,
-				debugEnabled:                        true,
-				extendedInventoryEnabled:            extendedInventoryEnabledDefault,
-				extendedInventoryCollectionInterval: extendedInventoryCollectionIntervalDefault,
-				svcEndpoint:                         strings.ReplaceAll(prodEndpoint, "{zone}", ""),
-				osConfigPollInterval:                15,
-				googetRepoFilePath:                  googetRepoFilePath,
-				zypperRepoFilePath:                  zypperRepoFilePath,
-				yumRepoFilePath:                     yumRepoFilePath,
-				aptRepoFilePath:                     aptRepoFilePath,
-				universeDomain:                      universeDomainDefault,
+				projectID:                "proj-1",
+				osInventoryEnabled:       true,
+				guestPoliciesEnabled:     true,
+				taskNotificationEnabled:  true,
+				debugEnabled:             true,
+				extendedInventoryEnabled: extendedInventoryEnabledDefault,
+				svcEndpoint:              strings.ReplaceAll(prodEndpoint, "{zone}", ""),
+				osConfigPollInterval:     15,
+				googetRepoFilePath:       googetRepoFilePath,
+				zypperRepoFilePath:       zypperRepoFilePath,
+				yumRepoFilePath:          yumRepoFilePath,
+				aptRepoFilePath:          aptRepoFilePath,
+				universeDomain:           universeDomainDefault,
 			},
 		},
 		{
@@ -944,20 +924,19 @@ func TestCreateConfigFromMetadata(t *testing.T) {
 				},
 			},
 			want: &config{
-				projectID:                           "proj-1",
-				osInventoryEnabled:                  false,
-				guestPoliciesEnabled:                false,
-				taskNotificationEnabled:             false,
-				debugEnabled:                        true,
-				extendedInventoryEnabled:            extendedInventoryEnabledDefault,
-				extendedInventoryCollectionInterval: extendedInventoryCollectionIntervalDefault,
-				svcEndpoint:                         strings.ReplaceAll(prodEndpoint, "{zone}", ""),
-				osConfigPollInterval:                20,
-				googetRepoFilePath:                  googetRepoFilePath,
-				zypperRepoFilePath:                  zypperRepoFilePath,
-				yumRepoFilePath:                     yumRepoFilePath,
-				aptRepoFilePath:                     aptRepoFilePath,
-				universeDomain:                      universeDomainDefault,
+				projectID:                "proj-1",
+				osInventoryEnabled:       false,
+				guestPoliciesEnabled:     false,
+				taskNotificationEnabled:  false,
+				debugEnabled:             true,
+				extendedInventoryEnabled: extendedInventoryEnabledDefault,
+				svcEndpoint:              strings.ReplaceAll(prodEndpoint, "{zone}", ""),
+				osConfigPollInterval:     20,
+				googetRepoFilePath:       googetRepoFilePath,
+				zypperRepoFilePath:       zypperRepoFilePath,
+				yumRepoFilePath:          yumRepoFilePath,
+				aptRepoFilePath:          aptRepoFilePath,
+				universeDomain:           universeDomainDefault,
 			},
 		},
 		{
@@ -977,20 +956,19 @@ func TestCreateConfigFromMetadata(t *testing.T) {
 				},
 			},
 			want: &config{
-				instanceID:                          "98765",
-				osInventoryEnabled:                  false,
-				guestPoliciesEnabled:                false,
-				taskNotificationEnabled:             true,
-				debugEnabled:                        debugEnabledDefault,
-				extendedInventoryEnabled:            extendedInventoryEnabledDefault,
-				extendedInventoryCollectionInterval: extendedInventoryCollectionIntervalDefault,
-				svcEndpoint:                         strings.ReplaceAll(prodEndpoint, "{zone}", ""),
-				osConfigPollInterval:                15,
-				googetRepoFilePath:                  googetRepoFilePath,
-				zypperRepoFilePath:                  zypperRepoFilePath,
-				yumRepoFilePath:                     yumRepoFilePath,
-				aptRepoFilePath:                     aptRepoFilePath,
-				universeDomain:                      universeDomainDefault,
+				instanceID:               "98765",
+				osInventoryEnabled:       false,
+				guestPoliciesEnabled:     false,
+				taskNotificationEnabled:  true,
+				debugEnabled:             debugEnabledDefault,
+				extendedInventoryEnabled: extendedInventoryEnabledDefault,
+				svcEndpoint:              strings.ReplaceAll(prodEndpoint, "{zone}", ""),
+				osConfigPollInterval:     15,
+				googetRepoFilePath:       googetRepoFilePath,
+				zypperRepoFilePath:       zypperRepoFilePath,
+				yumRepoFilePath:          yumRepoFilePath,
+				aptRepoFilePath:          aptRepoFilePath,
+				universeDomain:           universeDomainDefault,
 			},
 		},
 		{
@@ -1004,19 +982,18 @@ func TestCreateConfigFromMetadata(t *testing.T) {
 			},
 			setDebugFlag: true,
 			want: &config{
-				osInventoryEnabled:                  osInventoryEnabledDefault,
-				guestPoliciesEnabled:                guestPoliciesEnabledDefault,
-				taskNotificationEnabled:             taskNotificationEnabledDefault,
-				debugEnabled:                        true,
-				extendedInventoryEnabled:            extendedInventoryEnabledDefault,
-				extendedInventoryCollectionInterval: extendedInventoryCollectionIntervalDefault,
-				svcEndpoint:                         strings.ReplaceAll(prodEndpoint, "{zone}", ""),
-				osConfigPollInterval:                osConfigPollIntervalDefault,
-				googetRepoFilePath:                  googetRepoFilePath,
-				zypperRepoFilePath:                  zypperRepoFilePath,
-				yumRepoFilePath:                     yumRepoFilePath,
-				aptRepoFilePath:                     aptRepoFilePath,
-				universeDomain:                      universeDomainDefault,
+				osInventoryEnabled:       osInventoryEnabledDefault,
+				guestPoliciesEnabled:     guestPoliciesEnabledDefault,
+				taskNotificationEnabled:  taskNotificationEnabledDefault,
+				debugEnabled:             true,
+				extendedInventoryEnabled: extendedInventoryEnabledDefault,
+				svcEndpoint:              strings.ReplaceAll(prodEndpoint, "{zone}", ""),
+				osConfigPollInterval:     osConfigPollIntervalDefault,
+				googetRepoFilePath:       googetRepoFilePath,
+				zypperRepoFilePath:       zypperRepoFilePath,
+				yumRepoFilePath:          yumRepoFilePath,
+				aptRepoFilePath:          aptRepoFilePath,
+				universeDomain:           universeDomainDefault,
 			},
 		},
 	}


### PR DESCRIPTION
This PR adds configuration support for SCALIBR extended inventory collection in `agentconfig`.

### Changes Included:
* **Metadata keys added:** `osconfig-extended-inventory-enabled`, `osconfig-extended-inventory-collection-interval`, `osconfig-extended-inventory-extractors-allowed`.
* **Parsing & Overrides:** Added `setExtendedInventory` to support instance-level overrides for project settings, along with a `parseSlice` helper for extractors.
* **Tests:** Unit tests added in `agentconfig_test.go` for defaults, project settings, and instance overrides.